### PR TITLE
fix(mini-indentscope): correctly disable indentscope in buftypes and terminals

### DIFF
--- a/lua/astrocommunity/indent/mini-indentscope/init.lua
+++ b/lua/astrocommunity/indent/mini-indentscope/init.lua
@@ -1,3 +1,29 @@
+local excluded_filetypes = {
+  "Trouble",
+  "aerial",
+  "alpha",
+  "checkhealth",
+  "dashboard",
+  "fzf",
+  "help",
+  "lazy",
+  "lspinfo",
+  "man",
+  "mason",
+  "neo-tree",
+  "notify",
+  "null-ls-info",
+  "starter",
+  "toggleterm",
+  "undotree",
+}
+local excluded_buftypes = {
+  "nofile",
+  "prompt",
+  "quickfix",
+  "terminal",
+}
+
 return {
   {
     "echasnovski/mini.indentscope",
@@ -5,40 +31,21 @@ return {
     opts = { symbol = "│", options = { try_as_border = true } },
     init = function()
       vim.api.nvim_create_autocmd("FileType", {
-        pattern = "*",
-        callback = function()
-          local excluded_filetypes = {
-            "Trouble",
-            "aerial",
-            "alpha",
-            "checkhealth",
-            "dashboard",
-            "fzf",
-            "help",
-            "lazy",
-            "lspinfo",
-            "man",
-            "mason",
-            "neo-tree",
-            "notify",
-            "null-ls-info",
-            "starter",
-            "toggleterm",
-            "undotree",
-          }
-          local excluded_buftypes = {
-            "nofile",
-            "prompt",
-            "quickfix",
-            "terminal",
-          }
-          if
-            vim.tbl_contains(excluded_filetypes, vim.bo["filetype"])
-            or vim.tbl_contains(excluded_buftypes, vim.bo["buftype"])
-          then
-            vim.b.miniindentscope_disable = true
+        desc = "Disable indentscope for certain filetypes",
+        pattern = excluded_filetypes,
+        callback = function(event) vim.b[event.buf].miniindentscope_disable = true end,
+      })
+      vim.api.nvim_create_autocmd("BufWinEnter", {
+        desc = "Disable indentscope for certain buftypes",
+        callback = function(event)
+          if vim.tbl_contains(excluded_buftypes, vim.bo[event.buf].buftype) then
+            vim.b[event.buf].miniindentscope_disable = true
           end
         end,
+      })
+      vim.api.nvim_create_autocmd("TermOpen", {
+        desc = "Disable indentscope for terminals",
+        callback = function(event) vim.b[event.buf].miniindentscope_disable = true end,
       })
     end,
   },


### PR DESCRIPTION
## 📑 Description
Brings over upstream v4 checks to correctly disable indentscope on special buftypes and terminals: https://github.com/AstroNvim/AstroNvim/commit/48298253d7df1599797b6a754fa95357d2ce15e1

-->

## ℹ Additional Information

None
