### PR TITLE
fix(pack): make codelldb point to the right path in windows

### DIFF
--- a/lua/astrocommunity/pack/rust/rust.lua
+++ b/lua/astrocommunity/pack/rust/rust.lua
@@ -22,13 +22,23 @@ return {
       local package_path = require("mason-registry").get_package("codelldb"):get_install_path()
       local codelldb_path = package_path .. "/codelldb"
       local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
+      local this_os = vim.loop.os_uname().sysname;
+
+      -- The path in windows is different
+      if this_os:find 'Windows' then
+        codelldb_path = package_path .. "\\extension\\adapter\\codelldb.exe"
+        liblldb_path = package_path .. "\\extension\\lldb\\bin\\liblldb.dll"
+      else
+        -- The liblldb extension is .so for linux and .dylib for macOS
+        liblldb_path = liblldb_path .. (this_os == "Linux" and ".so" or ".dylib")
+      end
 
       return {
         server = require("astronvim.utils.lsp").config "rust_analyzer",
         dap = {
           adapter = require("rust-tools.dap").get_codelldb_adapter(
             codelldb_path,
-            liblldb_path .. (vim.loop.os_uname().sysname == "Linux" and ".so" or ".dylib")
+            liblldb_path
           ),
         },
       }

--- a/lua/astrocommunity/pack/rust/rust.lua
+++ b/lua/astrocommunity/pack/rust/rust.lua
@@ -22,10 +22,10 @@ return {
       local package_path = require("mason-registry").get_package("codelldb"):get_install_path()
       local codelldb_path = package_path .. "/codelldb"
       local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
-      local this_os = vim.loop.os_uname().sysname;
+      local this_os = vim.loop.os_uname().sysname
 
       -- The path in windows is different
-      if this_os:find 'Windows' then
+      if this_os:find "Windows" then
         codelldb_path = package_path .. "\\extension\\adapter\\codelldb.exe"
         liblldb_path = package_path .. "\\extension\\lldb\\bin\\liblldb.dll"
       else
@@ -36,10 +36,7 @@ return {
       return {
         server = require("astronvim.utils.lsp").config "rust_analyzer",
         dap = {
-          adapter = require("rust-tools.dap").get_codelldb_adapter(
-            codelldb_path,
-            liblldb_path
-          ),
+          adapter = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path),
         },
       }
     end,


### PR DESCRIPTION
Currently, if you are on Windows and you try to use the rust debugger you will get errors and you won't be able to use the debugger. #167 
In this PR I fix that issue by correcting the path when the plugin is run on windows.