### PR TITLE
feat(lsp): add `nvim-lsp-file-operations` plugin

### DIFF
--- a/lua/astrocommunity/lsp/nvim-lsp-file-operations/README.md
+++ b/lua/astrocommunity/lsp/nvim-lsp-file-operations/README.md
@@ -1,0 +1,5 @@
+# nvim-lsp-file-operations
+
+**Repository:** <https://github.com/antosha417/nvim-lsp-file-operations>
+
+Neovim plugin that adds support for file operations using built-in LSP by integrating with `nvim-tree` and `neo-tree`.

--- a/lua/astrocommunity/lsp/nvim-lsp-file-operations/init.lua
+++ b/lua/astrocommunity/lsp/nvim-lsp-file-operations/init.lua
@@ -1,0 +1,38 @@
+return {
+  "antosha417/nvim-lsp-file-operations",
+  -- lazy will handle loading nvim-tree and neo-tree appropriately based on the module load and our `init` function
+  lazy = true,
+  init = function(plugin) -- lazily load plugin after a tree plugin is loaded
+    -- the plugins that should trigger this one to load when they have loaded
+    local triggers = { "nvim-tree.lua", "neo-tree.nvim" }
+
+    local load_plugin = function() require("lazy").load { plugins = { plugin.name } } end
+    local lazy_plugins = require("lazy.core.config").plugins
+
+    -- check if any of the plugins are already loaded, in which case load
+    for _, trigger in ipairs(triggers) do
+      if vim.tbl_get(lazy_plugins, trigger, "_", "loaded") then
+        vim.schedule(load_plugin)
+        return
+      end
+    end
+
+    -- if none, then set up autocommand to load the plugin
+    local autocmd
+    autocmd = vim.api.nvim_create_autocmd("User", {
+      pattern = "LazyLoad",
+      desc = "lazily load nvim-lsp-file-operations",
+      callback = function(args)
+        if vim.tbl_contains(triggers, args.data) then
+          load_plugin()
+          if autocmd then vim.api.nvim_del_autocmd(autocmd) end
+        end
+      end,
+    })
+
+    -- TODO: This entire `init` function can be simplified to the following line after AstroNvim v4 is released
+    -- require("astrocore").on_load({ "neo-tree.nvim", "nvim-tree.lua" }, plugin.name)
+  end,
+  main = "lsp-file-operations", -- set the main module name where the `setup` function is
+  opts = {},
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This adds the [nvim-lsp-file-operations](https://github.com/antosha417/nvim-lsp-file-operations) plugin to the lsp category. It includes integration into neo-tree and nvim-tee.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
