### PR TITLE
fix(nvim-hlslens): add lazy event

### DIFF
--- a/lua/astrocommunity/search/nvim-hlslens/init.lua
+++ b/lua/astrocommunity/search/nvim-hlslens/init.lua
@@ -1,5 +1,6 @@
 return {
   "kevinhwang91/nvim-hlslens",
   opts = {},
+  event = "BufRead",
   init = function() vim.on_key(nil, vim.api.nvim_get_namespaces()["auto_hlsearch"]) end,
 }


### PR DESCRIPTION
Adds a lazy event to hlslens, since plugin is not loaded when searching buffer.