### PR TITLE
fix(projectmgr-nvim): disable lazy loading

### DIFF
--- a/lua/astrocommunity/project/projectmgr-nvim/init.lua
+++ b/lua/astrocommunity/project/projectmgr-nvim/init.lua
@@ -1,6 +1,7 @@
 return {
   "charludo/projectmgr.nvim",
   event = "VeryLazy",
+  lazy = false,
   keys = {
     { "<leader>P", "<cmd>ProjectMgr<cr>", desc = "Open ProjectMgr panel" },
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
just copy the projectmgr.nvim config and paste to my astro config, but got error like belowa
```
E5108: Error executing lua: ...hare/nvim/lazy/projectmgr.nvim/lua/projectmgr/manage.lua:50: attempt to index field 'config' (a nil value)
stack traceback:
        ...hare/nvim/lazy/projectmgr.nvim/lua/projectmgr/manage.lua:50: in function 'close_project'
        ...hare/nvim/lazy/projectmgr.nvim/lua/projectmgr/manage.lua:16: in function 'open_project'
        ...lazy/projectmgr.nvim/lua/projectmgr/telescope_picker.lua:46: in function 'run_replace_or_original'
        ...re/nvim/lazy/telescope.nvim/lua/telescope/actions/mt.lua:65: in function 'key_func'
        ...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:253: in function <...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:252>

```

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Astro version: 3.37.6
Nvim version: v0.9.4