### PR TITLE
fix: readd <leader>O as a prefix for octo

### DIFF
--- a/lua/astrocommunity/git/octo/octo.lua
+++ b/lua/astrocommunity/git/octo/octo.lua
@@ -1,4 +1,4 @@
-local prefix = "<leader>G"
+local prefix = "<leader>O"
 return {
   "pwntester/octo.nvim",
   dependencies = {


### PR DESCRIPTION
Sorry, this got lost somehow along the way. This was discussed in #138 as a better fit than `<leader>G` until a better integration has been found