### PR TITLE
feat(cpp): only load `clangd_extensions` when `clangd` attaches

### DIFF
--- a/lua/astrocommunity/pack/cpp/init.lua
+++ b/lua/astrocommunity/pack/cpp/init.lua
@@ -18,7 +18,20 @@ return {
   },
   {
     "p00f/clangd_extensions.nvim",
-    ft = { "c", "cpp", "objc", "objcpp", "cuda", "proto" },
+    init = function()
+      -- load clangd extensions when clangd attaches
+      local augroup = vim.api.nvim_create_augroup("clangd_extensions", { clear = true })
+      vim.api.nvim_create_autocmd("LspAttach", {
+        group = augroup,
+        desc = "Load clangd_extensions with clangd",
+        callback = function(args)
+          if assert(vim.lsp.get_client_by_id(args.data.client_id)).name == "clangd" then
+            require "clangd_extensions"
+            vim.api.nvim_del_augroup_by_id(augroup)
+          end
+        end,
+      })
+    end,
   },
   {
     "Civitasv/cmake-tools.nvim",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This improves the loading of `clangd_extensions` by making it only load when clangd actually attaches to a buffer rather than just loading it on file types.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
