### PR TITLE
fix(go): Add extra treesitter languages for Go

### DIFF
--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -5,7 +5,7 @@ return {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "go")
+        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "go", "gomod", "gosum", "gowork")
       end
     end,
   },


### PR DESCRIPTION
Go modules, module checksum, and workspaces should have syntax highlighting.