### PR TITLE
fix(rust): Lazy load crates.nvim on BufRead Cargo.toml event

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -50,6 +50,7 @@ return {
   },
   {
     "Saecki/crates.nvim",
+    event = { "BufRead Cargo.toml" },
     init = function()
       vim.api.nvim_create_autocmd("BufRead", {
         group = vim.api.nvim_create_augroup("CmpSourceCargo", { clear = true }),


### PR DESCRIPTION
## 📑 Description

Lazy load `crates.nvim` when Cargo.toml is loaded



## ℹ Additional Information

