### PR TITLE
fix(editing-support): wrap all require calls to refactoring in function

### DIFF
--- a/lua/astrocommunity/editing-support/refactoring-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/refactoring-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "ThePrimeagen/refactoring.nvim",
+  event = "User AstroFile",
   dependencies = {
     "nvim-lua/plenary.nvim",
     "nvim-treesitter/nvim-treesitter",

--- a/lua/astrocommunity/editing-support/refactoring-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/refactoring-nvim/init.lua
@@ -8,16 +8,28 @@ return {
       opts = {
         mappings = {
           n = {
-            ["<Leader>rb"] = { require("refactoring").refactor "Extract Block", desc = "Extract Block" },
-            ["<Leader>ri"] = { require("refactoring").refactor "Inline Variable", desc = "Inline Variable" },
-            ["<Leader>rp"] = { require("refactoring").debug.printf { below = false }, desc = "Debug: Print Function" },
-            ["<Leader>rc"] = { require("refactoring").debug.cleanup {}, desc = "Debug: Clean Up" },
+            ["<Leader>rb"] = {
+              function() require("refactoring").refactor "Extract Block" end,
+              desc = "Extract Block",
+            },
+            ["<Leader>ri"] = {
+              function() require("refactoring").refactor "Inline Variable" end,
+              desc = "Inline Variable",
+            },
+            ["<Leader>rp"] = {
+              function() require("refactoring").debug.printf { below = false } end,
+              desc = "Debug: Print Function",
+            },
+            ["<Leader>rc"] = {
+              function() require("refactoring").debug.cleanup {} end,
+              desc = "Debug: Clean Up",
+            },
             ["<Leader>rd"] = {
-              require("refactoring").debug.print_var { below = false },
+              function() require("refactoring").debug.print_var { below = false } end,
               desc = "Debug: Print Variable",
             },
             ["<Leader>rbf"] = {
-              require("refactoring").refactor "Extract Block To File",
+              function() require("refactoring").refactor "Extract Block To File" end,
               desc = "Extract Block To File",
             },
           },
@@ -30,8 +42,14 @@ return {
               function() require("refactoring").refactor "Extract Function To File" end,
               desc = "Extract Function To File",
             },
-            ["<leadeer>rv"] = { require("refactoring").refactor "Extract Variable", desc = "Extract Variable" },
-            ["<Leader>ri"] = { require("refactoring").refactor "Inline Variable", desc = "Inline Variable" },
+            ["<Leader>rv"] = {
+              function() require("refactoring").refactor "Extract Variable" end,
+              desc = "Extract Variable",
+            },
+            ["<Leader>ri"] = {
+              function() require("refactoring").refactor "Inline Variable" end,
+              desc = "Inline Variable",
+            },
           },
           v = {
             ["<Leader>re"] = {
@@ -42,18 +60,36 @@ return {
               function() require("refactoring").refactor "Extract Function To File" end,
               desc = "Extract Function To File",
             },
-            ["<leadeer>rv"] = { require("refactoring").refactor "Extract Variable", desc = "Extract Variable" },
-            ["<Leader>ri"] = { require("refactoring").refactor "Inline Variable", desc = "Inline Variable" },
-            ["<Leader>rb"] = { require("refactoring").refactor "Extract Block", desc = "Extract Block" },
+            ["<Leader>rv"] = {
+              function() require("refactoring").refactor "Extract Variable" end,
+              desc = "Extract Variable",
+            },
+            ["<Leader>ri"] = {
+              function() require("refactoring").refactor "Inline Variable" end,
+              desc = "Inline Variable",
+            },
+            ["<Leader>rb"] = {
+              function() require("refactoring").refactor "Extract Block" end,
+              desc = "Extract Block",
+            },
             ["<Leader>rbf"] = {
-              require("refactoring").refactor "Extract Block To File",
+              function() require("refactoring").refactor "Extract Block To File" end,
               desc = "Extract Block To File",
             },
-            ["<Leader>rr"] = { require("refactoring").select_refactor, desc = "Select Refactor" },
-            ["<Leader>rp"] = { require("refactoring").debug.printf { below = false }, desc = "Debug: Print Function" },
-            ["<Leader>rc"] = { require("refactoring").debug.cleanup {}, desc = "Debug: Clean Up" },
+            ["<Leader>rr"] = {
+              function() require("refactoring").select_refactor() end,
+              desc = "Select Refactor",
+            },
+            ["<Leader>rp"] = {
+              function() require("refactoring").debug.printf { below = false } end,
+              desc = "Debug: Print Function",
+            },
+            ["<Leader>rc"] = {
+              function() require("refactoring").debug.cleanup {} end,
+              desc = "Debug: Clean Up",
+            },
             ["<Leader>rd"] = {
-              require("refactoring").debug.print_var { below = false },
+              function() require("refactoring").debug.print_var { below = false } end,
               desc = "Debug: Print Variable",
             },
           },


### PR DESCRIPTION
Before this, I got a module not found error. Wrapping it in a function, the require call is deferred until the keypress is run where the module is now available

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
