### PR TITLE
fix: Remove rustywind from tailwindcss pack

### DIFF
--- a/lua/astrocommunity/pack/tailwindcss/README.md
+++ b/lua/astrocommunity/pack/tailwindcss/README.md
@@ -4,5 +4,5 @@ This plugin pack does the following:
 
 - Adds `css` Treesitter parser
 - Adds `tailwindcss` and `cssls` language servers
-- Adds `prettierd` and `rustywind` formatters
+- Adds `prettierd` formatter
 - Adds [`tailwindcss-colorizer-cmp.nvim`](https://github.com/js-everts/cmp-tailwind-colors) to cmp completion sources

--- a/lua/astrocommunity/pack/tailwindcss/tailwindcss.lua
+++ b/lua/astrocommunity/pack/tailwindcss/tailwindcss.lua
@@ -16,9 +16,7 @@ return {
   },
   {
     "jay-babu/mason-null-ls.nvim",
-    opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "prettierd" })
-    end,
+    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "prettierd" }) end,
   },
   {
     "hrsh7th/nvim-cmp",

--- a/lua/astrocommunity/pack/tailwindcss/tailwindcss.lua
+++ b/lua/astrocommunity/pack/tailwindcss/tailwindcss.lua
@@ -17,7 +17,7 @@ return {
   {
     "jay-babu/mason-null-ls.nvim",
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "prettierd", "rustywind" })
+      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "prettierd" })
     end,
   },
   {


### PR DESCRIPTION
Rustywind sorts Tailwind class names, however it doesn't follow the official [Tailwind Prettier plugin](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier). Only one should be included