### PR TITLE
fix(clojure): add space after clojure comment character

### DIFF
--- a/lua/astrocommunity/pack/clojure/init.lua
+++ b/lua/astrocommunity/pack/clojure/init.lua
@@ -35,7 +35,7 @@ return {
       vim.g["conjure#log#hud#anchor"] = "SE"
       vim.g["conjure#log#botright"] = true
       vim.g["conjure#extract#context_header_lines"] = 100
-      vim.g["conjure#eval#comment_prefix"] = ";;"
+      vim.g["conjure#eval#comment_prefix"] = ";; "
       vim.g["conjure#client#clojure#nrepl#connection#auto_repl#enabled"] = false
       vim.g["conjure#client#clojure#nrepl#connection#auto_repl#hidden"] = true
       vim.g["conjure#client#clojure#nrepl#connection#auto_repl#cmd"] = nil


### PR DESCRIPTION
Add comment between `;;` comment characters for clojure and text being commented