### PR TITLE
feat(debugging): add nvim-dap-virtual-text

### DIFF
--- a/lua/astrocommunity/debugging/nvim-dap-virtual-text/README.md
+++ b/lua/astrocommunity/debugging/nvim-dap-virtual-text/README.md
@@ -1,0 +1,7 @@
+# nvim-dap-virtual-text
+
+This plugin adds virtual text support to `nvim-dap`. `nvim-treesitter` is used to find variable definitions.
+
+**Repository:** <https://github.com/theHamsta/nvim-dap-virtual-text>
+
+The `hlgroup` for the virtual text is `NvimDapVirtualText` (linked to Comment). Exceptions that caused the debugger to stop are displayed as `NvimDapVirtualTextError` (linked to `DiagnosticVirtualTextError`). Changed and new variables will be highlighted with `NvimDapVirtualTextChanged` (default linked to `DiagnosticVirtualTextWarn`).

--- a/lua/astrocommunity/debugging/nvim-dap-virtual-text/init.lua
+++ b/lua/astrocommunity/debugging/nvim-dap-virtual-text/init.lua
@@ -1,0 +1,10 @@
+return {
+  "theHamsta/nvim-dap-virtual-text",
+  dependencies = { "mfussenegger/nvim-dap", "nvim-treesitter/nvim-treesitter" },
+  event = "User AstroFile",
+  opts = {
+    commented = true,
+    enabled = true,
+    enabled_commands = true,
+  },
+}


### PR DESCRIPTION
This plugin adds virtual text support to `nvim-dap`. `nvim-treesitter` is used to find variable definitions.