### PR TITLE
feat(haskell): add neotest-haskell, haskell-snippets, telescope-hoogle to pack

### DIFF
--- a/lua/astrocommunity/pack/haskell/README.md
+++ b/lua/astrocommunity/pack/haskell/README.md
@@ -2,17 +2,34 @@
 
 Requires:
 
-- plenary.nvim
+- plenary.nvim: Since v3 droppped this requirement, it is handled by the pack
+during install.
 
 Optionally:
 
-- A local hoogle installation
-- [fast-tags](https://github.com/elaforge/fast-tags) (reccomended by haskell-tools)
+- A local [hoogle](https://github.com/ndmitchell/hoogle) installation
+(recommended by haskell-tools)
+- [fast-tags](https://github.com/elaforge/fast-tags) (recommended by
+haskell-tools)
 
 This plugin pack does the following:
 
 - Adds `haskell` treesitter parsers
 - Adds `haskell-language-server` language server
+- Adds `haskell-debug-adapter` dap adapter
 - Adds [haskell-tools.nvim](https://github.com/mrcjkb/haskell-tools.nvim)
+(either v2 or v3 depending on nvim version)
 - Adds `yaml` language pack
 - Adds `json` language pack
+- Adds `neotest` from Astrocommunity
+- Adds [neotest-haskell](https://github.com/mrcjkb/neotest-haskell)
+- Adds [haskell-snippets.nvim](https://github.com/mrcjkb/haskell-snippets.nvim)
+
+Optionally available:
+
+> :warning: A local hoogle installation is required for this to work.
+
+- Adds [telescope-hoogle](https://github.com/psiska/telescope-hoogle.nvim)
+
+To install, set `{ "luc-tielen/telescope_hoogle" },` in `user/plugins/core.lua`
+and install this pack as normal.

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -1,7 +1,10 @@
 local utils = require "astronvim.utils"
+local haskell_ft = { "haskell", "lhaskell", "cabal", "cabalproject" }
+
 return {
   { import = "astrocommunity.pack.yaml" }, -- stack.yaml
   { import = "astrocommunity.pack.json" }, -- hls.json
+  { import = "astrocommunity.test.neotest" }, -- neotest-haskell
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
@@ -12,14 +15,15 @@ return {
   },
   {
     "mrcjkb/haskell-tools.nvim",
+    ft = haskell_ft,
     dependencies = {
-      "nvim-lua/plenary.nvim",
+      -- vim.fn.has >= nvim 0.9 removes plenary dependency
+      { "nvim-lua/plenary.nvim", optional = vim.fn.has "nvim-0.9" == 1 and true or false },
       { "nvim-telescope/telescope.nvim", optional = true },
       { "mfussenegger/nvim-dap", optional = true },
     },
-    version = "^2",
-    -- load the plugin when opening one of the following file types
-    ft = { "haskell", "lhaskell", "cabal", "cabalproject" },
+    -- vim.fn.has >= nvim 0.9 installs version 3
+    version = vim.fn.has "nvim-0.9" == 1 and "^3" or "^2",
     init = function()
       astronvim.lsp.skip_setup = utils.list_insert_unique(astronvim.lsp.skip_setup, "hls")
       vim.g.haskell_tools = vim.tbl_deep_extend("keep", vim.g.haskell_tools or {}, {
@@ -36,5 +40,38 @@ return {
   {
     "jay-babu/mason-nvim-dap.nvim",
     opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "haskell") end,
+  },
+  {
+    "mrcjkb/haskell-snippets.nvim",
+    ft = haskell_ft,
+    dependencies = { "L3MON4D3/LuaSnip" },
+    config = function()
+      local haskell_snippets = require("haskell-snippets").all
+      require("luasnip").add_snippets("haskell", haskell_snippets, { key = "haskell" })
+    end,
+  },
+  {
+    "luc-tielen/telescope_hoogle",
+    optional = true,
+    ft = haskell_ft,
+    dependencies = {
+      { "nvim-telescope/telescope.nvim" },
+    },
+    config = function()
+      local ok, telescope = pcall(require, "telescope")
+      if ok then telescope.load_extension "hoogle" end
+    end,
+  },
+  {
+    "nvim-neotest/neotest",
+    ft = haskell_ft,
+    dependencies = {
+      { "mrcjkb/neotest-haskell" },
+    },
+    opts = {
+      adapters = {
+        ["neotest-haskell"] = {},
+      },
+    },
   },
 }


### PR DESCRIPTION
## 📑 Description

Adding netotest-haskell, haskell-snippets and **optionally** telescope-hoogle.
Basing my changes on how @mrcjkb [implemented it on lazyvim](https://github.com/LazyVim/LazyVim/pull/2052).

## ℹ Additional Information

Since hoogle is an optionally recommended requirement for haskell-tools, the README reflects that and add instructions on how to enable the pack to install it and configure it properly.