### PR TITLE
docs(pack): fix python pack README, as pylint was removed

### DIFF
--- a/lua/astrocommunity/pack/python/README.md
+++ b/lua/astrocommunity/pack/python/README.md
@@ -9,7 +9,6 @@ This plugin pack does the following:
 - Adds the following `null-ls` sources:
   - [black](https://pypi.org/project/black/)
   - [isort](https://pypi.org/project/isort/)
-  - [pylint](https://pypi.org/project/pylint/)
 - Adds `debugpy` for debugging
 - Adds [venv-selector.nvim](https://github.com/linux-cultist/venv-selector.nvim) for virtual environment management. [**Important for Debian-like distro users**](https://github.com/linux-cultist/venv-selector.nvim/issues/6): because of the fd binary being named fdfind you'll need to add to `/plugins/user.lua` (for example) the following:
 ```


### PR DESCRIPTION
in 88adb54ebda4ee85842198eb06c5b1ed5585cb79