### PR TITLE
feat(pack): switch to codelldb for rust debugging

### DIFF
--- a/lua/astrocommunity/pack/rust/README.md
+++ b/lua/astrocommunity/pack/rust/README.md
@@ -1,7 +1,5 @@
 # Rust Language Pack
 
-Requires `lldb-vscode` in your `PATH`
-
 This plugin pack does the following:
 
 - Adds `rust` Treesitter parsers

--- a/lua/astrocommunity/pack/rust/rust.lua
+++ b/lua/astrocommunity/pack/rust/rust.lua
@@ -18,7 +18,22 @@ return {
     "simrat39/rust-tools.nvim",
     ft = { "rust" },
     init = function() utils.list_insert_unique(astronvim.lsp.skip_setup, "rust_analyzer") end,
-    opts = function() return { server = require("astronvim.utils.lsp").config "rust_analyzer" } end,
+    opts = function()
+      local extension_path = vim.fn.stdpath "data" .. "/mason/packages/codelldb/extension/"
+      local codelldb_path = extension_path .. "adapter/codelldb"
+      local liblldb_path = extension_path .. "lldb/lib/liblldb"
+
+      if vim.loop.os_uname().sysname == "Linux" then
+        liblldb_path = liblldb_path .. ".so"
+      else
+        liblldb_path = liblldb_path .. ".dylib"
+      end
+
+      return {
+        server = require("astronvim.utils.lsp").config "rust_analyzer",
+        dap = { adapter = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path) },
+      }
+    end,
     dependencies = {
       {
         "jay-babu/mason-nvim-dap.nvim",

--- a/lua/astrocommunity/pack/rust/rust.lua
+++ b/lua/astrocommunity/pack/rust/rust.lua
@@ -19,9 +19,9 @@ return {
     ft = { "rust" },
     init = function() utils.list_insert_unique(astronvim.lsp.skip_setup, "rust_analyzer") end,
     opts = function()
-      local extension_path = vim.fn.stdpath "data" .. "/mason/packages/codelldb/extension/"
-      local codelldb_path = extension_path .. "adapter/codelldb"
-      local liblldb_path = extension_path .. "lldb/lib/liblldb"
+      local package_path = require("mason-registry.index.codelldb"):get_install_path()
+      local codelldb_path = package_path .. "/codelldb"
+      local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
 
       if vim.loop.os_uname().sysname == "Linux" then
         liblldb_path = liblldb_path .. ".so"

--- a/lua/astrocommunity/pack/rust/rust.lua
+++ b/lua/astrocommunity/pack/rust/rust.lua
@@ -23,15 +23,14 @@ return {
       local codelldb_path = package_path .. "/codelldb"
       local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
 
-      if vim.loop.os_uname().sysname == "Linux" then
-        liblldb_path = liblldb_path .. ".so"
-      else
-        liblldb_path = liblldb_path .. ".dylib"
-      end
-
       return {
         server = require("astronvim.utils.lsp").config "rust_analyzer",
-        dap = { adapter = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path) },
+        dap = {
+          adapter = require("rust-tools.dap").get_codelldb_adapter(
+            codelldb_path,
+            liblldb_path .. (vim.loop.os_uname().sysname == "Linux" and ".so" or ".dylib")
+          ),
+        },
       }
     end,
     dependencies = {

--- a/lua/astrocommunity/pack/rust/rust.lua
+++ b/lua/astrocommunity/pack/rust/rust.lua
@@ -19,7 +19,7 @@ return {
     ft = { "rust" },
     init = function() utils.list_insert_unique(astronvim.lsp.skip_setup, "rust_analyzer") end,
     opts = function()
-      local package_path = require("mason-registry.index.codelldb"):get_install_path()
+      local package_path = require("mason-registry").get_package("codelldb"):get_install_path()
       local codelldb_path = package_path .. "/codelldb"
       local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
 


### PR DESCRIPTION
Sets up rust-tools to debug with codelldb from Mason instead of lldb-vscode from the system.

Closes #84.