### PR TITLE
fix(typescript): improve eslint and prettier loading

### DIFF
--- a/lua/astrocommunity/pack/typescript/typescript.lua
+++ b/lua/astrocommunity/pack/typescript/typescript.lua
@@ -36,25 +36,23 @@ return {
 
       if not opts.handlers then opts.handlers = {} end
 
+      local has_prettier = function(util)
+        return util.root_has_file ".prettierrc"
+          or util.root_has_file ".prettierrc.json"
+          or util.root_has_file ".prettierrc.js"
+      end
+      local has_eslint = function(util) return util.root_has_file ".eslintrc.json" or util.root_has_file ".eslintrc.js" end
+
       opts.handlers.prettierd = function()
         local null_ls = require "null-ls"
-        null_ls.register(null_ls.builtins.formatting.prettierd.with {
-          condition = function(util)
-            return util.root_has_file "package.json"
-              or util.root_has_file ".prettierrc"
-              or util.root_has_file ".prettierrc.json"
-              or util.root_has_file ".prettierrc.js"
-          end,
-        })
+        null_ls.register(null_ls.builtins.formatting.prettierd.with { condition = has_prettier })
       end
 
       opts.handlers.eslint_d = function()
         local null_ls = require "null-ls"
         null_ls.register(null_ls.builtins.diagnostics.eslint_d.with {
           condition = function(util)
-            return util.root_has_file "package.json"
-              or util.root_has_file ".eslintrc.json"
-              or util.root_has_file ".eslintrc.js"
+            return (util.root_has_file "package.json" and not has_prettier(util)) or has_eslint(util)
           end,
         })
       end

--- a/lua/astrocommunity/pack/typescript/typescript.lua
+++ b/lua/astrocommunity/pack/typescript/typescript.lua
@@ -58,15 +58,25 @@ return {
       if not opts.handlers then opts.handlers = {} end
 
       local has_prettier = function(util)
-        return util.root_has_file ".prettierrc"
+        return check_json_key_exists(vim.fn.getcwd() .. "/package.json", "prettier")
+          or util.root_has_file ".prettierrc"
           or util.root_has_file ".prettierrc.json"
+          or util.root_has_file ".prettierrc.yml"
+          or util.root_has_file ".prettierrc.yaml"
+          or util.root_has_file ".prettierrc.json5"
           or util.root_has_file ".prettierrc.js"
-          or check_json_key_exists(vim.fn.getcwd() .. "/package.json", "prettier")
+          or util.root_has_file ".prettierrc.cjs"
+          or util.root_has_file "prettierrc.config.js"
+          or util.root_has_file "prettierrc.config.cjs"
+          or util.root_has_file ".prettierrc.toml"
       end
 
       local has_eslint = function(util)
-        return util.root_has_file ".eslintrc.json"
-          or util.root_has_file ".eslintrc.js"
+        return util.root_has_file ".eslintrc.js"
+          or util.root_has_file ".eslintrc.cjs"
+          or util.root_has_file ".eslintrc.yaml"
+          or util.root_has_file ".eslintrc.yml"
+          or util.root_has_file ".eslintrc.json"
           or check_json_key_exists(vim.fn.getcwd() .. "/package.json", "eslintConfig")
       end
 


### PR DESCRIPTION
This seems like a pretty good way to improve the `prettier` and `eslint` loading. This does make it so that `eslint` is preferred over `prettier` if there are no configuration files for both specifically. This could be changed/improved based on suggestions probably from someone who works with these language servers/linters/formatters more than I do

Resolves #225 