### PR TITLE
fix(rust): enable cmp to crates and remove `clang` handler disabling

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -4,7 +4,6 @@ return {
     "AstroNvim/astrolsp",
     ---@type AstroLSPOpts
     opts = {
-      handlers = { clangd = false },
       ---@diagnostic disable: missing-fields
       config = {
         rust_analyzer = {
@@ -55,6 +54,9 @@ return {
       })
     end,
     opts = {
+      src = {
+        cmp = { enabled = true },
+      },
       null_ls = {
         enabled = true,
         name = "crates.nvim",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

- enable cmp to crates and clean unused code

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
