### PR TITLE
feat(pack): add luacheck linter to lua pack

### DIFF
--- a/lua/astrocommunity/pack/lua/lua.lua
+++ b/lua/astrocommunity/pack/lua/lua.lua
@@ -14,6 +14,8 @@ return {
   },
   {
     "jay-babu/mason-null-ls.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "stylua") end,
+    opts = function(_, opts)
+      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "stylua", "luacheck" })
+    end,
   },
 }


### PR DESCRIPTION
Since `selene` got removed from lua pack in 4caa6da and pretty much every plugin developer using `luacheck`, I think it would be a good idea to add it as linter, especially because Astronvim uses it and `.luacheckrc` is already configured there, so it's not going to be a wall of warnings like `accessing undefined variable 'vim'`