### PR TITLE
fix(editing-support): replace auto-save.nvim's url with its original repo

### DIFF
--- a/lua/astrocommunity/editing-support/auto-save-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/auto-save-nvim/init.lua
@@ -1,6 +1,5 @@
 return {
-  -- "Pocco81/auto-save.nvim",
-  "zoriya/auto-save.nvim", -- HACK: use fork until PR is accepted
+  "Pocco81/auto-save.nvim",
   event = { "User AstroFile", "InsertEnter" },
   opts = {
     callbacks = {


### PR DESCRIPTION
## 📑 Description

The fork repo http://github.com/zoriya/auto-save.nvim has been deleted by its owner, revert to the original repo.


