### PR TITLE
chore(pack): remove unnecessary event from rust pack

### DIFF
--- a/lua/astrocommunity/pack/rust/rust.lua
+++ b/lua/astrocommunity/pack/rust/rust.lua
@@ -55,13 +55,6 @@ return {
   },
   {
     "Saecki/crates.nvim",
-    event = { "BufRead Cargo.toml" },
-    opts = {
-      null_ls = {
-        enabled = true,
-        name = "crates.nvim",
-      },
-    },
     init = function()
       vim.api.nvim_create_autocmd("BufRead", {
         group = vim.api.nvim_create_augroup("CmpSourceCargo", { clear = true }),
@@ -72,5 +65,11 @@ return {
         end,
       })
     end,
+    opts = {
+      null_ls = {
+        enabled = true,
+        name = "crates.nvim",
+      },
+    },
   },
 }


### PR DESCRIPTION
In the `init` function we are setting up a autocommand that loads this plugin and sets up `cmp`. We don't need this other event in the lazy definition.