### PR TITLE
feat(grapple-nvim): change grapple icon from arrow to hook to distinguish from harpoon

### DIFF
--- a/lua/astrocommunity/motion/grapple-nvim/init.lua
+++ b/lua/astrocommunity/motion/grapple-nvim/init.lua
@@ -1,6 +1,6 @@
 local prefix = "<leader><leader>"
 local maps = { n = {} }
-local icon = vim.g.icons_enabled and "󱡀 " or ""
+local icon = vim.g.icons_enabled and "󰛢 " or ""
 maps.n[prefix] = { desc = icon .. "Grapple" }
 require("astronvim.utils").set_mappings(maps)
 return {


### PR DESCRIPTION
**Before**:
<img width="219" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/56745535/03c5923d-da9e-44f3-8708-da9082953304">
**After**:
<img width="226" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/56745535/468b3dd6-dbe5-45eb-8b22-1d6717ef3cae">

Definitely not opinionated or anything :)

