### PR TITLE
fix(openingh-nvim): more precise lazy loading with "cmd" and "keys"

### DIFF
--- a/lua/astrocommunity/git/openingh-nvim/init.lua
+++ b/lua/astrocommunity/git/openingh-nvim/init.lua
@@ -1,4 +1,10 @@
+local prefix = "<leader>g"
 return {
   "almo7aya/openingh.nvim",
-  event = "User AstroGitFile",
+  cmd = { "OpenInGHRepo", "OpenInGHFile", "OpenInGHFileLines" },
+  keys = {
+    { prefix .. "o", "<cmd>OpenInGHRepo<CR>", desc = "Open git repo in web", mode = { "n" } },
+    { prefix .. "f", "<cmd>OpenInGHFile<CR>", desc = "Open git file in web", mode = { "n" } },
+    { prefix .. "f", "<cmd>OpenInGHFileLines<CR>", desc = "Open git lines in web", mode = { "x" } },
+  },
 }


### PR DESCRIPTION
## 📑 Description
Use keys and cmd for lazy loading openingph-nvim instead of event
I made the description of the keys generic on purpose because the plugin author states that it supports not only Github but also other git hosting sites. Also, this plugin has a nice notification message if you try to use it not inside a git repository so I don't see a problem with using cmd and keys

