### PR TITLE
feat(lsp_lines-nvim): disable virtual text and add `<leader>uD` mapping

### DIFF
--- a/lua/astrocommunity/diagnostics/lsp_lines-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/lsp_lines-nvim/init.lua
@@ -1,6 +1,17 @@
 return {
   "https://git.sr.ht/~whynothugo/lsp_lines.nvim",
   event = "LspAttach",
+  keys = {
+    {
+      "<Leader>uD",
+      function()
+        vim.diagnostic.config {
+          virtual_text = not require("lsp_lines").toggle(),
+        }
+      end,
+      desc = "Toggle virtual diagnostic lines",
+    },
+  },
   init = function() require("astronvim.utils.ui").toggle_diagnostics() end,
   opts = {},
 }

--- a/lua/astrocommunity/diagnostics/lsp_lines-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/lsp_lines-nvim/init.lua
@@ -12,6 +12,12 @@ return {
       desc = "Toggle virtual diagnostic lines",
     },
   },
-  init = function() require("astronvim.utils.ui").toggle_diagnostics() end,
   opts = {},
+  config = function(_, opts)
+    -- disable diagnostic virtual text
+    local lsp_utils = require "astronvim.utils.lsp"
+    lsp_utils.diagnostics[3].virtual_text = false
+    vim.diagnostic.config(lsp_utils.diagnostics[vim.g.diagnostics_mode])
+    require("lsp_lines").setup(opts)
+  end,
 }

--- a/lua/astrocommunity/diagnostics/lsp_lines-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/lsp_lines-nvim/init.lua
@@ -1,1 +1,6 @@
-return { "https://git.sr.ht/~whynothugo/lsp_lines.nvim", event = "LspAttach", opts = {} }
+return {
+  "https://git.sr.ht/~whynothugo/lsp_lines.nvim",
+  event = "LspAttach",
+  init = function() require("astronvim.utils.ui").toggle_diagnostics() end,
+  opts = {},
+}


### PR DESCRIPTION
I wish I could have implemented the fix and the keybinds better.
`virtual_text` should be off when using `lsp_lines.nvim`