### PR TITLE
feat(swift): mv to swift only support (no xcode tooling here)

### DIFF
--- a/lua/astrocommunity/pack/swift/README.md
+++ b/lua/astrocommunity/pack/swift/README.md
@@ -9,6 +9,7 @@ This plugin pack does the following:
 - Adds `swift` Treesitter parsers
 - Adds `sourcekit` in LSP servers
 - Adds `sourcekit` in LSP config
+- Adds `codelldb` for debugging
 
 ## SwiftLint and SwiftFormat
 

--- a/lua/astrocommunity/pack/swift/README.md
+++ b/lua/astrocommunity/pack/swift/README.md
@@ -1,38 +1,33 @@
 # Swift Language Pack
 
-## Note
+Requires:
 
-xbase is a WIP plugin, and the experience provided by this plugin might be
-lackluster.
+- [sourcekit-lsp](https://github.com/apple/sourcekit-lsp)
 
-## Requirements
+This plugin pack does the following:
 
-1. Make sure you have [sourcekit-lsp](https://github.com/apple/sourcekit-lsp)
-   installed on your machine.
+- Adds `swift` Treesitter parsers
+- Adds `sourcekit` in LSP servers
+- Adds `sourcekit` in LSP config
 
-2. Install Xcode Device Simulators: To enable simulator functionality from
-   within Neovim, you need to have Xcode Device Simulators installed on your
-machine. You can install these simulators from Xcode.
+## SwiftLint and SwiftFormat
 
-3. Mappings: The default mappings for the xbase plugin overlap with AstroNvim's
-   default. Therefore, you should set the mappings yourself. Refer to
-[xBase](https://github.com/kkharji/xbase#neovim-3) documentation for more
-options.
+When it comes to linting and formatting, Swift is not standardized yet. Thus,
+you need to set your favorite configuration in `user/null-ls.lua`. For example:
 
 ```lua
-opts = {
-  -- ... (other options)
+[...]
+    config.sources = {
+      -- Set a formatter
+      null_ls.builtins.formatting.swiftformat, -- https://github.com/nicklockwood/SwiftFormat
+      -- null_ls.builtins.formatting.swift_format, -- https://github.com/apple/swift-format
 
-  mappings = {
-    enable = true,
-    build_picker = "<leader>rb", -- Set to 0 to disable
-    run_picker = "<leader>ra", -- Set to 0 to disable
-    watch_picker = 0, -- Set to 0 to disable
-    all_picker = 0, -- Set to 0 to disable
-    toggle_split_log_buffer = 0,
-    toggle_vsplit_log_buffer = "<leader>rs",
-  },
-
-  -- ... (other options)
-}
+      -- Set a linter
+      null_ls.builtins.diagnostics.swiftlint,
+    }
+[...]
 ```
+
+Make sure to install [SwiftLint](https://github.com/realm/SwiftLint) and either
+one of [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) **OR** [Apple's
+Swift-Format](https://github.com/apple/swift-format).

--- a/lua/astrocommunity/pack/swift/init.lua
+++ b/lua/astrocommunity/pack/swift/init.lua
@@ -2,23 +2,6 @@ local utils = require "astronvim.utils"
 
 return {
   {
-    "xbase-lab/xbase",
-    ft = {
-      "swift",
-      "objcpp",
-      "objc",
-    },
-    run = "make install", -- or "make install && make free_space" (not recommended, longer build time)
-    dependencies = {
-      "neovim/nvim-lspconfig",
-      -- "nvim-telescope/telescope.nvim", -- optional
-      -- "nvim-lua/plenary.nvim", -- optional/requirement of telescope.nvim
-      -- "stevearc/dressing.nvim", -- optional (in case you don't use telescope but something else)
-    },
-    init = function() require("astronvim.utils.lsp").setup "sourcekit" end,
-  },
-
-  {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
@@ -26,9 +9,8 @@ return {
       end
     end,
   },
-
   {
-    "jay-babu/mason-nvim-dap.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "codelldb") end,
+    "williamboman/mason-lspconfig.nvim",
+    init = function() require("astronvim.utils.lsp").setup "sourcekit" end,
   },
 }

--- a/lua/astrocommunity/pack/swift/init.lua
+++ b/lua/astrocommunity/pack/swift/init.lua
@@ -10,6 +10,10 @@ return {
     end,
   },
   {
+    "jay-babu/mason-nvim-dap.nvim",
+    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "codelldb") end,
+  },
+  {
     "williamboman/mason-lspconfig.nvim",
     init = function() require("astronvim.utils.lsp").setup "sourcekit" end,
   },


### PR DESCRIPTION
## 📑 Description

Moving away from any XCode tooling in Swift Lang pack. See: https://github.com/AstroNvim/astrocommunity/discussions/669#discussioncomment-7752199

## ℹ Additional Information

I am aware that opinionated is against the Astrocommunity guidelines. However, this pack **has** to be opinionated to make any sense. Otherwise the only thing in it would be treesitter. Not much to offer, really.

While not standardized (not for lack of trying), SwiftLint and SwiftFormat (not the Apple one) appear to be widely accepted by the community. They offer great customization too, in their own `.dotfiles` and it's an approach widely used by the community.

I'd say that until Apple (or the community) sets on a standard, this is the best we could do.