### PR TITLE
Add EdgeDB syntax plugin

### DIFF
--- a/lua/astrocommunity/pack/edgedb/README.md
+++ b/lua/astrocommunity/pack/edgedb/README.md
@@ -1,0 +1,5 @@
+# EdgeDB pack
+
+EdgeDB is a next-generation graph-relational database designed as a spiritual successor to the relational database.
+
+This plugin pack adds support for syntax highlighting of EdgeQL files.

--- a/lua/astrocommunity/pack/edgedb/edgedb.lua
+++ b/lua/astrocommunity/pack/edgedb/edgedb.lua
@@ -1,0 +1,10 @@
+return {
+  "edgedb/edgedb-vim",
+  ft = "edgeql",
+  config = function()
+    vim.api.nvim_create_autocmd(
+      { "BufRead", "BufNewFile" },
+      { pattern = { "*.esdl", "*.edgeql" }, command = "setf edgeql" }
+    )
+  end,
+}


### PR DESCRIPTION
This PR adds new syntax support for [EdgeDB](https://www.edgedb.com) syntax files.

I wasn't sure what directory to put it, and went with `pack/edgedb`. Right now it's not really a pack, but just a syntax hightlight support, but that can change in a future.