### PR TITLE
feat(pack): create multiple typescript packs

### DIFF
--- a/lua/astrocommunity/pack/typescript-all-in-one/README.md
+++ b/lua/astrocommunity/pack/typescript-all-in-one/README.md
@@ -1,0 +1,7 @@
+# TypeScript All-in-one Language Pack
+
+This plugin pack does the following:
+
+- Adds [tsserver pack](../typescript)
+- Adds [denols pack](../typescript-denols)
+- Enables either `denols` or `tsserver` based on the project

--- a/lua/astrocommunity/pack/typescript-all-in-one/typescript.lua
+++ b/lua/astrocommunity/pack/typescript-all-in-one/typescript.lua
@@ -1,0 +1,33 @@
+return {
+  { import = "astrocommunity.pack.typescript" },
+  { import = "astrocommunity.pack.typescript-deno" },
+  {
+    "sigmasd/deno-nvim",
+    -- HACK: This disables tsserver if denols is attached.
+    -- A solution that only enables the required lsp should replace it.
+    opts = function(_, opts)
+      vim.api.nvim_create_autocmd("LspAttach", {
+        callback = function(args)
+          local bufnr = args.buf
+          local curr_client = vim.lsp.get_client_by_id(args.data.client_id)
+          -- if deno attached, stop all typescript servers
+          if curr_client.name == "denols" then
+            vim.lsp.for_each_buffer_client(bufnr, function(client, client_id)
+              if client.name == "tsserver" then vim.lsp.stop_client(client_id, true) end
+            end)
+            -- if tsserver attached, stop it if there is a denols server attached
+          elseif curr_client.name == "tsserver" then
+            for _, client in ipairs(vim.lsp.get_active_clients { bufnr = bufnr }) do
+              if client.name == "denols" then
+                vim.lsp.stop_client(curr_client.id, true)
+                break
+              end
+            end
+          end
+        end,
+      })
+      opts.server = require("astronvim.utils.lsp").config "denols"
+      opts.server.root_dir = require("lspconfig.util").root_pattern("deno.json", "deno.jsonc")
+    end,
+  },
+}

--- a/lua/astrocommunity/pack/typescript-deno/README.md
+++ b/lua/astrocommunity/pack/typescript-deno/README.md
@@ -1,0 +1,8 @@
+# TypeScript Deno Language Pack
+
+This plugin pack does the following:
+
+- Adds `typescript`, `javascript`, and `tsx` Treesitter parsers
+- Adds `denols` language server
+- Adds [JSON language support](../json)
+- Adds [deno-nvim](https://github.com/sigmasd/deno-nvim) for language specific tooling

--- a/lua/astrocommunity/pack/typescript-deno/typescript.lua
+++ b/lua/astrocommunity/pack/typescript-deno/typescript.lua
@@ -1,0 +1,42 @@
+local utils = require "astrocommunity.utils"
+
+return {
+  { import = "astrocommunity.pack.json" },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      -- Ensure that opts.ensure_installed exists and is a table or string "all".
+      if not opts.ensure_installed then
+        opts.ensure_installed = {}
+      elseif opts.ensure_installed == "all" then
+        return
+      end
+      -- Add the required file types to opts.ensure_installed.
+      utils.list_insert_unique(opts.ensure_installed, { "javascript", "typescript", "tsx" })
+    end,
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    opts = function(_, opts)
+      -- Ensure that opts.ensure_installed exists and is a table.
+      if not opts.ensure_installed then opts.ensure_installed = {} end
+      -- Add denols to opts.ensure_installed using vim.list_extend.
+      utils.list_insert_unique(opts.ensure_installed, "denols")
+    end,
+  },
+  {
+    "jay-babu/mason-nvim-dap.nvim",
+    opts = function(_, opts)
+      -- Ensure that opts.ensure_installed exists and is a table.
+      if not opts.ensure_installed then opts.ensure_installed = {} end
+      -- Add to opts.ensure_installed using table.insert.
+      utils.list_insert_unique(opts.ensure_installed, "js")
+    end,
+  },
+  {
+    "sigmasd/deno-nvim",
+    init = function() utils.list_insert_unique(astronvim.lsp.skip_setup, "denols") end,
+    ft = { "javascript", "typescript", "javascriptreact", "typescriptreact" },
+    opts = function() return { server = require("astronvim.utils.lsp").config "denols" } end,
+  },
+}

--- a/lua/astrocommunity/pack/typescript/README.md
+++ b/lua/astrocommunity/pack/typescript/README.md
@@ -5,8 +5,9 @@ This plugin pack does the following:
 - Adds `typescript`, `javascript`, and `tsx` Treesitter parsers
 - Adds `tsserver` language server
 - Adds `prettierd` formatter
