### PR TITLE
fix(zen-mode-nvim): ensure winbar stays disabled and restore old mini.indentscope options

### DIFF
--- a/lua/astrocommunity/editing-support/zen-mode-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/zen-mode-nvim/init.lua
@@ -23,21 +23,32 @@ return {
     },
     on_open = function() -- disable diagnostics, indent blankline, and winbar
       vim.g.diagnostics_mode_old = vim.g.diagnostics_mode
-      vim.g.indent_blankline_enabled_old = vim.g.indent_blankline_enabled
-      vim.g.winbar_old = vim.wo.winbar
       vim.g.diagnostics_mode = 0
-      vim.g.indent_blankline_enabled = false
-      vim.b.miniindentscope_disable = true
-      vim.wo.winbar = nil
       vim.diagnostic.config(require("astronvim.utils.lsp").diagnostics[vim.g.diagnostics_mode])
+
+      vim.g.indent_blankline_enabled_old = vim.g.indent_blankline_enabled
+      vim.g.indent_blankline_enabled = false
+      vim.g.miniindentscope_disable_old = vim.g.miniindentscope_disable
+      vim.g.miniindentscope_disable = true
+
+      vim.g.winbar_old = vim.wo.winbar
+      vim.api.nvim_create_autocmd({ "BufWritePost", "BufWinEnter", "BufNew" }, {
+        pattern = "*",
+        callback = function() vim.wo.winbar = nil end,
+        group = vim.api.nvim_create_augroup("disable_winbar", { clear = true }),
+        desc = "Ensure winbar stays disabled when writing to file, switching buffers, opening floating windows, etc.",
+      })
     end,
     on_close = function() -- restore diagnostics, indent blankline, and winbar
       vim.g.diagnostics_mode = vim.g.diagnostics_mode_old
-      vim.g.indent_blankline_enabled = vim.g.indent_blankline_enabled_old
-      vim.b.miniindentscope_disable = false
-      vim.wo.winbar = vim.g.winbar_old
       vim.diagnostic.config(require("astronvim.utils.lsp").diagnostics[vim.g.diagnostics_mode])
+
+      vim.g.indent_blankline_enabled = vim.g.indent_blankline_enabled_old
+      vim.g.miniindentscope_disable = vim.g.miniindentscope_disable_old
       if vim.g.indent_blankline_enabled_old then vim.cmd "IndentBlanklineRefresh" end
+
+      vim.api.nvim_clear_autocmds { group = "disable_winbar" }
+      vim.wo.winbar = vim.g.winbar_old
     end,
   },
 }


### PR DESCRIPTION
Previously, the winbar would enable itself on various events (switching buffers, writing to file, which-key popups, telescope, etc.) I added an autocmd that will disable the winbar for all these events while ZenMode is enabled. This does feel a bit hacky though, so please let me know if there's a better way to toggle the winbar.

Additionally, this fixes an issue where previous mini.indentscope options would not be restored upon exiting ZenMode.