### PR TITLE
docs(ruby): Remove mentions of html and ruby_ls from docs.

### DIFF
--- a/lua/astrocommunity/pack/ruby/README.md
+++ b/lua/astrocommunity/pack/ruby/README.md
@@ -3,8 +3,6 @@
 This plugin does the following
 
 - Adds 'ruby' treesitter parser
-- Adds 'html' treesitter parser
 - Adds 'solargraph' language server
-- Adds 'ruby_ls' language server
 - Adds 'standardrb' through null-ls
 - Adds 'nvim-dap-ruby'


### PR DESCRIPTION
The [Ruby pack](https://github.com/AstroNvim/astrocommunity/blob/main/lua/astrocommunity/pack/ruby/init.lua) does not install `html` or `ruby_ls`.