### PR TITLE
feat(zen-mode-nvim)!: switch to maintained fork for now

### DIFF
--- a/lua/astrocommunity/editing-support/zen-mode-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/zen-mode-nvim/init.lua
@@ -1,7 +1,8 @@
 local utils = require "astronvim.utils"
 
 return {
-  "folke/zen-mode.nvim",
+  -- TODO: switch back to folke's repo when it's maintained again
+  "Subjective/zen-mode.nvim",
   cmd = "ZenMode",
   opts = {
     window = {


### PR DESCRIPTION
## 📑 Description

It seems like zen-mode-nvim isn't really being maintained right now (PRs have been open since the beginning of the year). For quite some time now, there's been an annoying issue where zen-mode doesn't play well when switching buffers that I've fixed on my own fork. I thought it might be a decent idea to switch over to that, at least for the time being.

## ℹ Additional Information
None
