### PR TITLE
fix(obsidian-nvim): remove annoying notification about "gf" mapping

### DIFF
--- a/lua/astrocommunity/note-taking/obsidian-nvim/README.md
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/README.md
@@ -16,5 +16,8 @@ and
 
 to match your vault location. 
 
+We set `mappings` to an empty table, because `gf` is used for lazy loading in `keys`  
+if you don't want `gf` for lazy loading, you should remove `keys` and `mappings` tables
+
 
 The plugin may also nag and ask you to create a `templates` directory in the vault. You can use `mkdir templates` to create an empty directory.

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -27,6 +27,7 @@ return {
     dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
     use_advanced_uri = true,
     finder = "telescope.nvim",
+    mappings = {},
 
     templates = {
       subdir = "templates",


### PR DESCRIPTION
## 📑 Description
Remove annoying notification
<img width="1722" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/67468725/cc5b4132-a707-41c2-a4fc-887f1b1d1f22">

according to the plugin's `help`:

If you want the `gf` passthrough functionality but you’ve already overridden
the `gf` keybinding, just change your `gf` mapping definition to something like
this:

```lua
    vim.keymap.set("n", "gf", function()
      if require("obsidian").util.cursor_on_markdown_link() then
        return "<cmd>ObsidianFollowLink<CR>"
      else
        return "gf"
      end
    end, { noremap = false, expr = true })
```

Then make sure to comment out the `gf` keybinding in your obsidian.nvim config:

```lua
    mappings = {
      -- ["gf"] = require("obsidian.mapping").gf_passthrough(),
    },
```


