### PR TITLE
feat(editing-support): added nvim-devdocs plugin

### DIFF
--- a/lua/astrocommunity/editing-support/nvim-devdocs/README.md
+++ b/lua/astrocommunity/editing-support/nvim-devdocs/README.md
@@ -1,0 +1,12 @@
+# nvim-devdocs
+
+**Repository**: https://github.com/luckasRanarison/nvim-devdocs
+
+nvim-devdocs is a plugin which brings [DevDocs][devdocs-site] documentations into neovim.
+Install, search and preview documentations directly inside neovim in markdown format with telescope integration.
+You can also use custom commands like [glow][glow-repo] to render the markdown for a better experience.
+
+_Astrocommunity note: [glow][glow-repo] render will work out of the box if you have it on your PATH_
+
+[glow-repo]: https://github.com/charmbracelet/glow
+[devdocs-site]: https://devdocs.io/

--- a/lua/astrocommunity/editing-support/nvim-devdocs/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-devdocs/init.lua
@@ -1,0 +1,41 @@
+local utils = require "astronvim.utils"
+local prefix = "<leader>f"
+
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      if opts.ensure_installed ~= "all" then
+        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "html")
+      end
+    end,
+  },
+  {
+    "luckasRanarison/nvim-devdocs",
+    cond = not vim.g.vscode,
+    dependencies = {
+      "nvim-lua/plenary.nvim",
+      "nvim-telescope/telescope.nvim",
+      "nvim-treesitter/nvim-treesitter",
+    },
+    cmd = {
+      "DevdocsFetch",
+      "DevdocsInstall",
+      "DevdocsUninstall",
+      "DevdocsOpen",
+      "DevdocsOpenFloat",
+      "DevdocsUpdate",
+      "DevdocsUpdateAll",
+    },
+    keys = {
+      { prefix .. "d", "<cmd>DevdocsOpenCurrentFloat<CR>", desc = "Find Devdocs for current file", mode = { "n" } },
+      { prefix .. "D", "<cmd>DevdocsOpenFloat<CR>", desc = "Find Devdocs", mode = { "n" } },
+    },
+    opts = {
+      previewer_cmd = vim.fn.executable "glow" == 1 and "glow" or nil,
+      cmd_args = { "-s", "dark", "-w", "80" },
+      picker_cmd = true,
+      picker_cmd_args = { "-p" },
+    },
+  },
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
This PR adds the [nvim-devdoc](https://github.com/luckasRanarison/nvim-devdocs) plugin

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
## Screenshots

<details>
<summary>Without glow</summary>
<img width="1728" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/67468725/36cbdbc0-f813-4893-b748-169a0a135413">
<img width="1728" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/67468725/52baaffa-87b5-460f-80ee-0e1a7c52f1df">
</details>

<details>
<summary>WIth glow</summary>
<img width="1728" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/67468725/a61d8507-b51c-4413-a1d5-d25f0f0739e3">
<img width="1728" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/67468725/ac0dea7d-2936-409a-9529-ff6e92e05d99">
<img width="1728" alt="image" src="https://github.com/AstroNvim/astrocommunity/assets/67468725/1f85f371-1b8f-4de3-9b2e-3d8756fbf554">
</details
