### PR TITLE
fix(hardtime-nvim): disable hardtime-nvim on neo-tree-popup

### DIFF
--- a/lua/astrocommunity/workflow/hardtime-nvim/init.lua
+++ b/lua/astrocommunity/workflow/hardtime-nvim/init.lua
@@ -29,6 +29,7 @@ return {
       "lazy",
       "mason",
       "neo-tree",
+      "neo-tree-popup",
       "netrw",
       "noice",
       "notify",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #530 
-->

## 📑 Description

<!-- Add a brief description of the pr -->
This disables `hardtime-nvim` on `neo-tree-popup` filetypes. This allows usage of arrow keys when the pop up for file/dir creation, deletion, and renaming shows up.

Closes #530 

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
