### PR TITLE
docs(neogit): add noice notification check in readme

### DIFF
--- a/lua/astrocommunity/git/neogit/README.md
+++ b/lua/astrocommunity/git/neogit/README.md
@@ -5,3 +5,26 @@ magit for neovim
 **Repository:** <https://github.com/TimUntersberger/neogit>
 
 A work-in-progress Magit clone for Neovim that is geared toward the Vim philosophy.
+
+
+## Noice notification support
+
+Neogit configuration checks if "nvim-notify" is available, otherwise disables Neogit notifications
+
+When using noice, add an override to check for "noice-nvim"
+
+```lua
+return {
+  "AstroNvim/astrocommunity",
+  { import = "astrocommunity.git.neogit" },
+  {
+    "NeogitOrg/neogit",
+    dependencies = {
+      { "nvim-lua/plenary.nvim", "sindrets/diffview.nvim" },
+    },
+    opts = {
+      -- disable_builtin_notifications = false,
+      disable_builtin_notifications = utils.is_available "noice-nvim",
+    },
+  },
+```


### PR DESCRIPTION
Add neogit config override in readme showing how to check if noice-nvim is avaialble rather than the default nvim-notify

Note: if there is a way to make a check for either nvim-notify or noice-nvim then that would be more useful

