### PR TITLE
fix(mini-ai): explicitly call setup()

### DIFF
--- a/lua/astrocommunity/motion/mini-ai/mini-ai.lua
+++ b/lua/astrocommunity/motion/mini-ai/mini-ai.lua
@@ -1,1 +1,5 @@
-return { "echasnovski/mini.ai", event = "User AstroFile" }
+return {
+  "echasnovski/mini.ai",
+  event = "User AstroFile",
+  config = function(_, opts) require("mini.ai").setup(opts) end,
+}


### PR DESCRIPTION
The mini-ai astrocommunity plug-in was not working because the setup function was not being called.  According to lazy docs, it seems to imply that it should automatically call setup, but this plug-in did not work without explicitly defining our own config that calls setup.