### PR TITLE
fix(ultimate-autopair-nvim): Fix breaking changes in config, and pin plugin version to 0.6

### DIFF
--- a/lua/astrocommunity/editing-support/ultimate-autopair-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/ultimate-autopair-nvim/init.lua
@@ -6,27 +6,20 @@ return {
   {
     "altermo/ultimate-autopair.nvim",
     event = "InsertEnter",
+    branch = "v0.6", --recommended as each new version will have breaking changes
     opts = {
       -- disable autopair in the command line: https://github.com/altermo/ultimate-autopair.nvim/issues/8
       cmap = false,
       extensions = {
-        rules = {
-          rules = {
-            {
-              "call",
-              function(o)
-                -- disable in comments including markdown style
-                local status, node = pcall(vim.treesitter.get_node, { pos = { o.linenr - 1, o.col - 2 } })
-                return o.incmd
-                  or o.col == 1
-                  or not status
-                  or not node
-                  or node:type() ~= "comment" and node:type() ~= "html_block"
-              end,
-            },
+        cond = {
+          -- disable in comments
+          -- https://github.com/altermo/ultimate-autopair.nvim/blob/6fd0d6aa976a97dd6f1bed4d46be1b437613a52f/Q%26A.md?plain=1#L26
+          cond = {
+            function(fn) return not fn.in_node "comment" end,
           },
         },
-        -- get fly mode working on strings: https://github.com/altermo/ultimate-autopair.nvim/issues/33
+        -- get fly mode working on strings:
+        -- https://github.com/altermo/ultimate-autopair.nvim/issues/33
         fly = {
           nofilter = true,
         },


### PR DESCRIPTION
## 📑 Description

Fixes the config for `ultimate-auto-pair` to work with the latest version and also pins the version at 0.6 to avoid future breaking changes (this is also recommended by the plugin).