### PR TITLE
fix(harpoon): Make which-key entry color blue, as it should be

### DIFF
--- a/lua/astrocommunity/motion/harpoon/init.lua
+++ b/lua/astrocommunity/motion/harpoon/init.lua
@@ -1,5 +1,9 @@
 local prefix = "<leader><leader>"
 local term_string = vim.fn.exists "$TMUX" == 1 and "tmux" or "terminal"
+local maps = { n = {} }
+local icon = vim.g.icons_enabled and "󱡀 " or ""
+maps.n[prefix] = { desc = icon .. "Harpoon" }
+require("astronvim.utils").set_mappings(maps)
 return {
   "ThePrimeagen/harpoon",
   dependencies = {
@@ -8,7 +12,6 @@ return {
   },
   cmd = { "Harpoon" },
   keys = {
-    { prefix, function() end, desc = (vim.g.icons_enabled and "󱡀 " or "") .. "Harpoon" },
     { prefix .. "a", function() require("harpoon.mark").add_file() end, desc = "Add file" },
     { prefix .. "e", function() require("harpoon.ui").toggle_quick_menu() end, desc = "Toggle quick menu" },
     {


### PR DESCRIPTION
I believe the Harpoon entry in which-key should be blue because it is a nested keymap,  unfortunately when using `keys` it doesn't get highlighted properly, this pr fixes it.

**Before:**
<img width="257" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/67468725/bff57de2-b529-49ec-b5d3-4a7b95abfee8">

**After:**
<img width="267" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/67468725/ec41a699-e938-4958-a810-9327b0bebf16">
