### PR TITLE
fix(ultimate-autopair-nvim): update ultimate-autopair.nvim

### DIFF
--- a/lua/astrocommunity/editing-support/ultimate-autopair-nvim/README.md
+++ b/lua/astrocommunity/editing-support/ultimate-autopair-nvim/README.md
@@ -4,4 +4,4 @@
 
 - Replace nvim-autopairs with ultimate-autopair.nvim.
 - Setup rule to automatically disable pairing while editing comments.
-- Add `<leader>ua` keymap to toggle the plugin off and on.
+- Maintain `<leader>ua` UI toggle keymap and notification previously used for nvim-autopair.

--- a/lua/astrocommunity/editing-support/ultimate-autopair-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/ultimate-autopair-nvim/init.lua
@@ -7,6 +7,7 @@ return {
     "altermo/ultimate-autopair.nvim",
     event = "InsertEnter",
     opts = {
+      -- disable autopair in the command line: https://github.com/altermo/ultimate-autopair.nvim/issues/8
       cmap = false,
       extensions = {
         rules = {
@@ -25,18 +26,31 @@ return {
             },
           },
         },
-        -- get fly mode working on strings: https://github.com/altermo/ultimate-autopair.nvim/issues/17
+        -- get fly mode working on strings: https://github.com/altermo/ultimate-autopair.nvim/issues/33
         fly = {
           nofilter = true,
         },
       },
-      { '"', '"', fly = true, p = 11 },
-      { "'", "'", fly = true, p = 11 },
+      config_internal_pairs = {
+        { '"', '"', fly = true },
+        { "'", "'", fly = true },
+      },
     },
     keys = {
       {
         "<leader>ua",
-        function() require("ultimate-autopair").toggle() end,
+        function()
+          local notify = require("astronvim.utils").notify
+          local function bool2str(bool) return bool and "on" or "off" end
+          local ok, ultimate_autopair = pcall(require, "ultimate-autopair")
+          if ok then
+            ultimate_autopair.toggle()
+            vim.g.ultimate_autopair_enabled = require("ultimate-autopair.core").disable
+            notify(string.format("ultimate-autopair %s", bool2str(not vim.g.ultimate_autopair_enabled)))
+          else
+            notify "ultimate-autopair not available"
+          end
+        end,
         desc = "Toggle ultimate-autopair",
       },
     },


### PR DESCRIPTION
Update suggested fly-mode config and maintain notification behavior from nvim-autopairs