### PR TITLE
perf(cmp-cmdline): lazy load

### DIFF
--- a/lua/astrocommunity/completion/cmp-cmdline/init.lua
+++ b/lua/astrocommunity/completion/cmp-cmdline/init.lua
@@ -1,22 +1,28 @@
-local cmp = require "cmp"
-
 return {
   "hrsh7th/cmp-cmdline",
-  lazy = false,
-  opts = {
-    mapping = cmp.mapping.preset.cmdline(),
-    sources = cmp.config.sources({
-      { name = "path" },
-    }, {
-      {
-        name = "cmdline",
-        option = {
-          ignore_cmds = { "Man", "!" },
+  opts = function()
+    local cmp_mapping = require "cmp.config.mapping"
+    local cmp_sources = require "cmp.config.sources"
+
+    return {
+      mapping = cmp_mapping.preset.cmdline(),
+      sources = cmp_sources({
+        { name = "path" },
+      }, {
+        {
+          name = "cmdline",
+          option = {
+            ignore_cmds = { "Man", "!" },
+          },
         },
-      },
-    }, {
-      { name = "buffer" },
-    }),
-  },
+      }, {
+        { name = "buffer" },
+      }),
+    }
+  end,
   config = function(_, opts) require("cmp").setup.cmdline(":", opts) end,
+  dependencies = {
+    "nvim-cmp",
+  },
+  event = { "CmdlineEnter" },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Lazy load `cmp-cmdline`, for faster startup time.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

Original implementation load `cmp` at startup.

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
