### PR TITLE
fix(pack/rust): Ensure that taplo is only initialized once.

### DIFF
--- a/lua/astrocommunity/pack/rust/rust.lua
+++ b/lua/astrocommunity/pack/rust/rust.lua
@@ -16,7 +16,7 @@ return {
   {
     "simrat39/rust-tools.nvim",
     ft = { "rust" },
-    init = function() utils.list_insert_unique(astronvim.lsp.skip_setup, "rust_analyzer") end,
+    init = function() utils.list_insert_unique(astronvim.lsp.skip_setup, { "rust_analyzer", "taplo" }) end,
     opts = function() return { server = require("astronvim.utils.lsp").config "rust_analyzer" } end,
     dependencies = {
       {


### PR DESCRIPTION
Closes #90

Ensure that taplo is only initialized once.

Just added it to astronvim.lsp.skip_setup. 