### PR TITLE
fix: Don't pull in prettierd

### DIFF
--- a/lua/astrocommunity/pack/json/README.md
+++ b/lua/astrocommunity/pack/json/README.md
@@ -4,4 +4,3 @@ This plugin pack does the following:
 
 - Adds `json` and `jsonc` Treesitter parsers
 - Adds `jsonls` language server
-- Adds `prettierd` formatter

--- a/lua/astrocommunity/pack/json/json.lua
+++ b/lua/astrocommunity/pack/json/json.lua
@@ -20,13 +20,4 @@ return {
       utils.list_insert_unique(opts.ensure_installed, "jsonls")
     end,
   },
-  {
-    "jay-babu/mason-null-ls.nvim",
-    opts = function(_, opts)
-      -- Ensure that opts.ensure_installed exists and is a table.
-      if not opts.ensure_installed then opts.ensure_installed = {} end
-      -- Add go lsps to opts.ensure_installed using vim.list_extend.
-      utils.list_insert_unique(opts.ensure_installed, "prettierd")
-    end,
-  },
 }


### PR DESCRIPTION
It seems counterintuitive to have `jsonls` and `prettierd` fight for formatting. 
I encountered several instances where prettierd won the formatting over jsonls and vice versa. 
I am uncertain if it's connected to that, but might as well be: Running into timeouts and/or freezing up neovim until one formatter wrote its changes..