### PR TITLE
feat(pack): show custom tailwindcss colors in cmp menu

### DIFF
--- a/lua/astrocommunity/pack/tailwindcss/README.md
+++ b/lua/astrocommunity/pack/tailwindcss/README.md
@@ -5,4 +5,4 @@ This plugin pack does the following:
 - Adds `css` Treesitter parser
 - Adds `tailwindcss` and `cssls` language servers
 - Adds `prettierd` and `rustywind` formatters
-- Adds `roobert/tailwindcss-colorizer-cmp.nvim` to cmp completion sources
+- Adds [`tailwindcss-colorizer-cmp.nvim`](https://github.com/js-everts/cmp-tailwind-colors) to cmp completion sources

--- a/lua/astrocommunity/pack/tailwindcss/tailwindcss.lua
+++ b/lua/astrocommunity/pack/tailwindcss/tailwindcss.lua
@@ -23,13 +23,16 @@ return {
   {
     "hrsh7th/nvim-cmp",
     dependencies = {
-      { "roobert/tailwindcss-colorizer-cmp.nvim", config = true },
+      { "js-everts/cmp-tailwind-colors", config = true },
     },
     opts = function(_, opts)
       local format_kinds = opts.formatting.format
       opts.formatting.format = function(entry, item)
-        format_kinds(entry, item)
-        return require("tailwindcss-colorizer-cmp").formatter(entry, item)
+        if item.kind == "Color" then
+          item = require("cmp-tailwind-colors").format(entry, item)
+          return item
+        end
+        return format_kinds(entry, item)
       end
     end,
   },


### PR DESCRIPTION
The previous plugin uses hardcoded values when determining which colors to display in the completion menu, which creates inconsistencies when custom tailwind colors are defined.