### PR TITLE
fix(smartcolumn-nvim): Add sensible default opts for when not to show colorcolumn

### DIFF
--- a/lua/astrocommunity/bars-and-lines/smartcolumn-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/smartcolumn-nvim/init.lua
@@ -2,6 +2,6 @@ return {
   "m4xshen/smartcolumn.nvim",
   event = { "InsertEnter", "User AstroFile" },
   opts = {
-    disabled_filetypes = { "neo-tree", "alpha", "help", "text", "markdown" },
+    disabled_filetypes = { "alpha", "neo-tree", "starter", "help", "text", "markdown" },
   },
 }

--- a/lua/astrocommunity/bars-and-lines/smartcolumn-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/smartcolumn-nvim/init.lua
@@ -1,5 +1,7 @@
 return {
   "m4xshen/smartcolumn.nvim",
   event = { "InsertEnter", "User AstroFile" },
-  opts = {},
+  opts = {
+    disabled_filetypes = { "neo-tree", "alpha", "help", "text", "markdown" },
+  },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Adds two filetypes (alpha, neo-tree) to the "smartcolumn" plugin's default list of disabled_filetypes (help, text, markdown). As both alpha-nvim and Neo-tree are included in the AstroNvim core and I see no reason why anyone would want a column in either case, I think it's a good idea to add them to the list of disabled filetypes.

## ℹ Additional Information

This is the current behavior:
<img width="1904" alt="Screenshot 2023-10-14 at 7 47 52 PM" src="https://github.com/AstroNvim/astrocommunity/assets/39179450/7adfb305-fb1c-401f-af53-f5746151f680">

This is after the change:
<img width="1904" alt="Screenshot 2023-10-14 at 7 46 59 PM" src="https://github.com/AstroNvim/astrocommunity/assets/39179450/3d1e250a-1755-483f-a8e9-0d0e2afbd167">