### PR TITLE
feat(git): Add gitlinker-nvim

### DIFF
--- a/lua/astrocommunity/git/gitlinker-nvim/README.md
+++ b/lua/astrocommunity/git/gitlinker-nvim/README.md
@@ -1,0 +1,6 @@
+# gitlinker-nvim
+
+A lua neovim plugin to generate shareable file permalinks (with line ranges)
+for several git web frontend hosts. Inspired by tpope/vim-fugitive's :GBrowse
+
+**Repository**: <https://github.com/ruifm/gitlinker.nvim>

--- a/lua/astrocommunity/git/gitlinker-nvim/init.lua
+++ b/lua/astrocommunity/git/gitlinker-nvim/init.lua
@@ -1,0 +1,11 @@
+return {
+  {
+    "linrongbin16/gitlinker.nvim",
+    event = "BufRead",
+    keys = {
+      { "<leader>gy", "<cmd>GitLink<CR>", desc = "Git link copy", mode = { "n", "v" } },
+      { "<leader>gz", "<cmd>GitLink!<CR>", desc = "Git link open", mode = { "n", "v" } },
+    },
+    opts = {},
+  },
+}


### PR DESCRIPTION
## 📑 Description

Adding gitlinker. An easy and quick way to link to any git file at specific line/s. Works with basically all providers (GitHub, GitLab, Bitbucket, and more).

## ℹ Additional Information

This is really useful when discussing code in a chat and have to share specific lines of any file. Mind you: commited files.