### PR TITLE
fix(haskell): make haskell-tools respect the `options` table

### DIFF
--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -14,16 +14,28 @@ return {
     "mrcjkb/haskell-tools.nvim",
     dependencies = {
       "nvim-lua/plenary.nvim",
-      { "nvim-telescope/telescope.nvim", optional = true }, -- Optional
+      { "nvim-telescope/telescope.nvim", optional = true },
+      { "mfussenegger/nvim-dap", optional = true },
     },
     branch = "2.x.x", -- Recommended
-    init = function() -- Optional, see Advanced configuration
-      astronvim.lsp.skip_setup = utils.list_insert_unique(astronvim.lsp.skip_setup, "hls")
-      vim.g.haskell_tools = {
+    init = function() astronvim.lsp.skip_setup = utils.list_insert_unique(astronvim.lsp.skip_setup, "hls") end,
+    opts = function(_, opts)
+      -- this allows users to pass opts through an opts table in community.lua
+      opts = opts or {}
+      local defaults = {
         hls = {
           on_attach = function(client, bufnr, _) require("astronvim.utils.lsp").on_attach(client, bufnr) end,
         },
       }
+      opts = vim.tbl_deep_extend("keep", opts, defaults)
+      return opts
+    end,
+    config = function(_, opts)
+      -- haskell-tools reads this config the first time `require('haskell-tools')` is called,
+      -- which is typically when opening a Haskell or Cabal file, or when the
+      -- user executes one of the plugin's commands.
+      -- NOTE: If vim.g.haskell_tools has already been set, its options take precedence.
+      vim.g.haskell_tools = vim.tbl_deep_extend("keep", vim.g.haskell_tools or {}, opts)
     end,
     -- load the plugin when opening one of the following file types
     ft = { "haskell", "lhaskell", "cabal", "cabalproject" },

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -21,7 +21,6 @@ return {
     init = function() astronvim.lsp.skip_setup = utils.list_insert_unique(astronvim.lsp.skip_setup, "hls") end,
     opts = function(_, opts)
       -- this allows users to pass opts through an opts table in community.lua
-      opts = opts or {}
       local defaults = {
         hls = {
           on_attach = function(client, bufnr, _) require("astronvim.utils.lsp").on_attach(client, bufnr) end,

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -17,26 +17,17 @@ return {
       { "nvim-telescope/telescope.nvim", optional = true },
       { "mfussenegger/nvim-dap", optional = true },
     },
-    branch = "2.x.x", -- Recommended
-    init = function() astronvim.lsp.skip_setup = utils.list_insert_unique(astronvim.lsp.skip_setup, "hls") end,
-    opts = function(_, opts)
-      -- this allows users to pass opts through an opts table in community.lua
-      local defaults = {
+    version = "^2",
+    -- load the plugin when opening one of the following file types
+    ft = { "haskell", "lhaskell", "cabal", "cabalproject" },
+    init = function()
+      astronvim.lsp.skip_setup = utils.list_insert_unique(astronvim.lsp.skip_setup, "hls")
+      vim.g.haskell_tools = vim.tbl_deep_extend("keep", vim.g.haskell_tools or {}, {
         hls = {
           on_attach = function(client, bufnr, _) require("astronvim.utils.lsp").on_attach(client, bufnr) end,
         },
-      }
-      return vim.tbl_deep_extend("keep", opts, defaults)
+      })
     end,
-    config = function(_, opts)
-      -- haskell-tools reads this config the first time `require('haskell-tools')` is called,
-      -- which is typically when opening a Haskell or Cabal file, or when the
-      -- user executes one of the plugin's commands.
-      -- NOTE: If vim.g.haskell_tools has already been set, its options take precedence.
-      vim.g.haskell_tools = vim.tbl_deep_extend("keep", vim.g.haskell_tools or {}, opts)
-    end,
-    -- load the plugin when opening one of the following file types
-    ft = { "haskell", "lhaskell", "cabal", "cabalproject" },
   },
   {
     "williamboman/mason-lspconfig.nvim",

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -26,8 +26,7 @@ return {
           on_attach = function(client, bufnr, _) require("astronvim.utils.lsp").on_attach(client, bufnr) end,
         },
       }
-      opts = vim.tbl_deep_extend("keep", opts, defaults)
-      return opts
+      return vim.tbl_deep_extend("keep", opts, defaults)
     end,
     config = function(_, opts)
       -- haskell-tools reads this config the first time `require('haskell-tools')` is called,

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -21,10 +21,7 @@ return {
       astronvim.lsp.skip_setup = utils.list_insert_unique(astronvim.lsp.skip_setup, "hls")
       vim.g.haskell_tools = {
         hls = {
-          on_attach = function(client, bufnr, ht)
-            require("astronvim.utils.lsp").on_attach(client, bufnr)
-            ht.dap.discover_configurations(bufnr)
-          end,
+          on_attach = function(client, bufnr, _) require("astronvim.utils.lsp").on_attach(client, bufnr) end,
         },
       }
     end,


### PR DESCRIPTION
## 📑 Description

This PR is stacked on top of #570, which should be merged first.

- As discussed in https://github.com/AstroNvim/astrocommunity/pull/553#issuecomment-1705684907, the haskell-tools plugin is not user-configurable
- This PR uses [the same method as the java package](https://github.com/mrcjkb/astrocommunity/blob/82e76559973205eb9c8bd76ee134d3bccdee75b6/lua/astrocommunity/pack/java/init.lua#L36) to allow users to configure the plugin through an `opts` table in `community.lua`.

As mentioned in https://github.com/AstroNvim/astrocommunity/pull/553, I don't feel strongly about this, so please close this PR if you don't agree with this approach.