### PR TITLE
Use yarn instead of npm for x6 installation speed.

### DIFF
--- a/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/markdown-preview-nvim.lua
+++ b/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/markdown-preview-nvim.lua
@@ -1,5 +1,5 @@
 return {
   "iamcco/markdown-preview.nvim",
-  build = "cd app && npm install",
+  build = "cd app && yarn install",
   ft = "markdown",
 }


### PR DESCRIPTION
Using npm this plugin lags behind all the others during the installation process. Using yarn this is solved.