### PR TITLE
refactor(pack): require neo-tree later in typescript

### DIFF
--- a/lua/astrocommunity/pack/typescript/typescript.lua
+++ b/lua/astrocommunity/pack/typescript/typescript.lua
@@ -1,5 +1,4 @@
 local utils = require "astronvim.utils"
-local events = require "neo-tree.events"
 
 local function on_file_remove(args)
   local ts_clients = vim.lsp.get_active_clients { name = "tsserver" }
@@ -84,8 +83,9 @@ return {
   },
   {
     "nvim-neo-tree/neo-tree.nvim",
-    opts = {
-      event_handlers = {
+    opts = function(_, opts)
+      local events = require "neo-tree.events"
+      opts.event_handlers = {
         {
           event = events.FILE_MOVED,
           handler = on_file_remove,
@@ -94,7 +94,7 @@ return {
           event = events.FILE_RENAMED,
           handler = on_file_remove,
         },
-      },
-    },
+      }
+    end,
   },
 }


### PR DESCRIPTION
This allows neo-tree to be disabled by overrriding the config and allow the plugin to keep working.