### PR TITLE
fix(swift): fix LSP handler error

### DIFF
--- a/lua/astrocommunity/pack/swift/README.md
+++ b/lua/astrocommunity/pack/swift/README.md
@@ -1,17 +1,23 @@
 # Swift Language Pack
 
-## Note: xbase is a WIP plugin, and the experience provided by this plugin might be lackluster
+## Note
 
-**Requirements:**
+xbase is a WIP plugin, and the experience provided by this plugin might be
+lackluster.
 
-1. Make sure you have [sourcekit-lsp](https://github.com/apple/sourcekit-lsp) installed on your machine.
+## Requirements
 
-2. Install Xcode Device Simulators:
-   To enable simulator functionality from within Neovim, you need to have Xcode Device Simulators installed on your machine. You can install these simulators from Xcode.
+1. Make sure you have [sourcekit-lsp](https://github.com/apple/sourcekit-lsp)
+   installed on your machine.
 
-3. Mappings:
-   The default mappings for the xbase plugin overlap with AstroNvim's default. Therefore, you should set the mappings yourself.
-   Refer to [xBase](https://github.com/kkharji/xbase#neovim-3) documentation for more options.
+2. Install Xcode Device Simulators: To enable simulator functionality from
+   within Neovim, you need to have Xcode Device Simulators installed on your
+machine. You can install these simulators from Xcode.
+
+3. Mappings: The default mappings for the xbase plugin overlap with AstroNvim's
+   default. Therefore, you should set the mappings yourself. Refer to
+[xBase](https://github.com/kkharji/xbase#neovim-3) documentation for more
+options.
 
 ```lua
 opts = {

--- a/lua/astrocommunity/pack/swift/init.lua
+++ b/lua/astrocommunity/pack/swift/init.lua
@@ -15,19 +15,9 @@ return {
       -- "nvim-lua/plenary.nvim", -- optional/requirement of telescope.nvim
       -- "stevearc/dressing.nvim", -- optional (in case you don't use telescope but something else)
     },
-    init = function() require("astronvim.utils.lsp").setup "sourcekit-lsp" end,
+    init = function() require("astronvim.utils.lsp").setup "sourcekit" end,
   },
-  {
-    "jose-elias-alvarez/null-ls.nvim",
-    opts = function(_, opts)
-      local nls = require "null-ls"
-      if type(opts.sources) == "table" then
-        vim.list_extend(opts.sources, {
-          nls.builtins.formatting.swift_format,
-        })
-      end
-    end,
-  },
+
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
@@ -36,6 +26,7 @@ return {
       end
     end,
   },
+
   {
     "jay-babu/mason-nvim-dap.nvim",
     opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "codelldb") end,


### PR DESCRIPTION
## 📑 Description

fixing an issue where:

- enabling  `{ import = "astrocommunity.pack.swift" },`
- enabling `lsp = { servers = { "sourcekit"} }` (not installed with mason)

- would trigger this error:

`[lspconfig] Cannot access configuration for sourcekit-lsp. Ensure this server is listed in "server_configurations.md" or added to a custom server.`