### PR TITLE
fix noice-nvim warning by disable lsp signature of noice-nvim

### DIFF
--- a/lua/astrocommunity/utility/noice-nvim/init.lua
+++ b/lua/astrocommunity/utility/noice-nvim/init.lua
@@ -22,6 +22,10 @@ return {
           ["vim.lsp.util.stylize_markdown"] = true,
           ["cmp.entry.get_documentation"] = true,
         },
+
+        signature = {
+          enabled = false,
+        },
       },
       presets = {
         bottom_search = true, -- use a classic bottom cmdline for search


### PR DESCRIPTION
## 📑 Description

I got a warning when I was opening my nvim.
I disable the signature and the warning is gone and I see no difference.

Here the warning
![image](https://github.com/AstroNvim/astrocommunity/assets/12479055/54bd544a-d3a2-4edb-b461-1b57174b7912)
