### PR TITLE
fix(dart): Add missing require

### DIFF
--- a/lua/astrocommunity/pack/dart/init.lua
+++ b/lua/astrocommunity/pack/dart/init.lua
@@ -1,4 +1,5 @@
 local utils = require "astronvim.utils"
+local astronvim = require "astronvim"
 return {
   { import = "astrocommunity.pack.yaml" },
   {


### PR DESCRIPTION
While attempting to fix #468, I came over this issue in the dart pack where the astronvim dependency is just used without any imports. This fixes that.