### PR TITLE
fix(ccc-nvim.lua): highlighter attached buffer error

### DIFF
--- a/lua/astrocommunity/color/ccc-nvim/ccc-nvim.lua
+++ b/lua/astrocommunity/color/ccc-nvim/ccc-nvim.lua
@@ -5,9 +5,5 @@ return {
     event = "User AstroFile",
     keys = { { "<leader>uC", "<cmd>CccPick<cr>", desc = "Toggle colorizer" } },
     opts = { highlighter = { auto_enable = true } },
-    config = function(_, opts)
-      require("ccc").setup(opts)
-      require("ccc.highlighter"):enable()
-    end,
   },
 }


### PR DESCRIPTION
Fix attached buffer error and utilize the auto loading instead of calling it directly since we're passing in the auto_enable option. https://github.com/uga-rosa/ccc.nvim/commit/5a9e394e61925d71f9c1c0cd1fd30ce463d8be46

<img width="634" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/1778670/bda1688e-9eb5-4546-9d87-b68a6d1610b3">

Did nothing to affect code style so not sure why the action is failing...
