### PR TITLE
fix(bufferline-nvim): fix neo-tree offset

### DIFF
--- a/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
@@ -3,12 +3,14 @@ return {
     "akinsho/bufferline.nvim",
     event = "VeryLazy",
     opts = {
-      offsets = {
-        {
-          filetype = "neo-tree",
-          text = "Neo-tree",
-          highlight = "Directory",
-          text_align = "left",
+      options = {
+        offsets = {
+          {
+            filetype = "neo-tree",
+            text = "Neo-tree",
+            highlight = "Directory",
+            text_align = "left",
+          },
         },
       },
     },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

I noted that the neo-tree offset was not applied after switching to bufferline.nvim from astrocommunity. Seems that I missed the `options` struct when copy paste from my local bufferline config in this PR https://github.com/AstroNvim/astrocommunity/pull/510 😅

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
