### PR TITLE
feat(debugging): add telescope dap extension

### DIFF
--- a/lua/astrocommunity/debugging/telescope-dap-nvim/README.md
+++ b/lua/astrocommunity/debugging/telescope-dap-nvim/README.md
@@ -1,0 +1,8 @@
+# telescope-dap.nvim
+
+Integration for `nvim-dap` with `telescope.nvim`.
+
+This plugin is also overriding `dap` internal `ui`, so running any `dap` command, which makes use of the internal ui, will result in a `telescope` prompt.
+
+**Repository:** <https://github.com/nvim-telescope/telescope-dap.nvim>
+

--- a/lua/astrocommunity/debugging/telescope-dap-nvim/init.lua
+++ b/lua/astrocommunity/debugging/telescope-dap-nvim/init.lua
@@ -2,7 +2,7 @@ return {
   {
     "nvim-telescope/telescope-dap.nvim",
     name = "telescope_dap",
-    event = "VeryLazy",
+    event = "User AstroFile",
     keys = {
       {
         "<leader>fdc",

--- a/lua/astrocommunity/debugging/telescope-dap-nvim/init.lua
+++ b/lua/astrocommunity/debugging/telescope-dap-nvim/init.lua
@@ -1,3 +1,5 @@
+local prefix = "<leader>fd"
+
 return {
   {
     "nvim-telescope/telescope-dap.nvim",
@@ -5,7 +7,7 @@ return {
     event = "User AstroFile",
     keys = {
       {
-        "<leader>fdc",
+        prefix .. "c",
         "<Cmd>lua require('telescope').extensions.dap.commands{}<CR>",
         { silent = true, expr = false },
         mode = {
@@ -14,7 +16,7 @@ return {
         desc = "Telescope DAP commands",
       },
       {
-        "<leader>fdg",
+        prefix .. "g",
         "<Cmd>lua require('telescope').extensions.dap.configurations{}<CR>",
         { silent = true, expr = false },
         mode = {
@@ -23,7 +25,7 @@ return {
         desc = "Telescope DAP configurations",
       },
       {
-        "<leader>fdl",
+        prefix .. "l",
         "<Cmd>lua require('telescope').extensions.dap.list_breakpoints{}<CR>",
         { silent = true, expr = false },
         mode = {
@@ -32,7 +34,7 @@ return {
         desc = "Telescope DAP list breakpoints",
       },
       {
-        "<leader>fdv",
+        prefix .. "v",
         "<Cmd>lua require('telescope').extensions.dap.variables{}<CR>",
         { silent = true, expr = false },
         mode = {
@@ -41,7 +43,7 @@ return {
         desc = "Telescope DAP variables",
       },
       {
-        "<leader>fdf",
+        prefix .. "f",
         "<Cmd>lua require('telescope').extensions.dap.frames{}<CR>",
         { silent = true, expr = false },
         mode = {

--- a/lua/astrocommunity/debugging/telescope-dap-nvim/init.lua
+++ b/lua/astrocommunity/debugging/telescope-dap-nvim/init.lua
@@ -1,0 +1,60 @@
+return {
+  {
+    "nvim-telescope/telescope-dap.nvim",
+    name = "telescope_dap",
+    event = "VeryLazy",
+    keys = {
+      {
+        "<leader>fdc",
+        "<Cmd>lua require('telescope').extensions.dap.commands{}<CR>",
+        { silent = true, expr = false },
+        mode = {
+          "n",
+        },
+        desc = "Telescope DAP commands",
+      },
+      {
+        "<leader>fdg",
+        "<Cmd>lua require('telescope').extensions.dap.configurations{}<CR>",
+        { silent = true, expr = false },
+        mode = {
+          "n",
+        },
+        desc = "Telescope DAP configurations",
+      },
+      {
+        "<leader>fdl",
+        "<Cmd>lua require('telescope').extensions.dap.list_breakpoints{}<CR>",
+        { silent = true, expr = false },
+        mode = {
+          "n",
+        },
+        desc = "Telescope DAP list breakpoints",
+      },
+      {
+        "<leader>fdv",
+        "<Cmd>lua require('telescope').extensions.dap.variables{}<CR>",
+        { silent = true, expr = false },
+        mode = {
+          "n",
+        },
+        desc = "Telescope DAP variables",
+      },
+      {
+        "<leader>fdf",
+        "<Cmd>lua require('telescope').extensions.dap.frames{}<CR>",
+        { silent = true, expr = false },
+        mode = {
+          "n",
+        },
+        desc = "Telescope DAP frames",
+      },
+    },
+  },
+  {
+    "nvim-telescope/telescope.nvim",
+    optional = true,
+    dependencies = { "telescope_dap" },
+    opts = function() require("telescope").load_extension "dap" end,
+  },
+}


### PR DESCRIPTION
This plugin is also overriding dap internal ui, so running any dap command, which makes use of the internal ui, will result in a telescope prompt.