### PR TITLE
fix(statuscol-nvim): flickring when statuscol width is not default

### DIFF
--- a/lua/astrocommunity/bars-and-lines/statuscol-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/statuscol-nvim/init.lua
@@ -1,5 +1,10 @@
 return {
-  { "luukvbaal/statuscol.nvim", lazy = false, opts = {} },
+  {
+    "luukvbaal/statuscol.nvim",
+    event = "User AstroFile",
+    lazy = vim.fn.argv()[1] == nil,
+    opts = {},
+  },
   {
     "rebelot/heirline.nvim",
     optional = true,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

When the status column has a non-default width, alpha-nvim may shift, leading to flickering.
This pull request addresses the issue and enhances performance.

An example configuration is provided.

```lua
{
    "statuscol.nvim",
    opts = function(_, _)
      local builtin = require "statuscol.builtin"
      local opts = {
        setopt = true,
        -- https://github.com/luukvbaal/statuscol.nvim/issues/72#issuecomment-1593828496
        ft_ignore = { "Overseer*" },
        bt_ignore = { "nofile", "prompt" },
        segments = {
          {
            sign = { name = { "GitSigns" }, maxwidth = 1, colwidth = 1, auto = false },
            click = "v:lua.ScSa",
          },
          {
            text = { builtin.lnumfunc, " " },
            condition = { true, builtin.not_empty },
            click = "v:lua.ScLa",
          },
          {
            sign = { name = { ".*" }, maxwidth = 1, colwidth = 1, auto = false },
            click = "v:lua.ScSa",
          },
          { text = { builtin.foldfunc, " " }, click = "v:lua.ScFa" },
        },
      }
      return opts
    end,
  }
```

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
