### PR TITLE
fix(auto-save-nvim): disable format on save when auto saving

### DIFF
--- a/lua/astrocommunity/editing-support/auto-save-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/auto-save-nvim/init.lua
@@ -1,5 +1,31 @@
 return {
-  "Pocco81/auto-save.nvim",
+  -- "Pocco81/auto-save.nvim",
+  "zoriya/auto-save.nvim", -- HACK: use fork until PR is accepted
   event = { "User AstroFile", "InsertEnter" },
-  opts = {},
+  opts = {
+    callbacks = {
+      before_saving = function()
+        -- save global autoformat status
+        vim.g.OLD_AUTOFORMAT = vim.g.autoformat_enabled
+
+        vim.g.autoformat_enabled = false
+        vim.g.OLD_AUTOFORMAT_BUFFERS = {}
+        -- disable all manually enabled buffers
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+          if vim.b[bufnr].autoformat_enabled then
+            table.insert(vim.g.OLD_BUFFER_AUTOFORMATS, bufnr)
+            vim.b[bufnr].autoformat_enabled = false
+          end
+        end
+      end,
+      after_saving = function()
+        -- restore global autoformat status
+        vim.g.autoformat_enabled = vim.g.OLD_AUTOFORMAT
+        -- reenable all manually enabled buffers
+        for _, bufnr in ipairs(vim.g.OLD_AUTOFORMAT_BUFFERS or {}) do
+          vim.b[bufnr].autoformat_enabled = true
+        end
+      end,
+    },
+  },
 }


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Formatting on save with the automatic saving breaks undo because whenever you undo it reformats immediatley. This disables the automatic formatting when buffers are auto saved. It still lets auto formatting work when saving manually with `:w` for example.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
