### PR TITLE
chore(mini-indentscope): inherit exclusions from indent_blankline

### DIFF
--- a/lua/astrocommunity/indent/mini-indentscope/init.lua
+++ b/lua/astrocommunity/indent/mini-indentscope/init.lua
@@ -5,31 +5,13 @@ return {
     opts = { symbol = "│", options = { try_as_border = true } },
     init = function()
       vim.api.nvim_create_autocmd("FileType", {
-        pattern = {
-          "Trouble",
-          "aerial",
-          "alpha",
-          "checkhealth",
-          "dashboard",
-          "fzf",
-          "help",
-          "lazy",
-          "lspinfo",
-          "man",
-          "mason",
-          "neo-tree",
-          "notify",
-          "null-ls-info",
-          "starter",
-          "toggleterm",
-          "undotree",
-        },
-        callback = function() vim.b.miniindentscope_disable = true end,
-      })
-      vim.api.nvim_create_autocmd("FileType", {
-        pattern = { "*" },
+        pattern = "*",
         callback = function()
-          if vim.tbl_contains({ "nofile", "prompt", "quickfix", "terminal" }, vim.bo["buftype"]) then
+          if
+            vim.tbl_contains(vim.g.indent_blankline_filetype_exclude, vim.bo["filetype"])
+            or vim.tbl_contains(vim.g.indent_blankline_buftype_exclude, vim.bo["buftype"])
+            or vim.tbl_contains(vim.g.indent_blankline_bufname_exclude, vim.api.nvim_buf_get_name(0))
+          then
             vim.b.miniindentscope_disable = true
           end
         end,

--- a/lua/astrocommunity/indent/mini-indentscope/init.lua
+++ b/lua/astrocommunity/indent/mini-indentscope/init.lua
@@ -26,6 +26,14 @@ return {
         },
         callback = function() vim.b.miniindentscope_disable = true end,
       })
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = { "*" },
+        callback = function()
+          if vim.tbl_contains({ "nofile", "prompt", "quickfix", "terminal" }, vim.bo["buftype"]) then
+            vim.b.miniindentscope_disable = true
+          end
+        end,
+      })
     end,
   },
   {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This synchronizes excluded filetypes/buftypes/bufnames for indent blankline and mini.indentscope, completely eliminating all inconsistencies between the two.

## ℹ Additional Information

Depends on whether https://github.com/AstroNvim/AstroNvim/pull/2251 is merged or not.
