### PR TITLE
fix(yanky-nvim): Fix yanky.nvim loading when restoring session

### DIFF
--- a/lua/astrocommunity/editing-support/yanky-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/yanky-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "gbprod/yanky.nvim",
+  event = "UIEnter",
   dependencies = { { "kkharji/sqlite.lua", enabled = not jit.os:find "Windows" } },
   opts = function()
     local mapping = require "yanky.telescope.mapping"


### PR DESCRIPTION
there can not set event 'User AstroFile', because restore session from resession.nvim will not tigger 'User AstroFile' event.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
