### PR TITLE
fix(oil-nvim): ssh support

### DIFF
--- a/lua/astrocommunity/file-explorer/oil-nvim/init.lua
+++ b/lua/astrocommunity/file-explorer/oil-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "stevearc/oil.nvim",
+  lazy = false,
   opts = {},
   enabled = true,
   cmd = "Oil",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

`oil.nvim` is equipped to handle `oil-ssh://`, as demonstrated [here](https://github.com/stevearc/oil.nvim#ssh).
However, attempting to lazy load it may result in an error when using `nvim oil-ssh//xxx`.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
