### PR TITLE
fix(pack): enable tailwindcss color highlighting

### DIFF
--- a/lua/astrocommunity/pack/tailwindcss/tailwindcss.lua
+++ b/lua/astrocommunity/pack/tailwindcss/tailwindcss.lua
@@ -47,6 +47,7 @@ return {
     "NvChad/nvim-colorizer.lua",
     opts = {
       user_default_options = {
+        names = true,
         tailwind = true,
       },
     },


### PR DESCRIPTION
AstroNvim's default config disables color highlighting for names, which prevents tailwind color highlighting from working properly