### PR TITLE
feat(completion): improve copilot-cmp defaults 

### DIFF
--- a/lua/astrocommunity/completion/copilot-lua-cmp/copilot-lua-cmp.lua
+++ b/lua/astrocommunity/completion/copilot-lua-cmp/copilot-lua-cmp.lua
@@ -30,22 +30,14 @@ return {
           fallback()
         end
       end, { "i", "s" })
-      opts.mapping["<C-e>"] = cmp.mapping {
-        i = function(fallback)
-          if copilot.is_visible() then
-            copilot.dismiss()
-          elseif not cmp.abort() then
-            fallback()
-          end
-        end,
-        c = function(fallback)
-          if copilot.is_visible() then
-            copilot.dismiss()
-          elseif not cmp.close() then
-            fallback()
-          end
-        end,
-      }
+
+      opts.mapping["<C-x>"] = cmp.mapping(function()
+        if copilot.is_visible() then copilot.next() end
+      end)
+
+      opts.mapping["<C-z>"] = cmp.mapping(function()
+        if copilot.is_visible() then copilot.prev() end
+      end)
 
       return opts
     end,


### PR DESCRIPTION
- Re-enable C-e to turn off cmp window to see overlapping hidden copilot suggestion without losing said suggestion
- Add C-x and C-z mappings to go to next and previous copilot suggestions

This suggestion comes from an issue I have been having where whenever copilot gives a multi-line suggestion the overlapping cmp window hides it. By re-enabling C-e we can quickly shutoff the window without losing the suggestion and then we can go through them using the new mappings I added.

<img width="1108" alt="Screenshot 2023-04-09 at 2 02 55" src="https://user-images.githubusercontent.com/77372584/230739576-bcd562b1-7faa-4ff4-9dcb-c7d268a25a18.png">
