### PR TITLE
chore(copilot-lua-cmp): alter accept line key mapping

### DIFF
--- a/lua/astrocommunity/completion/copilot-lua-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-lua-cmp/init.lua
@@ -51,7 +51,7 @@ return {
         if copilot.is_visible() then copilot.accept_line() end
       end)
 
-      opts.mapping["<C-j>"] = cmp.mapping(function()
+      opts.mapping["<C-n>"] = cmp.mapping(function()
         if copilot.is_visible() then copilot.accept_line() end
       end)
 


### PR DESCRIPTION
Since cycling through basic `cmp.nvim` completions with `<C-j>,<C-k>` is a common usage, it feels more natural to map the copilot accept line action to one of the alternative (`<C-n>,<C-p>`) keymappings of `cmp.nvim`. Also since cycling with `<Tab>` is not possible if there is a copilot suggestion it becomes a bit inconvenient with the current mapping.