### PR TITLE
fix(catppuccin): enable alpha.nvim by default

### DIFF
--- a/lua/astrocommunity/colorscheme/catppuccin/init.lua
+++ b/lua/astrocommunity/colorscheme/catppuccin/init.lua
@@ -3,16 +3,16 @@ return {
   name = "catppuccin",
   opts = {
     integrations = {
-      nvimtree = false,
-      ts_rainbow = false,
       aerial = true,
       dap = { enabled = true, enable_ui = true },
       mason = true,
       neotree = true,
       notify = true,
+      nvimtree = false,
       semantic_tokens = true,
       symbols_outline = true,
       telescope = true,
+      ts_rainbow = false,
       which_key = true,
     },
   },

--- a/lua/astrocommunity/colorscheme/catppuccin/init.lua
+++ b/lua/astrocommunity/colorscheme/catppuccin/init.lua
@@ -3,6 +3,7 @@ return {
   name = "catppuccin",
   opts = {
     integrations = {
+      alpha = true,
       aerial = true,
       dap = { enabled = true, enable_ui = true },
       mason = true,


### PR DESCRIPTION
We use alpha.nvim for the start screen, might as well enable it.

Also sorting integrations alphabetically makes adding/removing later nicer. 