### PR TITLE
fix(typescript): Requires should be dependencies

### DIFF
--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -99,7 +99,7 @@ return {
   },
   {
     "vuki656/package-info.nvim",
-    requires = "MunifTanjim/nui.nvim",
+    dependencies = { "MunifTanjim/nui.nvim" },
     opts = {},
     event = "BufRead package.json",
   },


### PR DESCRIPTION
## 📑 Description
```
 lazy: require("lazy.health").check()
 
 lazy.nvim
 - OK Git installed
 - OK no existing packages found by other package managers
 - OK packer_compiled.lua not found
 - WARNING {package-info.nvim}: unknown key <requires>
```

## Additional Information
Based on [this example in AstroNvim](https://github.com/AstroNvim/AstroNvim/blob/26aedacec6a3d2aeba44c365360b3ba3637b20ca/lua/plugins/neo-tree.lua#L4), this appears to be the right syntax.

