### PR TITLE
chore(bufferline-nvim): add neo-tree offset

### DIFF
--- a/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
@@ -1,5 +1,18 @@
 return {
-  { "akinsho/bufferline.nvim", event = "VeryLazy", opts = {} },
+  {
+    "akinsho/bufferline.nvim",
+    event = "VeryLazy",
+    opts = {
+      offsets = {
+        {
+          filetype = "neo-tree",
+          text = "Neo-tree",
+          highlight = "Directory",
+          text_align = "left",
+        },
+      },
+    },
+  },
   {
     "rebelot/heirline.nvim",
     optional = true,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Since `Neo-tree` is the default file explorer, it would be nice to add the `neo-tree` offset to `bufferline` by default as:

![Screenshot 2023-08-08 at 17 06 22](https://github.com/AstroNvim/astrocommunity/assets/16321871/34cb2e93-f05f-499d-92ae-dc6ad33f56ce)

Currently it looks like this:

![Screenshot 2023-08-08 at 17 08 38](https://github.com/AstroNvim/astrocommunity/assets/16321871/7f338972-92fb-495a-a93c-6c3664ba364b)

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [x] Not Completed
- [x] Completed
-->
