### PR TITLE
fix(obsidian-nvim): added obsidian.nvim config and changed the readme

### DIFF
--- a/lua/astrocommunity/note-taking/obsidian-nvim/README.md
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/README.md
@@ -5,3 +5,16 @@ Neovim plugin for Obsidian, written in Lua
 **Repository:** <https://github.com/epwalsh/obsidian.nvim>
 
 A Neovim plugin for writing and navigating an [Obsidian](https://obsidian.md) vault, written in Lua.
+
+This config assumes the vault location is at `~/obsidian-vault`. You can move the vault there. If you instead want to change the location in the config, you can create a new file `plugins/obsidian.lua`, copy the contents of this `init.lua` to it, and then edit the 2 following lines
+
+`event = { "BufReadPre  */obsidian-vault/*.md" },`
+
+and
+
+`dir = "~/obsidian-vault",`
+
+to match your vault location. 
+
+
+The plugin may also nag and ask you to create a `templates` directory in the vault. You can use `mkdir templates` to create an empty directory.

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -27,7 +27,7 @@ return {
     -- "preservim/vim-markdown",
   },
   opts = {
-    dir = "~/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
+    dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
 
     -- -- Optional, if you keep notes in a specific subdirectory of your vault.
     -- notes_subdir = "notes",

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -1,17 +1,125 @@
 return {
   "epwalsh/obsidian.nvim",
-  cmd = {
-    "ObsdianBacklinks",
-    "ObsidianToday",
-    "ObsidianYesterday",
-    "ObsidianOpen",
-    "ObsidianNew",
-    "ObsidianSearch",
-    "ObsidianQuickSwitch",
-    "ObsidianLink",
-    "ObsidianLinkNew",
-    "ObsidianFollowLink",
-    "ObsidianTemplate",
+  lazy = true,
+  -- the obsidian vault in this default config  ~/obsidian-vault
+  event = { "BufReadPre  */obsidian-vault/*.md" },
+  -- If you want to use the home shortcut '~' here you need to call 'vim.fn.expand':
+  -- event = { "bufreadpre " .. vim.fn.expand "~" .. "/my-vault/**.md" },
+  dependencies = {
+    -- Required.
+    "nvim-lua/plenary.nvim",
+
+    -- Optional, for completion.
+    "hrsh7th/nvim-cmp",
+
+    -- Optional, for search and quick-switch functionality.
+    "nvim-telescope/telescope.nvim",
+
+    -- Optional, an alternative to telescope for search and quick-switch functionality.
+    -- "ibhagwan/fzf-lua"
+
+    -- Optional, another alternative to telescope for search and quick-switch functionality.
+    -- "junegunn/fzf",
+    -- "junegunn/fzf.vim"
+
+    -- Optional, alternative to nvim-treesitter for syntax highlighting.
+    -- "godlygeek/tabular",
+    -- "preservim/vim-markdown",
   },
-  opts = { completion = { nvim_cmp = true } },
+  opts = {
+    dir = "~/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
+
+    -- -- Optional, if you keep notes in a specific subdirectory of your vault.
+    -- notes_subdir = "notes",
+    --
+    -- daily_notes = {
+    --   -- Optional, if you keep daily notes in a separate directory.
+    --   folder = "notes/dailies",
+    --   -- Optional, if you want to change the date format for daily notes.
+    --   date_format = "%Y-%m-%d"
+    -- },
+
+    -- Optional, completion.
+    completion = {
+      nvim_cmp = true, -- if using nvim-cmp, otherwise set to false
+    },
+
+    -- -- Optional, customize how names/IDs for new notes are created.
+    -- note_id_func = function(title)
+    --   -- Create note IDs in a Zettelkasten format with a timestamp and a suffix.
+    --   -- In this case a note with the title 'My new note' will given an ID that looks
+    --   -- like '1657296016-my-new-note', and therefore the file name '1657296016-my-new-note.md'
+    --   local suffix = ""
+    --   if title ~= nil then
+    --     -- If title is given, transform it into valid file name.
+    --     suffix = title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower()
+    --   else
+    --     -- If title is nil, just add 4 random uppercase letters to the suffix.
+    --     for _ = 1, 4 do
+    --       suffix = suffix .. string.char(math.random(65, 90))
+    --     end
+    --   end
+    --   return tostring(os.time()) .. "-" .. suffix
+    -- end,
+
+    -- Optional, set to true if you don't want Obsidian to manage frontmatter.
+    disable_frontmatter = false,
+
+    -- Optional, alternatively you can customize the frontmatter data.
+    note_frontmatter_func = function(note)
+      -- This is equivalent to the default frontmatter function.
+      local out = { id = note.id, aliases = note.aliases, tags = note.tags }
+      -- `note.metadata` contains any manually added fields in the frontmatter.
+      -- So here we just make sure those fields are kept in the frontmatter.
+      if note.metadata ~= nil and require("obsidian").util.table_length(note.metadata) > 0 then
+        for k, v in pairs(note.metadata) do
+          out[k] = v
+        end
+      end
+      return out
+    end,
+
+    -- Optional, for templates (see below).
+    templates = {
+      subdir = "templates",
+      date_format = "%Y-%m-%d-%a",
+      time_format = "%H:%M",
+    },
+
+    -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
+    -- URL it will be ignored but you can customize this behavior here.
+    follow_url_func = function(url)
+      -- Open the URL in the default web browser.
+      vim.fn.jobstart({ "open", url }) -- Mac OS
+      -- vim.fn.jobstart({"xdg-open", url})  -- linux
+    end,
+
+    -- Optional, set to true if you use the Obsidian Advanced URI plugin.
+    -- https://github.com/Vinzent03/obsidian-advanced-uri
+    use_advanced_uri = true,
+
+    -- Optional, set to true to force ':ObsidianOpen' to bring the app to the foreground.
+    open_app_foreground = false,
+
+    -- Optional, by default commands like `:ObsidianSearch` will attempt to use
+    -- telescope.nvim, fzf-lua, and fzf.nvim (in that order), and use the
+    -- first one they find. By setting this option to your preferred
+    -- finder you can attempt it first. Note that if the specified finder
+    -- is not installed, or if it the command does not support it, the
+    -- remaining finders will be attempted in the original order.
+    finder = "telescope.nvim",
+  },
+  config = function(_, opts)
+    require("obsidian").setup(opts)
+
+    -- Optional, override the 'gf' keymap to utilize Obsidian's search functionality.
+    -- see also: 'follow_url_func' config option above.
+    vim.keymap.set("n", "gf", function()
+      if require("obsidian").util.cursor_on_markdown_link() then
+        return "<cmd>ObsidianFollowLink<CR>"
+      else
+        return "gf"
+      end
+    end, { noremap = false, expr = true })
+  end,
 }

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -56,6 +56,9 @@ return {
         vim.fn.jobstart { "open", url }
       elseif this_os == "Linux" then
         vim.fn.jobstart { "xdg-open", url }
+     elseif this_os == "Windows" then
+     vim.fn.jobstart { "explorer", url }
+     
       end
     end,
   },

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -25,10 +25,7 @@ return {
   },
   opts = {
     dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
-    completion = { nvim_cmp = true },
-    disable_frontmatter = false,
     use_advanced_uri = true,
-    open_app_foreground = false,
     finder = "telescope.nvim",
 
     templates = {

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -5,17 +5,18 @@ return {
   -- event = { "bufreadpre " .. vim.fn.expand "~" .. "/my-vault/**.md" },
   event = { "BufReadPre  */obsidian-vault/*.md" },
   keys = {
-    "gf",
-    function()
-      if require("obsidian").util.cursor_on_markdown_link() then
-        return "<cmd>ObsidianFollowLink<CR>"
-      else
-        return "gf"
-      end
-    end,
-    desc = "Obsidian Follow Link",
-    noremap = false,
-    expr = true,
+    {
+      "gf",
+      function()
+        if require("obsidian").util.cursor_on_markdown_link() then
+          return "<cmd>ObsidianFollowLink<CR>"
+        else
+          return "gf"
+        end
+      end,
+      noremap = false,
+      expr = true,
+    },
   },
   dependencies = {
     "nvim-lua/plenary.nvim",

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -58,7 +58,6 @@ return {
         vim.fn.jobstart { "xdg-open", url }
      elseif this_os == "Windows" then
      vim.fn.jobstart { "explorer", url }
-     
       end
     end,
   },

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -23,21 +23,21 @@ return {
     "hrsh7th/nvim-cmp",
     "nvim-telescope/telescope.nvim",
   },
-  opts = function(_, opts)
-    opts.dir = vim.env.HOME .. "/obsidian-vault" -- specify the vault location. no need to call 'vim.fn.expand' here
-    opts.completion = { nvim_cmp = true }
-    opts.disable_frontmatter = false
-    opts.use_advanced_uri = true
-    opts.open_app_foreground = false
-    opts.finder = "telescope.nvim"
+  opts = {
+    dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
+    completion = { nvim_cmp = true },
+    disable_frontmatter = false,
+    use_advanced_uri = true,
+    open_app_foreground = false,
+    finder = "telescope.nvim",
 
-    opts.templates = {
+    templates = {
       subdir = "templates",
       date_format = "%Y-%m-%d-%a",
       time_format = "%H:%M",
-    }
+    },
 
-    opts.note_frontmatter_func = function(note)
+    note_frontmatter_func = function(note)
       -- This is equivalent to the default frontmatter function.
       local out = { id = note.id, aliases = note.aliases, tags = note.tags }
       -- `note.metadata` contains any manually added fields in the frontmatter.
@@ -48,11 +48,11 @@ return {
         end
       end
       return out
-    end
+    end,
 
     -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
     -- URL it will be ignored but you can customize this behavior here.
-    opts.follow_url_func = function(url)
+    follow_url_func = function(url)
       local this_os = vim.loop.os_uname().sysname
       -- Open the URL in the default web browser.
       if this_os == "Darwin" then
@@ -60,6 +60,6 @@ return {
       elseif this_os == "Linux" then
         vim.fn.jobstart { "xdg-open", url }
       end
-    end
-  end,
+    end,
+  },
 }

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -49,16 +49,6 @@ return {
 
     -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
     -- URL it will be ignored but you can customize this behavior here.
-    follow_url_func = function(url)
-      local this_os = vim.loop.os_uname().sysname
-      -- Open the URL in the default web browser.
-      if this_os == "Darwin" then
-        vim.fn.jobstart { "open", url }
-      elseif this_os == "Linux" then
-        vim.fn.jobstart { "xdg-open", url }
-     elseif this_os == "Windows" then
-     vim.fn.jobstart { "explorer", url }
-      end
-    end,
+    follow_url_func = vim.ui.open or require("astronvim.utils").system_open,
   },
 }

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -1,72 +1,42 @@
 return {
   "epwalsh/obsidian.nvim",
-  lazy = true,
   -- the obsidian vault in this default config  ~/obsidian-vault
-  event = { "BufReadPre  */obsidian-vault/*.md" },
   -- If you want to use the home shortcut '~' here you need to call 'vim.fn.expand':
   -- event = { "bufreadpre " .. vim.fn.expand "~" .. "/my-vault/**.md" },
-  dependencies = {
-    -- Required.
-    "nvim-lua/plenary.nvim",
-
-    -- Optional, for completion.
-    "hrsh7th/nvim-cmp",
-
-    -- Optional, for search and quick-switch functionality.
-    "nvim-telescope/telescope.nvim",
-
-    -- Optional, an alternative to telescope for search and quick-switch functionality.
-    -- "ibhagwan/fzf-lua"
-
-    -- Optional, another alternative to telescope for search and quick-switch functionality.
-    -- "junegunn/fzf",
-    -- "junegunn/fzf.vim"
-
-    -- Optional, alternative to nvim-treesitter for syntax highlighting.
-    -- "godlygeek/tabular",
-    -- "preservim/vim-markdown",
+  event = { "BufReadPre  */obsidian-vault/*.md" },
+  keys = {
+    "gf",
+    function()
+      if require("obsidian").util.cursor_on_markdown_link() then
+        return "<cmd>ObsidianFollowLink<CR>"
+      else
+        return "gf"
+      end
+    end,
+    desc = "Obsidian Follow Link",
+    noremap = false,
+    expr = true,
   },
-  opts = {
-    dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "hrsh7th/nvim-cmp",
+    "nvim-telescope/telescope.nvim",
+  },
+  opts = function(_, opts)
+    opts.dir = vim.env.HOME .. "/obsidian-vault" -- specify the vault location. no need to call 'vim.fn.expand' here
+    opts.completion = { nvim_cmp = true }
+    opts.disable_frontmatter = false
+    opts.use_advanced_uri = true
+    opts.open_app_foreground = false
+    opts.finder = "telescope.nvim"
 
-    -- -- Optional, if you keep notes in a specific subdirectory of your vault.
-    -- notes_subdir = "notes",
-    --
-    -- daily_notes = {
-    --   -- Optional, if you keep daily notes in a separate directory.
-    --   folder = "notes/dailies",
-    --   -- Optional, if you want to change the date format for daily notes.
-    --   date_format = "%Y-%m-%d"
-    -- },
+    opts.templates = {
+      subdir = "templates",
+      date_format = "%Y-%m-%d-%a",
+      time_format = "%H:%M",
+    }
 
-    -- Optional, completion.
-    completion = {
-      nvim_cmp = true, -- if using nvim-cmp, otherwise set to false
-    },
-
-    -- -- Optional, customize how names/IDs for new notes are created.
-    -- note_id_func = function(title)
-    --   -- Create note IDs in a Zettelkasten format with a timestamp and a suffix.
-    --   -- In this case a note with the title 'My new note' will given an ID that looks
-    --   -- like '1657296016-my-new-note', and therefore the file name '1657296016-my-new-note.md'
-    --   local suffix = ""
-    --   if title ~= nil then
-    --     -- If title is given, transform it into valid file name.
-    --     suffix = title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower()
-    --   else
-    --     -- If title is nil, just add 4 random uppercase letters to the suffix.
-    --     for _ = 1, 4 do
-    --       suffix = suffix .. string.char(math.random(65, 90))
-    --     end
-    --   end
-    --   return tostring(os.time()) .. "-" .. suffix
-    -- end,
-
-    -- Optional, set to true if you don't want Obsidian to manage frontmatter.
-    disable_frontmatter = false,
-
-    -- Optional, alternatively you can customize the frontmatter data.
-    note_frontmatter_func = function(note)
+    opts.note_frontmatter_func = function(note)
       -- This is equivalent to the default frontmatter function.
       local out = { id = note.id, aliases = note.aliases, tags = note.tags }
       -- `note.metadata` contains any manually added fields in the frontmatter.
@@ -77,49 +47,18 @@ return {
         end
       end
       return out
-    end,
-
-    -- Optional, for templates (see below).
-    templates = {
-      subdir = "templates",
-      date_format = "%Y-%m-%d-%a",
-      time_format = "%H:%M",
-    },
+    end
 
     -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
     -- URL it will be ignored but you can customize this behavior here.
-    follow_url_func = function(url)
+    opts.follow_url_func = function(url)
+      local this_os = vim.loop.os_uname().sysname
       -- Open the URL in the default web browser.
-      vim.fn.jobstart({ "open", url }) -- Mac OS
-      -- vim.fn.jobstart({"xdg-open", url})  -- linux
-    end,
-
-    -- Optional, set to true if you use the Obsidian Advanced URI plugin.
-    -- https://github.com/Vinzent03/obsidian-advanced-uri
-    use_advanced_uri = true,
-
-    -- Optional, set to true to force ':ObsidianOpen' to bring the app to the foreground.
-    open_app_foreground = false,
-
-    -- Optional, by default commands like `:ObsidianSearch` will attempt to use
-    -- telescope.nvim, fzf-lua, and fzf.nvim (in that order), and use the
-    -- first one they find. By setting this option to your preferred
-    -- finder you can attempt it first. Note that if the specified finder
-    -- is not installed, or if it the command does not support it, the
-    -- remaining finders will be attempted in the original order.
-    finder = "telescope.nvim",
-  },
-  config = function(_, opts)
-    require("obsidian").setup(opts)
-
-    -- Optional, override the 'gf' keymap to utilize Obsidian's search functionality.
-    -- see also: 'follow_url_func' config option above.
-    vim.keymap.set("n", "gf", function()
-      if require("obsidian").util.cursor_on_markdown_link() then
-        return "<cmd>ObsidianFollowLink<CR>"
-      else
-        return "gf"
+      if this_os == "Darwin" then
+        vim.fn.jobstart { "open", url }
+      elseif this_os == "Linux" then
+        vim.fn.jobstart { "xdg-open", url }
       end
-    end, { noremap = false, expr = true })
+    end
   end,
 }


### PR DESCRIPTION
As requested from #309. We need this config to follow links to other markdown files. Please check if anything is amiss. 

Edit: I see the review checklist asks for "Proper usage of `opts` table rather than setting things up with the `config` function." I'm not sure if that is satisfied here.