### PR TITLE
refactor(main): Prefer using `main` instead of `name`

### DIFF
--- a/lua/astrocommunity/colorscheme/poimandres-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/poimandres-nvim/init.lua
@@ -1,12 +1,1 @@
-return {
-  "olivercederborg/poimandres.nvim",
-  name = "poimandres",
-  opts = {
-    -- leave this setup function empty for default config
-    bold_vert_split = false, -- use bold vertical separators
-    dim_nc_background = false, -- dim 'non-current' window backgrounds
-    disable_background = false, -- disable background
-    disable_float_background = false, -- disable background for floats
-    disable_italics = false, -- disable italics
-  },
-}
+return { "olivercederborg/poimandres.nvim", opts = {} }

--- a/lua/astrocommunity/completion/tabnine-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabnine-nvim/init.lua
@@ -1,6 +1,6 @@
 return {
   "codota/tabnine-nvim",
-  name = "tabnine",
+  main = "tabnine",
   build = vim.loop.os_uname().sysname == "Windows_NT" and "pwsh.exe -file .\\dl_binaries.ps1" or "./dl_binaries.sh",
   cmd = { "TabnineStatus", "TabnineDisable", "TabnineEnable", "TabnineToggle" },
   event = "User AstroFile",

--- a/lua/astrocommunity/pack/ruby/init.lua
+++ b/lua/astrocommunity/pack/ruby/init.lua
@@ -19,10 +19,6 @@ return {
   },
   {
     "mfussenegger/nvim-dap",
-    dependencies = {
-      "suketa/nvim-dap-ruby",
-      name = "dap-ruby",
-      opts = {},
-    },
+    dependencies = { "suketa/nvim-dap-ruby", config = true },
   },
 }

--- a/lua/astrocommunity/project/project-nvim/init.lua
+++ b/lua/astrocommunity/project/project-nvim/init.lua
@@ -1,14 +1,14 @@
 return {
   {
     "jay-babu/project.nvim",
-    name = "project_nvim",
+    main = "project_nvim",
     event = "VeryLazy",
     opts = { ignore_lsp = { "lua_ls" } },
   },
   {
     "nvim-telescope/telescope.nvim",
     optional = true,
-    dependencies = { "project_nvim" },
+    dependencies = { "jay-babu/project.nvim" },
     opts = function() require("telescope").load_extension "projects" end,
   },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

When configuring plugin specifications, sometimes the main module of the plugin doesn't match the name of the repository. Previously we would use `name` to set the name of the main module but what this is actually doing is changing the name of the plugin when it is cloned. This can make it harder for the user to know what name to use when overriding the provided configuration. `lazy.nvim` provides a separate configuration option, `main`, which lets you just set the name of the main module in which the `setup` function is called. This is a much cleaner approach and we should utilize it 99% of the time when the module doesn't match the repository.

There are a couple cases left in AstroCommunity where `name` is used and this is mainly when the repository name is completely wrong for what it should be cloned as. `catppuccin/nvim` and `rose-pine/neovim` are two examples. These projects have an entire organization dedicated to the theme and each repo is a different application that it supports. Here we do actually want to fully rename the cloned plugin to `catppuccin` and `rose-pine` respectively rather than just fixing their main plugins.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