+- Adds `eslint_d` linter
 - Adds [JSON language support](../json)
-- Adds [nvim-dap-vscode-js](https://github.com/mxsdev/nvim-dap-vscode-js) for debugging
+- ~~Adds [nvim-dap-vscode-js](https://github.com/mxsdev/nvim-dap-vscode-js) for debugging~~ Currently broken
 - Adds [typescript.nvim](https://github.com/jose-elias-alvarez/typescript.nvim) for language specific tooling
 - Adds [package-info.nvim](https://github.com/vuki656/package-info.nvim) for project package management
 - Handles file imports on rename or move within neo-tree

--- a/lua/astrocommunity/pack/typescript/typescript.lua
+++ b/lua/astrocommunity/pack/typescript/typescript.lua
@@ -1,5 +1,6 @@
 local utils = require "astrocommunity.utils"
 local events = require "neo-tree.events"
+
 local function on_file_remove(args)
   local ts_clients = vim.lsp.get_active_clients { name = "tsserver" }
   for _, ts_client in ipairs(ts_clients) do
@@ -44,8 +45,34 @@ return {
     opts = function(_, opts)
       -- Ensure that opts.ensure_installed exists and is a table.
       if not opts.ensure_installed then opts.ensure_installed = {} end
-      -- Add to opts.ensure_installed using vim.list_extend.
+      -- Add prettierd & eslint_d to opts.ensure_installed using vim.list_extend.
       utils.list_insert_unique(opts.ensure_installed, "prettierd")
+      utils.list_insert_unique(opts.ensure_installed, "eslint_d")
+
+      if not opts.handlers then opts.handlers = {} end
+
+      opts.handlers.prettierd = function()
+        local null_ls = require "null-ls"
+        null_ls.register(null_ls.builtins.formatting.prettierd.with {
+          condition = function(util)
+            return util.root_has_file "package.json"
+              or util.root_has_file ".prettierrc"
+              or util.root_has_file ".prettierrc.json"
+              or util.root_has_file ".prettierrc.js"
+          end,
+        })
+      end
+
+      opts.handlers.eslint_d = function()
+        local null_ls = require "null-ls"
+        null_ls.register(null_ls.builtins.diagnostics.eslint_d.with {
+          condition = function(util)
+            return util.root_has_file "package.json"
+              or util.root_has_file ".eslintrc.json"
+              or util.root_has_file ".eslintrc.js"
+          end,
+        })
+      end
     end,
   },
   {
@@ -62,60 +89,6 @@ return {
     requires = "MunifTanjim/nui.nvim",
     config = true,
     event = "BufRead package.json",
-  },
-  {
-    "mfussenegger/nvim-dap",
-    ft = { "ts", "js", "tsx", "jsx" },
-    enabled = true,
-    dependencies = {
-      {
-        "mxsdev/nvim-dap-vscode-js",
-        opts = { debugger_cmd = { "js-debug-adapter" }, adapters = { "pwa-node" } },
-      },
-      { "theHamsta/nvim-dap-virtual-text", config = true },
-      { "rcarriga/nvim-dap-ui", config = true },
-    },
-    config = function()
-      local dap = require "dap"
-
-      local attach_node = {
-        type = "pwa-node",
-        request = "attach",
-        name = "Attach",
-        processId = function(...) return require("dap.utils").pick_process(...) end,
-        cwd = "${workspaceFolder}",
-      }
-
-      dap.configurations.javascript = {
-        {
-          type = "pwa-node",
-          request = "launch",
-          name = "Launch file",
-          program = "${file}",
-          cwd = "${workspaceFolder}",
-        },
-        attach_node,
-      }
-      dap.configurations.typescript = {
-        {
-          type = "pwa-node",
-          request = "launch",
-          name = "Launch file",
-          program = "${file}",
-          cwd = "${workspaceFolder}",
-          runtimeExecutable = "ts-node",
-          sourceMaps = true,
-          protocol = "inspector",
-          console = "integratedTerminal",
-          resolveSourceMapLocations = {
-            "${workspaceFolder}/dist/**/*.js",
-            "${workspaceFolder}/**",
-            "!**/node_modules/**",
-          },
-        },
-        attach_node,
-      }
-    end,
   },
   {
     "jose-elias-alvarez/typescript.nvim",


### PR DESCRIPTION
As described [here](https://github.com/AstroNvim/astrocommunity/issues/120) I am looking to add separate packs for both tsserver, denols & tsserver + denols for TypeScript developers. This is a first attempt at doing it and the changes are yet to be tested. The reason why I already open a PR is so the original authors of the typescript pack can take a look at it and possibly extend the functionality (especially to the denols pack) to create a more mature prduct.

Personally I'd also consider adding `eslint_d` to the tsserver pack, please let me know your opinions about that.

Resolves #120 