### PR TITLE
docs(catppuccin): replace ts-rainbow2 integration for catppuccin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ return {
         cmp = true,
         overseer = true,
         lsp_trouble = true,
-        ts_rainbow2 = true,
+        rainbow_delimiters = true,
       },
     },
   },


### PR DESCRIPTION
As ts-rainbow2 is deprecated in favor of rainbow-delimiters, this should also be reflected within our catppuccin integration example