### PR TITLE
fix(true-zen-nvim): removing mode from key mapping in true-zen-nvim as it is not valid

### DIFF
--- a/lua/astrocommunity/editing-support/true-zen-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/true-zen-nvim/init.lua
@@ -39,7 +39,6 @@ return {
             truezen.narrow(first, last)
           end,
           desc = "Narrow (True Zen)",
-          mode = { "v" },
         }
       end,
     },


### PR DESCRIPTION

Happy New Year!!!

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
fix(editing-support): removing mode from key mapping in true-zen-nvim as it is not valid

![image](https://github.com/AstroNvim/astrocommunity/assets/36803168/47d37945-6a99-4528-b5f3-c155ced015fd)


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
