### PR TITLE
feat(split-and-window): Add mini-map

### DIFF
--- a/lua/astrocommunity/split-and-window/mini-map/README.md
+++ b/lua/astrocommunity/split-and-window/mini-map/README.md
@@ -1,0 +1,5 @@
+# mini-map
+
+Blazing fast minimap and scrollbar for vim with no external dependencies.
+
+**Repository:** <https://github.com/echasnovski/mini.map>

--- a/lua/astrocommunity/split-and-window/mini-map/init.lua
+++ b/lua/astrocommunity/split-and-window/mini-map/init.lua
@@ -1,0 +1,38 @@
+return {
+  {
+    "echasnovski/mini.map",
+    version = "*",
+    keys = {
+      { "<leader>um", function() require("mini.map").toggle() end, desc = "Toggle minimap" },
+    },
+    opts = function()
+      local map = require "mini.map"
+      return {
+        integrations = {
+          map.gen_integration.builtin_search(),
+          map.gen_integration.gitsigns(),
+          map.gen_integration.diagnostic {
+            error = "DiagnosticFloatingError",
+            warn = "DiagnosticFloatingWarn",
+            info = "DiagnosticFloatingInfo",
+            hint = "DiagnosticFloatingHint",
+          },
+        },
+        symbols = {
+          encode = map.gen_encode_symbols.dot "3x2",
+        },
+        window = {
+          side = "right",
+          width = 22,
+          winblend = 5,
+          show_integration_count = true,
+        },
+      }
+    end,
+  },
+  {
+    "catppuccin/nvim",
+    optional = true,
+    opts = { integrations = { mini = true } },
+  },
+}


### PR DESCRIPTION
## 📑 Description

Adding mini.map plugin. 100% Lua, no external dependencies but GitSigns (as optional).

@Uzaaft I left autocmd out of the picture, feel free to modify the readme for instructions or the init if you think it should be the default. If you do the latter it should be perhaps configurable on/off? I can help tomorrow.

## ℹ Additional Information

I was so frustrated with minimap (the rust one), its conflicts, and its bugs, that I seeked for an alternative so desperately. I finally found a GREAT ONE called mini.map :)

It works ridiculously well, it's extremley fast and lightweight, and it can double as a sidebar too! 100% Lua, no external dependencies (bar gitsigns if one wants to integrate it), and forget about brittle changes and stitches to make it compatible. it just works!!!