### PR TITLE
fix(pack): gracefully rust plugin if codelldb is not available

### DIFF
--- a/lua/astrocommunity/pack/rust/rust.lua
+++ b/lua/astrocommunity/pack/rust/rust.lua
@@ -14,36 +14,28 @@ return {
     ft = { "rust" },
     init = function() astronvim.lsp.skip_setup = utils.list_insert_unique(astronvim.lsp.skip_setup, "rust_analyzer") end,
     opts = function()
-      local success, package = pcall(function() return require("mason-registry").get_package("codelldb") end)
-      if not success then
-        -- gracefully degrade when the platform is not supported by mason
-        return {
-          server = require("astronvim.utils.lsp").config "rust_analyzer",
-          dap = {
-            adapter = require("rust-tools.dap").get_codelldb_adapter(),
-          },
-        }
-      end
-      local package_path = package:get_install_path()
-      local codelldb_path = package_path .. "/codelldb"
-      local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
-      local this_os = vim.loop.os_uname().sysname
+      local adapter
+      local success, package = pcall(function() return require("mason-registry").get_package "codelldb" end)
+      if success then
+        local package_path = package:get_install_path()
+        local codelldb_path = package_path .. "/codelldb"
+        local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
+        local this_os = vim.loop.os_uname().sysname
 
-      -- The path in windows is different
-      if this_os:find "Windows" then
-        codelldb_path = package_path .. "\\extension\\adapter\\codelldb.exe"
-        liblldb_path = package_path .. "\\extension\\lldb\\bin\\liblldb.dll"
+        -- The path in windows is different
+        if this_os:find "Windows" then
+          codelldb_path = package_path .. "\\extension\\adapter\\codelldb.exe"
+          liblldb_path = package_path .. "\\extension\\lldb\\bin\\liblldb.dll"
+        else
+          -- The liblldb extension is .so for linux and .dylib for macOS
+          liblldb_path = liblldb_path .. (this_os == "Linux" and ".so" or ".dylib")
+        end
+        adapter = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path)
       else
-        -- The liblldb extension is .so for linux and .dylib for macOS
-        liblldb_path = liblldb_path .. (this_os == "Linux" and ".so" or ".dylib")
+        adapter = require("rust-tools.dap").get_codelldb_adapter()
       end
 
-      return {
-        server = require("astronvim.utils.lsp").config "rust_analyzer",
-        dap = {
-          adapter = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path),
-        },
-      }
+      return { server = require("astronvim.utils.lsp").config "rust_analyzer", dap = { adapter = adapter } }
     end,
     dependencies = {
       {

--- a/lua/astrocommunity/pack/rust/rust.lua
+++ b/lua/astrocommunity/pack/rust/rust.lua
@@ -14,7 +14,17 @@ return {
     ft = { "rust" },
     init = function() astronvim.lsp.skip_setup = utils.list_insert_unique(astronvim.lsp.skip_setup, "rust_analyzer") end,
     opts = function()
-      local package_path = require("mason-registry").get_package("codelldb"):get_install_path()
+      local success, package = pcall(function() return require("mason-registry").get_package("codelldb") end)
+      if not success then
+        -- gracefully degrade when the platform is not supported by mason
+        return {
+          server = require("astronvim.utils.lsp").config "rust_analyzer",
+          dap = {
+            adapter = require("rust-tools.dap").get_codelldb_adapter(),
+          },
+        }
+      end
+      local package_path = package:get_install_path()
       local codelldb_path = package_path .. "/codelldb"
       local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
       local this_os = vim.loop.os_uname().sysname


### PR DESCRIPTION
We have this issue on NixOS but potentiall also other operating systems such as *BSDs and non-mainstream cpu architectures are affected by this.