### PR TITLE
feat: Add Pylint and make it work in a virtualenv

### DIFF
--- a/lua/astrocommunity/pack/python/README.md
+++ b/lua/astrocommunity/pack/python/README.md
@@ -9,5 +9,6 @@ This plugin pack does the following:
 - Adds the following `null-ls` sources:
   - [black](https://pypi.org/project/black/)
   - [isort](https://pypi.org/project/isort/)
+  - [pylint](https://pypi.org/project/pylint/)
 - Adds `debugpy` for debugging
 - Adds [venv-selector.nvim](https://github.com/linux-cultist/venv-selector.nvim) for virtual environment management

--- a/lua/astrocommunity/pack/python/python.lua
+++ b/lua/astrocommunity/pack/python/python.lua
@@ -28,7 +28,7 @@ return {
       -- Ensure that opts.ensure_installed exists and is a table.
       if not opts.ensure_installed then opts.ensure_installed = {} end
       -- Add to opts.ensure_installed using vim.list_extend.
-      utils.list_insert_unique(opts.ensure_installed, { "isort", "black" })
+      utils.list_insert_unique(opts.ensure_installed, { "isort", "black", "pylint" })
     end,
   },
   {
@@ -45,4 +45,11 @@ return {
     opts = {},
     keys = { { "<leader>lv", "<cmd>:VenvSelect<cr>", desc = "Select VirtualEnv" } },
   },
+  {
+    -- This is needed for pylint to work in a virtualenv. See https://github.com/williamboman/mason.nvim/issues/668#issuecomment-1320859097
+    "williamboman/mason.nvim",
+    opts = {
+      PATH = "append"
+    }
+  }
 }

--- a/lua/astrocommunity/pack/python/python.lua
+++ b/lua/astrocommunity/pack/python/python.lua
@@ -49,7 +49,7 @@ return {
     -- This is needed for pylint to work in a virtualenv. See https://github.com/williamboman/mason.nvim/issues/668#issuecomment-1320859097
     "williamboman/mason.nvim",
     opts = {
-      PATH = "append"
-    }
-  }
+      PATH = "append",
+    },
+  },
 }


### PR DESCRIPTION
Pylint is a very popular linter, unfortunately it doesn't work out of the box if you are using a virtualenv (as you should be doing). This issue in mason.nvim describes why it doesn't work and how to apply a workaround: https://github.com/williamboman/mason.nvim/issues/668