### PR TITLE
chore(nord-nvim): update colorscheme readme

### DIFF
--- a/lua/astrocommunity/colorscheme/nord-nvim/README.md
+++ b/lua/astrocommunity/colorscheme/nord-nvim/README.md
@@ -3,3 +3,14 @@
 Neovim theme based off of the Nord Color Palette, written in lua with tree sitter support
 
 **Repository:** <https://github.com/shaunsingh/nord.nvim>
+
+**Note:** Until the maintainer fixes the problem, the theme is incompatible with semantic tokens ([issue](https://github.com/shaunsingh/nord.nvim/issues/143), you therefore have to turn off the feature otherwise many tokens will be the same color. (put this in the `polish` function of `lua/user/init.lua`:
+
+```
+vim.api.nvim_create_autocmd("LspAttach", {
+  callback = function(args)
+    local client = vim.lsp.get_client_by_id(args.data.client_id)
+    client.server_capabilities.semanticTokensProvider = nil
+  end,
+})
+```


### PR DESCRIPTION
Without the proposed change code looks like this:
![image](https://github.com/AstroNvim/astrocommunity/assets/14826113/ff02ebc0-2efb-4f10-a1b9-ed13038f65bb)


With the proposed change it looks like this:
![capture-2023-07-31_19-07-1690846261](https://github.com/AstroNvim/astrocommunity/assets/14826113/8f22a51f-288f-4501-b3f2-f95463960222)
