### PR TITLE
fix(mini-indentscope): exclude special buftypes

### DIFF
--- a/lua/astrocommunity/indent/mini-indentscope/init.lua
+++ b/lua/astrocommunity/indent/mini-indentscope/init.lua
@@ -5,26 +5,40 @@ return {
     opts = { symbol = "│", options = { try_as_border = true } },
     init = function()
       vim.api.nvim_create_autocmd("FileType", {
-        pattern = {
-          "Trouble",
-          "aerial",
-          "alpha",
-          "checkhealth",
-          "dashboard",
-          "fzf",
-          "help",
-          "lazy",
-          "lspinfo",
-          "man",
-          "mason",
-          "neo-tree",
-          "notify",
-          "null-ls-info",
-          "starter",
-          "toggleterm",
-          "undotree",
-        },
-        callback = function() vim.b.miniindentscope_disable = true end,
+        pattern = "*",
+        callback = function()
+          local excluded_filetypes = {
+            "Trouble",
+            "aerial",
+            "alpha",
+            "checkhealth",
+            "dashboard",
+            "fzf",
+            "help",
+            "lazy",
+            "lspinfo",
+            "man",
+            "mason",
+            "neo-tree",
+            "notify",
+            "null-ls-info",
+            "starter",
+            "toggleterm",
+            "undotree",
+          }
+          local excluded_buftypes = {
+            "nofile",
+            "prompt",
+            "quickfix",
+            "terminal",
+          }
+          if
+            vim.tbl_contains(excluded_filetypes, vim.bo["filetype"])
+            or vim.tbl_contains(excluded_buftypes, vim.bo["buftype"])
+          then
+            vim.b.miniindentscope_disable = true
+          end
+        end,
       })
     end,
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Prevents indentscope from loading on special buftypes ("nofiles", "terminal", "quickfix", "prompt"), similar to indent blankline

## ℹ Additional Information

None
