### PR TITLE
fix(lua): disable formatting from `lua_ls` by default

### DIFF
--- a/lua/astrocommunity/pack/lua/init.lua
+++ b/lua/astrocommunity/pack/lua/init.lua
@@ -10,7 +10,13 @@ return {
   },
   {
     "williamboman/mason-lspconfig.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "lua_ls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "lua_ls")
+
+      -- Disable formatting from lua_ls
+      local formatting = require("astronvim.utils.lsp").formatting
+      formatting.disabled = utils.list_insert_unique(formatting.disabled, "lua_ls")
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",


### PR DESCRIPTION
This is a bit hacky, but I think this should work in disabling `lua_ls` formatting and just use `stylua`