### PR TITLE
fix(python-ruff/rust): python-ruff require error and rust add to mason-lspconfig

### DIFF
--- a/lua/astrocommunity/pack/cpp/init.lua
+++ b/lua/astrocommunity/pack/cpp/init.lua
@@ -4,7 +4,6 @@ return {
     "AstroNvim/astrolsp",
     ---@type AstroLSPOpts
     opts = {
-      handlers = { clangd = false },
       ---@diagnostic disable: missing-fields
       config = {
         clangd = {

--- a/lua/astrocommunity/pack/python-ruff/init.lua
+++ b/lua/astrocommunity/pack/python-ruff/init.lua
@@ -1,4 +1,4 @@
-local utils = require "astronvim.utils"
+local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
@@ -28,8 +28,19 @@ return {
   },
   {
     "linux-cultist/venv-selector.nvim",
+    dependencies = {
+      {
+        "AstroNvim/astrocore",
+        opts = {
+          mappings = {
+            n = {
+              ["<Leader>lv"] = { "<CMD>VenvSelect<CR>", desc = "Select VirtualEnv" },
+            },
+          },
+        },
+      },
+    },
     opts = {},
-    keys = { { "<Leader>lv", "<CMD>:VenvSelect<CR>", desc = "Select VirtualEnv" } },
   },
   {
     "mfussenegger/nvim-dap-python",

--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -1,10 +1,10 @@
+local utils = require "astrocore"
 return {
   { import = "astrocommunity.pack.toml" },
   {
     "AstroNvim/astrolsp",
     ---@type AstroLSPOpts
     opts = {
-      handlers = { clangd = false },
       ---@diagnostic disable: missing-fields
       config = {
         rust_analyzer = {
@@ -18,6 +18,12 @@ return {
         },
       },
     },
+  },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "rust_analyzer" })
+    end,
   },
   {
     "vxpm/ferris.nvim",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

- fix: python-ruff `utils` requires error
- fix: rust add to mason-lspconfig and delete disabled clangd code
- fix: cpp clangd is enabled

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
