### PR TITLE
chore: update readme according to breaking renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ If you prefer to organize your plugins in the `user/plugins` folder, you can cre
 return {
   "AstroNvim/astrocommunity",
   { import = "astrocommunity.pack.rust" },
-  { import = "astrocommunity.colorscheme.nightfox", enabled = false },
-  { import = "astrocommunity.colorscheme.kanagawa", enabled = true },
+  { import = "astrocommunity.colorscheme.nightfox-nvim", enabled = false },
+  { import = "astrocommunity.colorscheme.kanagawa-nvim", enabled = true },
   { import = "astrocommunity.colorscheme.rose-pine" },
   { import = "astrocommunity.colorscheme.catppuccin" },
   { -- further customize the options set by the community


### PR DESCRIPTION
The `README` should reflect the new colorscheme names.