### PR TITLE
feat(completion): added more mappings for copilot-lua-cmp

### DIFF
--- a/lua/astrocommunity/completion/copilot-lua-cmp/copilot-lua-cmp.lua
+++ b/lua/astrocommunity/completion/copilot-lua-cmp/copilot-lua-cmp.lua
@@ -38,6 +38,26 @@ return {
       opts.mapping["<C-z>"] = cmp.mapping(function()
         if copilot.is_visible() then copilot.prev() end
       end)
+      
+      opts.mapping["<C-right>"] = cmp.mapping(function()
+        if copilot.is_visible() then copilot.accept_word() end
+      end)
+
+      opts.mapping["<C-l>"] = cmp.mapping(function()
+        if copilot.is_visible() then copilot.accept_word() end
+      end)
+
+      opts.mapping["<C-down>"] = cmp.mapping(function()
+        if copilot.is_visible() then copilot.accept_line() end
+      end)
+
+      opts.mapping["<C-j>"] = cmp.mapping(function()
+        if copilot.is_visible() then copilot.accept_line() end
+      end)
+
+      opts.mapping["<C-c>"] = cmp.mapping(function()
+        if copilot.is_visible() then copilot.dismiss() end
+      end)
 
       return opts
     end,

--- a/lua/astrocommunity/completion/copilot-lua-cmp/copilot-lua-cmp.lua
+++ b/lua/astrocommunity/completion/copilot-lua-cmp/copilot-lua-cmp.lua
@@ -38,7 +38,7 @@ return {
       opts.mapping["<C-z>"] = cmp.mapping(function()
         if copilot.is_visible() then copilot.prev() end
       end)
-      
+
       opts.mapping["<C-right>"] = cmp.mapping(function()
         if copilot.is_visible() then copilot.accept_word() end
       end)


### PR DESCRIPTION
It is very useful to accept Co-pilot suggestions one word at a time or even a whole line.  Copilot offers these features but they have not been exposed.  VS Code, by default uses Ctrl+Right to accept a word.  I've added similar vim-like controls:

* Ctrl+Right/L for accepting a word
* Ctrl+Down/J for accepting a line
* Ctrl+C to dismiss the suggestion