### PR TITLE
fix(harpoon): typo in concatenation

### DIFF
--- a/lua/astrocommunity/motion/harpoon/init.lua
+++ b/lua/astrocommunity/motion/harpoon/init.lua
@@ -1,6 +1,6 @@
 local prefix = "<leader><leader>"
 local running_tmux_session = vim.fn.exists "$TMUX" == 1
-local dynamic_tmux_keymap_desc = "Go to " .. running_tmux_session and "TMUX" or "terminal" .. " window"
+local dynamic_tmux_keymap_desc = "Go to " .. (running_tmux_session and "TMUX" or "terminal") .. " window"
 local icon = vim.g.icons_enabled and "󱡀 " or ""
 return {
   "ThePrimeagen/harpoon",


### PR DESCRIPTION
Hello, after the changes in #292 it started to fail with:
``` attempt to concatenate local 'running_tmux_session' (a boolean value)```

This PR should fix the issue.
