### PR TITLE
fix(rainbow-delimiters-nvim): event loading

### DIFF
--- a/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
@@ -2,7 +2,7 @@ return {
   {
     "HiPhish/rainbow-delimiters.nvim",
     dependencies = "nvim-treesitter/nvim-treesitter",
-    event = "User AstroFile",
+    event = "VeryLazy",
     main = "rainbow-delimiters.setup",
   },
   {


### PR DESCRIPTION
addresses: https://github.com/AstroNvim/astrocommunity/issues/672

currently rainbow-delimiters do not load properly unless `:e` is run in the document. using VeryLazy event, it loads properly. I don't fully understand this, but I believe loading the file first then having rainbow-delimiters load causes it to not color everything properly. https://github.com/HiPhish/rainbow-delimiters.nvim/issues/31#issuecomment-1694775091. the `:e` fix seems to be known by the author

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
