### PR TITLE
fix(nvim-spectre): Make which-key entry color blue

### DIFF
--- a/lua/astrocommunity/project/nvim-spectre/init.lua
+++ b/lua/astrocommunity/project/nvim-spectre/init.lua
@@ -1,10 +1,17 @@
 local prefix = "<leader>s"
+local maps = { n = {}, x = {} }
+
+local icon = vim.g.icons_enabled and "󰛔 " or ""
+maps.n[prefix] = { desc = icon .. "Search / Replace" }
+maps.x[prefix] = { desc = icon .. "Search / Replace" }
+
+require("astronvim.utils").set_mappings(maps)
+
 return {
   {
     "nvim-pack/nvim-spectre",
     cmd = "Spectre",
     keys = {
-      { prefix, desc = "Search / Replace", mode = { "n", "x" } },
       { prefix .. "s", function() require("spectre").toggle() end, desc = "Toggle Spectre" },
       {
         prefix .. "w",


### PR DESCRIPTION
I believe the Spectre entry in which-key should be blue because it is a nested keymap, unfortunately when using keys it doesn't get highlighted properly, this pr fixes it.