### PR TITLE
feat(motion)!: separate flit.nvim from leap.nvim

### DIFF
--- a/lua/astrocommunity/motion/flit-nvim/README.md
+++ b/lua/astrocommunity/motion/flit-nvim/README.md
@@ -1,0 +1,5 @@
+# flit.nvim
+
+**Repository:** https://github.com/ggandor/flit.nvim
+
+f/F/t/T motions on steroids, building on the Leap interface.

--- a/lua/astrocommunity/motion/flit-nvim/flit-nvim.lua
+++ b/lua/astrocommunity/motion/flit-nvim/flit-nvim.lua
@@ -1,0 +1,20 @@
+return {
+  {
+    "ggandor/flit.nvim",
+    keys = function()
+      ---@type LazyKeys[]
+      local ret = {}
+      for _, key in ipairs { "f", "F", "t", "T" } do
+        ret[#ret + 1] = { key, mode = { "n", "x", "o" }, desc = key }
+      end
+      return ret
+    end,
+    opts = { labeled_modes = "nx" },
+    dependencies = {
+      "ggandor/leap.nvim",
+      dependencies = {
+        "tpope/vim-repeat",
+      },
+    },
+  },
+}

--- a/lua/astrocommunity/motion/leap-nvim/README.md
+++ b/lua/astrocommunity/motion/leap-nvim/README.md
@@ -1,7 +1,5 @@
-# flit.nvim
+# leap.nvim
 
 **Repository:** https://github.com/ggandor/leap.nvim
 
 :kangaroo: Neovim's answer to the mouse
-
-This also includes [flit.nvim](https://github.com/ggandor/flit.nvim).

--- a/lua/astrocommunity/motion/leap-nvim/leap-nvim.lua
+++ b/lua/astrocommunity/motion/leap-nvim/leap-nvim.lua
@@ -1,32 +1,18 @@
 return {
-  {
-    "ggandor/flit.nvim",
-    keys = function()
-      ---@type LazyKeys[]
-      local ret = {}
-      for _, key in ipairs { "f", "F", "t", "T" } do
-        ret[#ret + 1] = { key, mode = { "n", "x", "o" }, desc = key }
-      end
-      return ret
-    end,
-    opts = { labeled_modes = "nx" },
-    dependencies = {
-      "ggandor/leap.nvim",
-      keys = {
-        { "s", mode = { "n", "x", "o" }, desc = "Leap forward to" },
-        { "S", mode = { "n", "x", "o" }, desc = "Leap backward to" },
-        { "gs", mode = { "n", "x", "o" }, desc = "Leap from windows" },
-      },
-      config = function(_, opts)
-        local leap = require "leap"
-        for k, v in pairs(opts) do
-          leap.opts[k] = v
-        end
-        leap.add_default_mappings(true)
-      end,
-      dependencies = {
-        "tpope/vim-repeat",
-      },
-    },
+  "ggandor/leap.nvim",
+  keys = {
+    { "s", mode = { "n", "x", "o" }, desc = "Leap forward to" },
+    { "S", mode = { "n", "x", "o" }, desc = "Leap backward to" },
+    { "gs", mode = { "n", "x", "o" }, desc = "Leap from windows" },
+  },
+  config = function(_, opts)
+    local leap = require "leap"
+    for k, v in pairs(opts) do
+      leap.opts[k] = v
+    end
+    leap.add_default_mappings(true)
+  end,
+  dependencies = {
+    "tpope/vim-repeat",
   },
 }


### PR DESCRIPTION
This change has the benefit that only one of those plugins is active instead of both reserving keybinds