### PR TITLE
fix(pack/tailwindcss): use icon when color is not available for cmp

### DIFF
--- a/lua/astrocommunity/pack/tailwindcss/tailwindcss.lua
+++ b/lua/astrocommunity/pack/tailwindcss/tailwindcss.lua
@@ -28,6 +28,7 @@ return {
       opts.formatting.format = function(entry, item)
         if item.kind == "Color" then
           item = require("cmp-tailwind-colors").format(entry, item)
+          if item.kind == "Color" then return format_kinds(entry, item) end
           return item
         end
         return format_kinds(entry, item)


### PR DESCRIPTION
This resolves the issue where the kind "Color" would be displayed instead of its corresponding icon in the cmp menu when a tailwindcss color does not exist for a given entry.
<img width="504" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/56745535/c8b9d4da-d8a6-41c0-8e18-ecc528823882">