### PR TITLE
fix(ccc-nvim): ccc.nvim can not show colors from neo-tree `o`.

### DIFF
--- a/lua/astrocommunity/color/ccc-nvim/init.lua
+++ b/lua/astrocommunity/color/ccc-nvim/init.lua
@@ -2,7 +2,7 @@ return {
   { "NvChad/nvim-colorizer.lua", enabled = false },
   {
     "uga-rosa/ccc.nvim",
-    event = "User AstroFile",
+    event = "BufEnter",
     keys = {
       { "<leader>uC", "<cmd>CccPick<cr>", desc = "Toggle colorizer" },
       { "<leader>zc", "<cmd>CccConvert<cr>", desc = "Convert color" },


### PR DESCRIPTION
change event 'User AstroFile' to 'BufEnter' for open ccc.nvim.