### PR TITLE
fix(octo-nvim): adjusted whichkey description mapping

### DIFF
--- a/lua/astrocommunity/git/octo-nvim/init.lua
+++ b/lua/astrocommunity/git/octo-nvim/init.lua
@@ -27,6 +27,7 @@ return {
       mappings = {},
     },
     keys = {
+      { prefix .. "v", "<cmd>Octo manage pr reviewers", desc = "Manage reviewers" }, 
       { prefix .. "ca", "<cmd>Octo comment add<CR>", desc = "Add a new comment" },
       { prefix .. "cd", "<cmd>Octo comment delete<CR>", desc = "Delete a comment" },
 
@@ -80,7 +81,7 @@ return {
 
       { prefix .. "ss", "<cmd> Octo review start<CR>", desc = "Start review" },
       { prefix .. "sf", "<cmd> Octo review submit<CR>", desc = "Submit review" },
-      { prefix .. "sr", "<cmd> Octo review resume<CR>", desc = "Submit resume" },
+      { prefix .. "sr", "<cmd> Octo review resume<CR>", desc = "Resume review" },
       { prefix .. "sd", "<cmd> Octo review discard<CR>", desc = "Delete pending review" },
       { prefix .. "sc", "<cmd> Octo review comments<CR>", desc = "View pending comments" },
       { prefix .. "sp", "<cmd> Octo review commit<CR>", desc = "Select commit to review" },

--- a/lua/astrocommunity/git/octo-nvim/init.lua
+++ b/lua/astrocommunity/git/octo-nvim/init.lua
@@ -27,7 +27,6 @@ return {
       mappings = {},
     },
     keys = {
-      { prefix .. "v", "<cmd>Octo manage pr reviewers", desc = "Manage reviewers" }, 
       { prefix .. "ca", "<cmd>Octo comment add<CR>", desc = "Add a new comment" },
       { prefix .. "cd", "<cmd>Octo comment delete<CR>", desc = "Delete a comment" },
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Previously 'Resume review' was 'Start resume', this switch makes for a more intuitive description and aligns the first letter with the mapping. Not a big deal in the long run but I took way too long to find that mapping so figured a tiny PR wouldn't hurt :) 

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
