### PR TITLE
fix(typescript): don't overwrite neo-tree events

### DIFF
--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -130,16 +130,11 @@ return {
     "nvim-neo-tree/neo-tree.nvim",
     opts = function(_, opts)
       local events = require "neo-tree.events"
-      opts.event_handlers = {
-        {
-          event = events.FILE_MOVED,
-          handler = on_file_remove,
-        },
-        {
-          event = events.FILE_RENAMED,
-          handler = on_file_remove,
-        },
-      }
+      if not opts.event_handlers then opts.event_handlers = {} end
+      vim.list_extend(opts.event_handlers, {
+        { event = events.FILE_MOVED, handler = on_file_remove },
+        { event = events.FILE_RENAMED, handler = on_file_remove },
+      })
     end,
   },
   {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

Closes #713 


## 📑 Description

The current typescript pack fully overwrites the events in the neo-tree configuration rather than extending it. This makes sure the user can still add more events without getting overwritten as well as not overwriting the default AstroNvim neo-tree events

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
