### PR TITLE
fix(zen-mode-nvim): disable global winbar upon entering zen mode

### DIFF
--- a/lua/astrocommunity/editing-support/zen-mode-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/zen-mode-nvim/init.lua
@@ -33,10 +33,10 @@ return {
       vim.g.miniindentscope_disable_old = vim.g.miniindentscope_disable
       vim.g.miniindentscope_disable = true
 
-      vim.g.winbar_old = vim.wo.winbar
-      vim.api.nvim_create_autocmd({ "BufWritePost", "BufWinEnter", "BufNew" }, {
+      vim.g.winbar_old = vim.o.winbar
+      vim.api.nvim_create_autocmd({ "BufWinEnter", "BufNew" }, {
         pattern = "*",
-        callback = function() vim.wo.winbar = nil end,
+        callback = function() vim.o.winbar = nil end,
         group = vim.api.nvim_create_augroup("disable_winbar", { clear = true }),
         desc = "Ensure winbar stays disabled when writing to file, switching buffers, opening floating windows, etc.",
       })
@@ -57,7 +57,7 @@ return {
       if vim.g.indent_blankline_enabled_old then vim.cmd "IndentBlanklineRefresh" end
 
       vim.api.nvim_clear_autocmds { group = "disable_winbar" }
-      vim.wo.winbar = vim.g.winbar_old
+      vim.o.winbar = vim.g.winbar_old
 
       if utils.is_available "vim-matchup" then
         vim.g.matchup_matchparen_offscreen = vim.g.matchup_matchparen_offscreen_old


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Fixes an issue where toggling a floating terminal will enable the winbar again. Also removes the unecessary "BufWritePost" autocmd event.

## ℹ Additional Information
None
