### PR TITLE
fix(vim-matchup): remove matchup_match_paren_deferred option

### DIFF
--- a/lua/astrocommunity/motion/vim-matchup/init.lua
+++ b/lua/astrocommunity/motion/vim-matchup/init.lua
@@ -3,7 +3,6 @@ return {
   dependencies = { "andymass/vim-matchup" },
   init = function()
     vim.g.matchup_matchparen_offscreen = { method = "popup", fullwidth = 1, highlight = "Normal", syntax_hl = 1 }
-    vim.g.matchup_matchparen_deferred = 1
   end,
   opts = { matchup = { enable = true } },
 }


### PR DESCRIPTION
This will leave the option set to 0 by default

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #2276
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
Enabling the option was causing issues by printing matching content on top of buffers in split screens, as seen on https://github.com/AstroNvim/AstroNvim/issues/2276
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
See demo video of the issue on https://github.com/AstroNvim/AstroNvim/issues/2276