### PR TITLE
fix(note-taking): use new neorg v3 config options

### DIFF
--- a/lua/astrocommunity/note-taking/neorg/neorg.lua
+++ b/lua/astrocommunity/note-taking/neorg/neorg.lua
@@ -6,15 +6,15 @@ return {
   opts = {
     load = {
       ["core.defaults"] = {}, -- Loads default behaviour
-      ["core.norg.concealer"] = {}, -- Adds pretty icons to your documents
+      ["core.concealer"] = {}, -- Adds pretty icons to your documents
       ["core.keybinds"] = {}, -- Adds default keybindings
-      ["core.norg.completion"] = {
+      ["core.completion"] = {
         config = {
           engine = "nvim-cmp",
         },
       }, -- Enables support for completion plugins
-      ["core.norg.journal"] = {}, -- Enables support for the journal module
-      ["core.norg.dirman"] = { -- Manages Neorg workspaces
+      ["core.journal"] = {}, -- Enables support for the journal module
+      ["core.dirman"] = { -- Manages Neorg workspaces
         config = {
           workspaces = {
             notes = "~/projects/notes",


### PR DESCRIPTION
Neorg has a new configuration change removing the ".nerog" in many of it's modules.