### PR TITLE
fix(haskell): remove now redundant `discover_configurations` call

### DIFF
--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -21,10 +21,7 @@ return {
       astronvim.lsp.skip_setup = utils.list_insert_unique(astronvim.lsp.skip_setup, "hls")
       vim.g.haskell_tools = {
         hls = {
-          on_attach = function(client, bufnr, ht)
-            require("astronvim.utils.lsp").on_attach(client, bufnr)
-            ht.dap.discover_configurations(bufnr)
-          end,
+          on_attach = function(client, bufnr, _) require("astronvim.utils.lsp").on_attach(client, bufnr) end,
         },
       }
     end,


### PR DESCRIPTION
## 📑 Description

- Since version `2.1.0`, haskell-tools.nvim automatically discovers DAP launch configurations if both `nvim-dap` and `haskell-debug-adapter` are installed.
- See https://github.com/AstroNvim/astrocommunity/pull/553#issuecomment-1707147579

@Uzaaft @Per48edjes 

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

The `2.1.0` change is backward compatible, but the `discover_configurations` call is now redundant.
