### PR TITLE
fix(octo-nvim): which-key description and color for nested entries

### DIFF
--- a/lua/astrocommunity/git/octo-nvim/init.lua
+++ b/lua/astrocommunity/git/octo-nvim/init.lua
@@ -1,4 +1,18 @@
 local prefix = "<leader>O"
+local maps = { n = {} }
+local icon = vim.g.icons_enabled and " " or ""
+maps.n[prefix] = { desc = icon .. "Octo" }
+maps.n[prefix .. "c"] = { desc = "Comments" }
+maps.n[prefix .. "t"] = { desc = "Threads" }
+maps.n[prefix .. "i"] = { desc = "Issues" }
+maps.n[prefix .. "p"] = { desc = "Pull requests" }
+maps.n[prefix .. "pm"] = { desc = "Merge current PR" }
+maps.n[prefix .. "r"] = { desc = "Repo" }
+maps.n[prefix .. "a"] = { desc = "Assignee/Reviewer" }
+maps.n[prefix .. "l"] = { desc = "Label" }
+maps.n[prefix .. "e"] = { desc = "Reaction" }
+maps.n[prefix .. "s"] = { desc = "Review" }
+require("astronvim.utils").set_mappings(maps)
 return {
   "pwntester/octo.nvim",
   dependencies = {
@@ -9,27 +23,22 @@ return {
   cmd = { "Octo" },
   opts = {
     use_diagnostic_signs = true,
+    mappings = {},
   },
   keys = {
-    { prefix, desc = "Octo" },
-    { prefix .. "c", desc = "Comments" },
     { prefix .. "ca", "<cmd>Octo comment add<CR>", desc = "Add a new comment" },
     { prefix .. "cd", "<cmd>Octo comment delete<CR>", desc = "Delete a comment" },
 
-    { prefix .. "t", desc = "Threads" },
     { prefix .. "ta", "<cmd>Octo thread resolve<CR>", desc = "Mark thread as resolved" },
     { prefix .. "td", "<cmd>Octo thread unresolve<CR>", desc = "Mark thread as unresolved" },
 
-    { prefix .. "i", desc = "Issues" },
     { prefix .. "ic", "<cmd>Octo issue close<CR>", desc = "Close current issue" },
     { prefix .. "ir", "<cmd>Octo issue reopen<CR>", desc = "Reopen current issue" },
     { prefix .. "il", "<cmd>Octo issue list<CR>", desc = "List open issues" },
     { prefix .. "iu", "<cmd>Octo issue url<CR>", desc = "Copies URL of current issue" },
     { prefix .. "io", "<cmd>Octo issue browser<CR>", desc = "Open current issue in browser" },
 
-    { prefix .. "p", desc = "Pull requests" },
     { prefix .. "pp", "<cmd>Octo pr checkout<CR>", desc = "Checkout PR" },
-    { prefix .. "pm", desc = "Merge current PR" },
     { prefix .. "pmm", "<cmd>Octo pr merge commit<CR>", desc = "Merge commit PR" },
     { prefix .. "pms", "<cmd>Octo pr merge squash<CR>", desc = "Squash merge PR" },
     { prefix .. "pmd", "<cmd>Octo pr merge delete<CR>", desc = "Delete merge PR" },
@@ -44,23 +53,19 @@ return {
     { prefix .. "pt", "<cmd>Octo pr commits<CR>", desc = "List PR commits" },
     { prefix .. "pl", "<cmd>Octo pr commits<CR>", desc = "List changed files in PR" },
 
-    { prefix .. "r", desc = "Repo" },
     { prefix .. "rl", "<cmd>Octo repo list<CR>", desc = "List repo user stats" },
     { prefix .. "rf", "<cmd>Octo repo fork<CR>", desc = "Fork repo" },
     { prefix .. "ro", "<cmd>Octo repo open<CR>", desc = "Open current repo in browser" },
     { prefix .. "ru", "<cmd>Octo repo url<CR>", desc = "Copies URL of current repo" },
 
-    { prefix .. "a", desc = "Assignee/Reviewer" },
     { prefix .. "aa", "<cmd> Octo assignee add<CR>", desc = "Assign a user" },
     { prefix .. "ar", "<cmd> Octo assignee remove<CR>", desc = "Remove a user" },
     { prefix .. "ap", "<cmd> Octo reviewer add<CR>", desc = "Assign a PR reviewer" },
 
-    { prefix .. "l", desc = "Label" },
     { prefix .. "la", "<cmd> Octo label add<CR>", desc = "Assign a label" },
     { prefix .. "lr", "<cmd> Octo label remove<CR>", desc = "Remove a label" },
     { prefix .. "lc", "<cmd> Octo label create<CR>", desc = "Create a label" },
 
-    { prefix .. "e", desc = "Reactions" },
     { prefix .. "e1", "<cmd>Octo reaction thumbs_up<CR>", desc = "Add 👍 reaction" },
     { prefix .. "e2", "<cmd>Octo reaction thumbs_down<CR>", desc = "Add 👎 reaction" },
     { prefix .. "e3", "<cmd>Octo reaction eyes<CR>", desc = "Add 👀 reaction" },
@@ -72,7 +77,6 @@ return {
 
     { prefix .. "x", "<cmd>Octo actions<CR>", desc = "Run an action" },
 
-    { prefix .. "s", desc = "Review" },
     { prefix .. "ss", "<cmd> Octo review start<CR>", desc = "Start review" },
     { prefix .. "sf", "<cmd> Octo review submit<CR>", desc = "Submit review" },
     { prefix .. "sr", "<cmd> Octo review resume<CR>", desc = "Submit resume" },


### PR DESCRIPTION
Yet another one of like #376 and what after it. Also, remove default `mappings` which the plugin sets, to avoid keymap mess