### PR TITLE
fix(rainbow-delimiters-nvim): fix setup function due to breaking change 

### DIFF
--- a/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
@@ -3,7 +3,7 @@ return {
     "HiPhish/rainbow-delimiters.nvim",
     dependencies = "nvim-treesitter/nvim-treesitter",
     event = "User AstroFile",
-    config = function(_, opts) require "rainbow-delimiters.setup"(opts) end,
+    config = function(_, opts) require("rainbow-delimiters.setup").setup(opts) end,
   },
   {
     "catppuccin/nvim",

--- a/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
@@ -3,7 +3,7 @@ return {
     "HiPhish/rainbow-delimiters.nvim",
     dependencies = "nvim-treesitter/nvim-treesitter",
     event = "User AstroFile",
-    config = function(_, opts) require("rainbow-delimiters.setup").setup(opts) end,
+    main = "rainbow-delimiters.setup",
   },
   {
     "catppuccin/nvim",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

Breaking change in [f1ce55edcbd2c25a544c93357c66d4172a870766](https://github.com/HiPhish/rainbow-delimiters.nvim/commit/f1ce55edcbd2c25a544c93357c66d4172a870766)
