### PR TITLE
feat: add astro filetype to eslint_d handler in typescript pack

### DIFF
--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -87,9 +87,15 @@ return {
 
       opts.handlers.eslint_d = function()
         local null_ls = require "null-ls"
-        null_ls.register(null_ls.builtins.diagnostics.eslint_d.with { condition = has_eslint })
-        null_ls.register(null_ls.builtins.formatting.eslint_d.with { condition = has_eslint })
-        null_ls.register(null_ls.builtins.code_actions.eslint_d.with { condition = has_eslint })
+        null_ls.register(
+          null_ls.builtins.diagnostics.eslint_d.with { condition = has_eslint, extra_filetypes = "astro" }
+        )
+        null_ls.register(
+          null_ls.builtins.formatting.eslint_d.with { condition = has_eslint, extra_filetypes = "astro" }
+        )
+        null_ls.register(
+          null_ls.builtins.code_actions.eslint_d.with { condition = has_eslint, extra_filetypes = "astro" }
+        )
       end
     end,
   },


### PR DESCRIPTION
According to [this](https://github.com/jose-elias-alvarez/null-ls.nvim/issues/1552) null-ls issue, [Astro.build](https://astro.build/) filetypes needs to be added as `extra_filetypes`.

I thought it made sense to add it in the typescript pack since you'll be writing js/ts with Astro anyway.

The `astro-language-server` uses Prettier [under the hood](https://github.com/withastro/language-tools/tree/main/packages/language-server) so it doesn't have to be added to the `prettierd` handler.

