### PR TITLE
feat(pack): clojure language pack

### DIFF
--- a/lua/astrocommunity/pack/clojure/README.md
+++ b/lua/astrocommunity/pack/clojure/README.md
@@ -1,0 +1,38 @@
+# Clojure Language Pack
+
+Requires:
+
+- Java Development Kit, e.g. `JDK-17`
+- [Clojure CLI](https://clojure.org/guides/install_clojure) or [Leiningen](https://leiningen.org/)
+
+This plugin pack does the following:
+
+- Adds `clojure` treesitter parsers
+- Adds `clojure_ls` language server
+- Adds [Olical/conjure](https://github.com/Olical/conjure) and [gpanders/nvim-parinfer](https://github.com/gpanders/nvim-parinfer) plugins
+- Add autocmd to disable lsp diagnostics in Conjure log
+- Add autocmd to configure comments to Clojure style guide
+
+## Additional Config
+
+Add a localleader mapping to the user config (if not defined in AstroNvim) to enable Conjure key mappings, e.g. `, e r` to evaluate top level root
+
+Define a localleader mapping in `options.lua`
+
+```lua
+return {
+  g = {
+    mapleader = " ",                 -- sets vim.g.mapleader
+    maplocalleader = ",",            -- Set local leader key binding
+    -- additional options...
+  },
+}
+```
+
+## Clojure Guides
+
+`:ConjureSchool` in a Clojure buffer runs an interactive tutorial for Conjure
+
+- [Clojure.org](https://clojure.org/index) API reference and guides
+- [Conjure - Clojure guide](https://github.com/Olical/conjure/wiki/Quick-start:-Clojure)
+- [Practicalli Neovim](https://practical.li/neovim/) Clojure development workflow

--- a/lua/astrocommunity/pack/clojure/clojure.lua
+++ b/lua/astrocommunity/pack/clojure/clojure.lua
@@ -1,0 +1,60 @@
+-- Clojure support with Conjure plugin
+local utils = require "astronvim.utils"
+return {
+  -- Clojure Language Server
+  {
+    "williamboman/mason-lspconfig.nvim",
+    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "clojure_lsp") end,
+  },
+  -- Clojure parser
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "clojure")
+      end
+    end,
+  },
+  -- Parinfer parens management for Clojure
+  {
+    "gpanders/nvim-parinfer",
+    ft = { "clojure" },
+    init = function()
+      vim.g.parinfer_force_balance = true
+      vim.g.parinfer_comment_chars = ";;"
+    end,
+  },
+  -- Conjure plugin for Clojure REPL
+  {
+    "Olical/conjure",
+    -- load plugin on filetypes
+    ft = { "clojure" },
+    init = function()
+      vim.g["conjure#log#hud#width"] = 1
+      vim.g["conjure#log#hud#enabled"] = false
+      vim.g["conjure#log#hud#anchor"] = "SE"
+      vim.g["conjure#log#botright"] = true
+      vim.g["conjure#extract#context_header_lines"] = 100
+      vim.g["conjure#eval#comment_prefix"] = ";;"
+      vim.g["conjure#client#clojure#nrepl#connection#auto_repl#enabled"] = false
+      vim.g["conjure#client#clojure#nrepl#connection#auto_repl#hidden"] = true
+      vim.g["conjure#client#clojure#nrepl#connection#auto_repl#cmd"] = nil
+      vim.g["conjure#client#clojure#nrepl#eval#auto_require"] = false
+      vim.g["conjure#client#clojure#nrepl#test#runner"] = "kaocha"
+
+      vim.api.nvim_create_autocmd("BufNewFile", {
+        group = vim.api.nvim_create_augroup("conjure_log_disable_lsp", { clear = true }),
+        pattern = { "conjure-log-*" },
+        callback = function() vim.diagnostic.disable(0) end,
+        desc = "Conjure Log disable LSP diagnostics",
+      })
+
+      vim.api.nvim_create_autocmd("FileType", {
+        group = vim.api.nvim_create_augroup("comment_config", { clear = true }),
+        pattern = { "clojure" },
+        callback = function() vim.bo.commentstring = ";; %s" end,
+        desc = "Lisp style line comment",
+      })
+    end,
+  },
+}


### PR DESCRIPTION
Add a clojure pack to the Astrocommunity

- Treesitter parser: clojure
- LSP: clojure_lsp
- Plugins: "Olical/conjure" and "gpanders/nvim-parinfer"
- Add autocmd to disable lsp diagnostics in Conjure log
- Add autocmd to configure comments to Clojure style guide

#### Additional Config

Add a localleader mapping to the user config (if not defined in AstroNvim) to enable Conjure key mappings, e.g. `, e r` to evaluate top level root

Define a localleader mapping in `options.lua`

```lua
return {
  g = {
    mapleader = " ",                 -- sets vim.g.mapleader
    maplocalleader = ",",            -- Set local leader key binding
    -- additional options...
  },
}
```

An autocmd is used to set ;; as the line comment character, to follow the Clojure style guide.

Resolve #247 