### PR TITLE
fix(peek-nvim): Swap remote of peek-nvim to fork

### DIFF
--- a/lua/astrocommunity/markdown-and-latex/peek-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/peek-nvim/init.lua
@@ -1,5 +1,5 @@
 return {
-  "toppair/peek.nvim",
+  "saimo/peek.nvim",
   build = "deno task --quiet build:fast",
   config = function()
     vim.api.nvim_create_user_command("PeekOpen", require("peek").open, {})


### PR DESCRIPTION
Due to https://github.com/toppair/peek.nvim/issues/47, peek.nvim is unusable without https://github.com/toppair/peek.nvim/pull/50, this PR proposes to change the remote in order for the plugin to work 