### PR TITLE
fix(ansible): use public API for getting buffer lines

### DIFF
--- a/lua/astrocommunity/pack/ansible/init.lua
+++ b/lua/astrocommunity/pack/ansible/init.lua
@@ -22,7 +22,7 @@ return {
     init = function()
       local function yaml_ft(path, bufnr)
         -- get content of buffer as string
-        local content = vim.filetype.getlines(bufnr)
+        local content = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
         if type(content) == "table" then content = table.concat(content, "\n") end
 
         -- check if file is in roles, tasks, or handlers folder


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

`vim.filetype.getlines` is actually a private function (I did this originally so my b 😢). This moves it to the correct public API

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
