### PR TITLE
fix(pack): improve compatibility of table.unpack function

### DIFF
--- a/lua/astrocommunity/pack/java/java.lua
+++ b/lua/astrocommunity/pack/java/java.lua
@@ -110,7 +110,7 @@ return {
                 .. "/extension/server/com.microsoft.java.debug.plugin-*.jar"
             ),
             -- unpack remaining bundles
-            table.unpack(
+            (table.unpack or unpack)(
               vim.split(
                 vim.fn.glob(
                   require("mason-registry").get_package("java-test"):get_install_path() .. "/extension/server/*.jar"


### PR DESCRIPTION
- found this fix from https://github.com/hrsh7th/nvim-cmp/issues/1017
- this fix is working fine in my local