### PR TITLE
fix(pack): disable taplo in null-ls

### DIFF
--- a/lua/astrocommunity/pack/toml/toml.lua
+++ b/lua/astrocommunity/pack/toml/toml.lua
@@ -20,4 +20,12 @@ return {
       utils.list_insert_unique(opts.ensure_installed, "taplo")
     end,
   },
+  {
+    "jay-babu/mason-null-ls.nvim",
+    opts = function(_, opts)
+      -- Ensure that opts.handlers exists and is a table
+      if not opts.handlers then opts.handlers = {} end
+      opts.handlers.taplo = function() end
+    end,
+  },
 }


### PR DESCRIPTION
Relies on https://github.com/AstroNvim/AstroNvim/pull/1695 and release of AstroNvim v3.5.3 (@sjcobb2022)