### PR TITLE
fix(nvim-ts-rainbow2): remove hack

### DIFF
--- a/lua/astrocommunity/editing-support/nvim-ts-rainbow2/nvim-ts-rainbow2.lua
+++ b/lua/astrocommunity/editing-support/nvim-ts-rainbow2/nvim-ts-rainbow2.lua
@@ -2,15 +2,6 @@ return {
   "nvim-treesitter/nvim-treesitter",
   dependencies = {
     "HiPhish/nvim-ts-rainbow2",
-    config = function()
-      -- HACK: https://github.com/p00f/nvim-ts-rainbow/issues/112#issuecomment-1310835936
-      vim.api.nvim_create_autocmd({ "BufWritePost", "FocusGained" }, {
-        callback = function()
-          vim.cmd "TSDisable rainbow"
-          vim.cmd "TSEnable rainbow"
-        end,
-      })
-    end,
   },
   opts = { rainbow = { enable = true } },
 }


### PR DESCRIPTION
Recently, I've noticed that my editor slows down over time. Turns out that this hack is causing the problem. Without it, there is no more slowdown.