### PR TITLE
fix(chatgpt-nvim): typo in `dependencies` key

### DIFF
--- a/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
@@ -1,7 +1,7 @@
 return {
   "jackMort/ChatGPT.nvim",
   cmd = { "ChatGPT", "ChatGPTActAs", "ChatGPTEditWithInstructions", "ChatGPTRun" },
-  depencencies = {
+  dependencies = {
     "MunifTanjim/nui.nvim",
     "nvim-lua/plenary.nvim",
     "nvim-telescope/telescope.nvim",


### PR DESCRIPTION
This fixes #460