### PR TITLE
fix(python): added debugpy path auto-resolution using mason-registry

### DIFF
--- a/lua/astrocommunity/pack/python/init.lua
+++ b/lua/astrocommunity/pack/python/init.lua
@@ -33,6 +33,9 @@ return {
     -- NOTE: ft: lazy-load on filetype
     ft = "python",
     event = "User AstroFile",
-    config = function() require("dap-python").setup("python", {}) end,
+    config = function()
+      local path = require("mason-registry").get_package("debugpy"):get_install_path() .. "/venv/bin/python"
+      require("dap-python").setup(path, {})
+    end,
   },
 }

--- a/lua/astrocommunity/pack/python/init.lua
+++ b/lua/astrocommunity/pack/python/init.lua
@@ -33,9 +33,9 @@ return {
     -- NOTE: ft: lazy-load on filetype
     ft = "python",
     event = "User AstroFile",
-    config = function()
+    config = function(_, opts)
       local path = require("mason-registry").get_package("debugpy"):get_install_path() .. "/venv/bin/python"
-      require("dap-python").setup(path, {})
+      require("dap-python").setup(path, opts)
     end,
   },
 }


### PR DESCRIPTION
Mason installs debugpy in a venv in $HOME/.local/share/$NVIM_APPNAME/mason/packages/debugpy/ .
This fixes a bug where DAP would not find debugpy (ModuleNotFoundError : no module named "debugpy") and would not start debugging.
The replaced code would only work if you just installed debugpy or running :DapInstall python and use DAP without exiting nvim, or if you had debugpy installed system-wide (via pip) and not using a venv. It would fail upon new nvim runs.