### PR TITLE
fix: refactor utils so that `astrocore` is lazily loaded

### DIFF
--- a/lua/astrocommunity/debugging/nvim-dap-repl-highlights/init.lua
+++ b/lua/astrocommunity/debugging/nvim-dap-repl-highlights/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   "nvim-treesitter/nvim-treesitter",
   dependencies = {
@@ -8,7 +7,7 @@ return {
   },
   opts = function(_, opts)
     if opts.ensure_installed ~= "all" then
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "dap_repl")
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "dap_repl")
     end
   end,
 }

--- a/lua/astrocommunity/editing-support/cutlass-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/cutlass-nvim/init.lua
@@ -1,9 +1,8 @@
-local utils = require "astrocore"
-
 return {
   "gbprod/cutlass.nvim",
   event = { "User AstroFile" },
   opts = function(_, opts)
+    local utils = require "astrocore"
     if utils.is_available "leap.nvim" then opts.exclude = utils.list_insert_unique(opts.exclude, { "ns", "nS" }) end
     if utils.is_available "hop.nvim" then opts.exclude = utils.list_insert_unique(opts.exclude, { "ns", "nS" }) end
   end,

--- a/lua/astrocommunity/editing-support/nvim-regexplainer/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-regexplainer/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   {
     "bennypowers/nvim-regexplainer",
@@ -11,7 +10,7 @@ return {
     opts = function(_, opts)
       -- add regex to treesitters
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "regex")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "regex")
       end
     end,
   },

--- a/lua/astrocommunity/editing-support/true-zen-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/true-zen-nvim/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   "Pocco81/true-zen.nvim",
   dependencies = {
@@ -44,6 +43,7 @@ return {
     },
   },
   opts = function(_, opts)
+    local utils = require "astrocore"
     return utils.extend_tbl(opts, {
       integrations = {
         tmux = os.getenv "TMUX" ~= nil, -- hide tmux status bar in (minimalist, ataraxis)

--- a/lua/astrocommunity/editing-support/zen-mode-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/zen-mode-nvim/init.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 return {
   "folke/zen-mode.nvim",
   cmd = "ZenMode",
@@ -41,7 +39,7 @@ return {
         desc = "Ensure winbar stays disabled when writing to file, switching buffers, opening floating windows, etc.",
       })
 
-      if utils.is_available "vim-matchup" then
+      if require("astrocore").is_available "vim-matchup" then
         vim.cmd.NoMatchParen()
         vim.g.matchup_matchparen_offscreen_old = vim.g.matchup_matchparen_offscreen
         vim.g.matchup_matchparen_offscreen = {}
@@ -59,7 +57,7 @@ return {
       vim.api.nvim_clear_autocmds { group = "disable_winbar" }
       vim.o.winbar = vim.g.winbar_old
 
-      if utils.is_available "vim-matchup" then
+      if require("astrocore").is_available "vim-matchup" then
         vim.g.matchup_matchparen_offscreen = vim.g.matchup_matchparen_offscreen_old
         vim.cmd.DoMatchParen()
       end

--- a/lua/astrocommunity/markdown-and-latex/markmap-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/markmap-nvim/init.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 --  [markdown markmap]
 --  https://github.com/Zeioth/markmap.nvim
 return {
@@ -11,6 +9,8 @@ return {
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "markmap" }) end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "markmap" })
+    end,
   },
 }

--- a/lua/astrocommunity/note-taking/zk-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/zk-nvim/init.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 return {
   {
     "mickael-menu/zk-nvim",
@@ -10,6 +8,8 @@ return {
 
   {
     "williamboman/mason-lspconfig.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "zk") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "zk")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/angular/init.lua
+++ b/lua/astrocommunity/pack/angular/init.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 return {
   { import = "astrocommunity.pack.typescript" },
   { import = "astrocommunity.pack.html-css" },
@@ -9,13 +7,15 @@ return {
     dependencies = { { "elgiano/nvim-treesitter-angular", branch = "topic/jsx-fix" } },
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "angular")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "angular")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "angularls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "angularls")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/ansible/init.lua
+++ b/lua/astrocommunity/pack/ansible/init.lua
@@ -1,24 +1,26 @@
-local utils = require "astrocore"
-
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "yaml")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "yaml")
       end
     end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "ansiblelint") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "ansiblelint")
+    end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "ansiblels") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "ansiblels")
+    end,
   },
   {
     "pearofducks/ansible-vim",

--- a/lua/astrocommunity/pack/astro/init.lua
+++ b/lua/astrocommunity/pack/astro/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
@@ -6,18 +5,22 @@ return {
     opts = function(_, opts)
       -- Ensure that opts.ensure_installed exists and is a table or string "all".
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "astro")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "astro")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "astro") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "astro")
+    end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "js") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "js")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/bash/init.lua
+++ b/lua/astrocommunity/pack/bash/init.lua
@@ -1,29 +1,32 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "bash")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "bash")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "bashls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "bashls")
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "shellcheck", "shfmt" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "shellcheck", "shfmt" })
     end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "bash") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "bash")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/clojure/init.lua
+++ b/lua/astrocommunity/pack/clojure/init.lua
@@ -1,11 +1,12 @@
 -- Clojure support with Conjure plugin
-local utils = require "astrocore"
 return {
   -- Clojure Language Server
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "clojure_lsp") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "clojure_lsp")
+    end,
   },
   -- Clojure parser
   {
@@ -13,7 +14,7 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "clojure")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "clojure")
       end
     end,
   },

--- a/lua/astrocommunity/pack/cmake/init.lua
+++ b/lua/astrocommunity/pack/cmake/init.lua
@@ -1,17 +1,18 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "cmake")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "cmake")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "neocmake") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "neocmake")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/cpp/init.lua
+++ b/lua/astrocommunity/pack/cpp/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   {
     "AstroNvim/astrolsp",
@@ -19,14 +18,17 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "cpp", "c", "objc", "cuda", "proto" })
+        opts.ensure_installed =
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "cpp", "c", "objc", "cuda", "proto" })
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "clangd") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "clangd")
+    end,
   },
   {
     "p00f/clangd_extensions.nvim",
@@ -51,7 +53,9 @@ return {
     dependencies = {
       {
         "jay-babu/mason-nvim-dap.nvim",
-        opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "codelldb") end,
+        opts = function(_, opts)
+          opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "codelldb")
+        end,
       },
     },
     opts = {},

--- a/lua/astrocommunity/pack/crystal/init.lua
+++ b/lua/astrocommunity/pack/crystal/init.lua
@@ -1,5 +1,4 @@
 vim.filetype.add { extension = { cr = "crystal" } }
-local utils = require "astrocore"
 
 return {
   {
@@ -8,10 +7,14 @@ return {
   },
   {
     "williamboman/mason-lspconfig.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "crystalline") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "crystalline")
+    end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "codelldb") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "codelldb")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/cs/init.lua
+++ b/lua/astrocommunity/pack/cs/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   -- CSharp support
   {
@@ -6,23 +5,29 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "c_sharp")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "c_sharp")
       end
     end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "csharpier") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "csharpier")
+    end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "csharp_ls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "csharp_ls")
+    end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "coreclr") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "coreclr")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/cue/init.lua
+++ b/lua/astrocommunity/pack/cue/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   -- Cue support
   {
@@ -6,7 +5,7 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "cue")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "cue")
       end
     end,
   },
@@ -14,11 +13,15 @@ return {
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "cueimports" }) end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "cueimports" })
+    end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "dagger") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "dagger")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/dart/init.lua
+++ b/lua/astrocommunity/pack/dart/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   { import = "astrocommunity.pack.yaml" },
   {
@@ -14,7 +13,7 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "dart")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "dart")
       end
     end,
   },
@@ -32,7 +31,9 @@ return {
       {
         "jay-babu/mason-nvim-dap.nvim",
         optional = true,
-        opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "dart") end,
+        opts = function(_, opts)
+          opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "dart")
+        end,
       },
     },
   },

--- a/lua/astrocommunity/pack/docker/init.lua
+++ b/lua/astrocommunity/pack/docker/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 vim.filetype.add {
   filename = {
     ["docker-compose.yaml"] = "yaml.docker-compose",
@@ -11,7 +10,7 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "dockerfile")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "dockerfile")
       end
     end,
   },
@@ -19,13 +18,17 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed =
-        utils.list_insert_unique(opts.ensure_installed, { "docker_compose_language_service", "dockerls" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        { "docker_compose_language_service", "dockerls" }
+      )
     end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "hadolint") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "hadolint")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/elm/init.lua
+++ b/lua/astrocommunity/pack/elm/init.lua
@@ -1,22 +1,24 @@
-local utils = require "astrocore"
-
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "elm" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "elm" })
       end
     end,
   },
 
   {
     "williamboman/mason-lspconfig.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "elmls" }) end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "elmls" })
+    end,
   },
 
   {
     "jay-babu/mason-null-ls.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "elm_format" }) end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "elm_format" })
+    end,
   },
 }

--- a/lua/astrocommunity/pack/gleam/init.lua
+++ b/lua/astrocommunity/pack/gleam/init.lua
@@ -1,16 +1,16 @@
-local utils = require "astrocore"
-
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "gleam" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "gleam" })
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "gleam" }) end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "gleam" })
+    end,
   },
 }

--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   -- Golang support
   {
@@ -6,7 +5,8 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "go", "gomod", "gosum", "gowork")
+        opts.ensure_installed =
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "go", "gomod", "gosum", "gowork" })
       end
     end,
   },
@@ -15,14 +15,18 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed =
-        utils.list_insert_unique(opts.ensure_installed, { "gomodifytags", "gofumpt", "iferr", "impl", "goimports" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        { "gomodifytags", "gofumpt", "iferr", "impl", "goimports" }
+      )
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "gopls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "gopls")
+    end,
   },
   {
     "leoluz/nvim-dap-go",
@@ -32,7 +36,9 @@ return {
       {
         "jay-babu/mason-nvim-dap.nvim",
         optional = true,
-        opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "delve") end,
+        opts = function(_, opts)
+          opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "delve")
+        end,
       },
     },
     opts = {},

--- a/lua/astrocommunity/pack/godot/init.lua
+++ b/lua/astrocommunity/pack/godot/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   {
     "QuickGD/quickgd.nvim",
@@ -23,7 +22,7 @@ return {
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed =
-          utils.list_insert_unique(opts.ensure_installed, { "gdscript", "glsl", "godot_resource" })
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "gdscript", "glsl", "godot_resource" })
       end
     end,
   },

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 local haskell_ft = { "haskell", "lhaskell", "cabal", "cabalproject" }
 
 return {
@@ -18,7 +17,7 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "haskell")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "haskell")
       end
     end,
   },
@@ -35,7 +34,7 @@ return {
     version = vim.fn.has "nvim-0.9" == 1 and "^3" or "^2",
     init = function()
       local astrolsp = require "astrolsp"
-      vim.g.haskell_tools = utils.extend_tbl({
+      vim.g.haskell_tools = require("astrocore").extend_tbl({
         hls = { capabilities = astrolsp.config.capabilities, on_attach = astrolsp.on_attach },
       }, vim.g.haskell_tools)
     end,
@@ -43,12 +42,16 @@ return {
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "hls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "hls")
+    end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "haskell") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "haskell")
+    end,
   },
   {
     "mrcjkb/haskell-snippets.nvim",

--- a/lua/astrocommunity/pack/haxe/init.lua
+++ b/lua/astrocommunity/pack/haxe/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   "nvim-treesitter/nvim-treesitter",
   optional = true,
@@ -14,6 +13,6 @@ return {
       filetype = "haxe",
     }
 
-    opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "haxe")
+    opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "haxe")
   end,
 }

--- a/lua/astrocommunity/pack/helm/init.lua
+++ b/lua/astrocommunity/pack/helm/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   -- Helm support
   {
@@ -17,14 +16,14 @@ return {
       }
       vim.treesitter.language.register("gotmpl", "helm")
 
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "gotmpl")
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "gotmpl")
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "helm_ls")
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "helm_ls")
 
       local configs = require "lspconfig.configs"
       local lspconfig = require "lspconfig"

--- a/lua/astrocommunity/pack/html-css/init.lua
+++ b/lua/astrocommunity/pack/html-css/init.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 return {
   { import = "astrocommunity.pack.json" },
   {
@@ -7,7 +5,7 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "html", "css" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "css" })
       end
     end,
   },
@@ -15,7 +13,8 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "html", "cssls", "emmet_ls" })
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "cssls", "emmet_ls" })
     end,
   },
 }

--- a/lua/astrocommunity/pack/java/init.lua
+++ b/lua/astrocommunity/pack/java/init.lua
@@ -1,12 +1,10 @@
-local utils = require "astrocore"
-
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "java", "html" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "java", "html" })
       end
     end,
   },
@@ -14,21 +12,23 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "jdtls", "lemminx" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "jdtls", "lemminx" })
     end,
   },
 
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "clang_format") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "clang_format")
+    end,
   },
 
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "javadbg", "javatest" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "javadbg", "javatest" })
     end,
   },
 
@@ -47,6 +47,7 @@ return {
       },
     },
     opts = function(_, opts)
+      local utils = require "astrocore"
       -- use this function notation to build some variables
       local root_markers = { ".git", "mvnw", "gradlew", "pom.xml", "build.gradle", ".project" }
       local root_dir = require("jdtls.setup").find_root(root_markers)
@@ -135,7 +136,7 @@ return {
           if opts.root_dir and opts.root_dir ~= "" then
             require("jdtls").start_or_attach(opts)
           else
-            utils.notify("jdtls: root_dir not found. Please specify a root marker", vim.log.levels.ERROR)
+            require("astrocore").notify("jdtls: root_dir not found. Please specify a root marker", vim.log.levels.ERROR)
           end
         end,
       })

--- a/lua/astrocommunity/pack/json/init.lua
+++ b/lua/astrocommunity/pack/json/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   {
     "b0o/SchemaStore.nvim",
@@ -27,13 +26,15 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "json", "jsonc" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "json", "jsonc" })
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "jsonls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "jsonls")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/julia/init.lua
+++ b/lua/astrocommunity/pack/julia/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   { import = "astrocommunity.pack.toml" },
   {
@@ -6,14 +5,16 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "julia")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "julia")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "julials") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "julials")
+    end,
   },
   {
     "hrsh7th/nvim-cmp",

--- a/lua/astrocommunity/pack/kotlin/init.lua
+++ b/lua/astrocommunity/pack/kotlin/init.lua
@@ -1,12 +1,10 @@
-local utils = require "astrocore"
-
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "kotlin")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "kotlin")
       end
     end,
   },
@@ -14,19 +12,23 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "kotlin_language_server")
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "kotlin_language_server")
     end,
   },
 
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "ktlint") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "ktlint")
+    end,
   },
 
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "kotlin") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "kotlin")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/lua/init.lua
+++ b/lua/astrocommunity/pack/lua/init.lua
@@ -1,24 +1,25 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "lua", "luap" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "lua", "luap" })
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "lua_ls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "lua_ls")
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "stylua", "luacheck" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "stylua", "luacheck" })
     end,
   },
 }

--- a/lua/astrocommunity/pack/markdown/init.lua
+++ b/lua/astrocommunity/pack/markdown/init.lua
@@ -1,22 +1,26 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "markdown", "markdown_inline" })
+        opts.ensure_installed =
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "markdown", "markdown_inline" })
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "marksman") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "marksman")
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "prettierd") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "prettierd")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/nim/init.lua
+++ b/lua/astrocommunity/pack/nim/init.lua
@@ -1,20 +1,23 @@
-local utils = require "astrocore"
-
 return {
   {
     "williamboman/mason-lspconfig.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "nim_langserver") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "nim_langserver")
+    end,
   },
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "nim", "nim_format_string" })
+        opts.ensure_installed =
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "nim", "nim_format_string" })
       end
     end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "nimpretty") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "nimpretty")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/nix/init.lua
+++ b/lua/astrocommunity/pack/nix/init.lua
@@ -1,18 +1,19 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "nix")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "nix")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "rnix") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "rnix")
+    end,
   },
   {
     "nvimtools/none-ls.nvim",

--- a/lua/astrocommunity/pack/php/init.lua
+++ b/lua/astrocommunity/pack/php/init.lua
@@ -1,27 +1,32 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "php")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "php")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "phpactor") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "phpactor")
+    end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "php") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "php")
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "php-cs-fixer") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "php-cs-fixer")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/prisma/init.lua
+++ b/lua/astrocommunity/pack/prisma/init.lua
@@ -1,17 +1,18 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "prisma")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "prisma")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "prismals") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "prismals")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/proto/init.lua
+++ b/lua/astrocommunity/pack/proto/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
@@ -6,18 +5,22 @@ return {
     opts = function(_, opts)
       -- Ensure that opts.ensure_installed exists and is a table or string "all".
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "proto")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "proto")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "bufls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "bufls")
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "buf") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "buf")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/ps1/init.lua
+++ b/lua/astrocommunity/pack/ps1/init.lua
@@ -1,10 +1,10 @@
-local utils = require "astrocore"
-
 return {
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "powershell_es") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "powershell_es")
+    end,
   },
   { "PProvost/vim-ps1", ft = "ps1" },
 }

--- a/lua/astrocommunity/pack/python-ruff/init.lua
+++ b/lua/astrocommunity/pack/python-ruff/init.lua
@@ -1,11 +1,10 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "python", "toml" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "python", "toml" })
       end
     end,
   },
@@ -13,19 +12,21 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "pyright", "ruff_lsp" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "pyright", "ruff_lsp" })
     end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "ruff" }) end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ruff" })
+    end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "python")
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "python")
       if not opts.handlers then opts.handlers = {} end
       opts.handlers.python = function() end -- make sure python doesn't get set up by mason-nvim-dap, it's being set up by nvim-dap-python
     end,

--- a/lua/astrocommunity/pack/python/init.lua
+++ b/lua/astrocommunity/pack/python/init.lua
@@ -1,31 +1,32 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "python", "toml" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "python", "toml" })
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "pyright" }) end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "pyright" })
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "black", "isort" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "black", "isort" })
     end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "python")
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "python")
       if not opts.handlers then opts.handlers = {} end
       opts.handlers.python = function() end -- make sure python doesn't get set up by mason-nvim-dap, it's being set up by nvim-dap-python
     end,

--- a/lua/astrocommunity/pack/quarto/init.lua
+++ b/lua/astrocommunity/pack/quarto/init.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 return {
   {
     "quarto-dev/quarto-nvim",
@@ -31,7 +29,7 @@ return {
         "css",
       }
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, ensure_installed)
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, ensure_installed)
       end
     end,
   },

--- a/lua/astrocommunity/pack/ruby/init.lua
+++ b/lua/astrocommunity/pack/ruby/init.lua
@@ -1,24 +1,26 @@
-local utils = require "astrocore"
-
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "ruby")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "ruby")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "solargraph") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "solargraph")
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "standardrb") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "standardrb")
+    end,
   },
   {
     "mfussenegger/nvim-dap",

--- a/lua/astrocommunity/pack/scala/init.lua
+++ b/lua/astrocommunity/pack/scala/init.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 return {
   {
     "AstroNvim/astrolsp",
@@ -14,7 +12,7 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "scala")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "scala")
       end
     end,
   },
@@ -38,7 +36,7 @@ return {
             metals.setup_dap()
           end
 
-          metals.initialize_or_attach(utils.extend_tbl(metals.bare_config(), user_config))
+          metals.initialize_or_attach(require("astrocore").extend_tbl(metals.bare_config(), user_config))
         end,
         group = vim.api.nvim_create_augroup("nvim-metals", { clear = true }),
       })

--- a/lua/astrocommunity/pack/svelte/init.lua
+++ b/lua/astrocommunity/pack/svelte/init.lua
@@ -1,22 +1,25 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "svelte")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "svelte")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "svelte") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "svelte")
+    end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "js") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "js")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/swift/init.lua
+++ b/lua/astrocommunity/pack/swift/init.lua
@@ -1,19 +1,19 @@
-local utils = require "astrocore"
-
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "swift")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "swift")
       end
     end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "codelldb") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "codelldb")
+    end,
   },
   {
     "AstroNvim/astrolsp",

--- a/lua/astrocommunity/pack/tailwindcss/init.lua
+++ b/lua/astrocommunity/pack/tailwindcss/init.lua
@@ -1,11 +1,10 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "css")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "css")
       end
     end,
   },
@@ -13,13 +12,15 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "tailwindcss", "cssls" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "tailwindcss", "cssls" })
     end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "prettierd" }) end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "prettierd" })
+    end,
   },
   {
     "hrsh7th/nvim-cmp",

--- a/lua/astrocommunity/pack/terraform/init.lua
+++ b/lua/astrocommunity/pack/terraform/init.lua
@@ -1,24 +1,25 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "terraform")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "terraform")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "terraformls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "terraformls")
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "tflint", "tfsec" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "tflint", "tfsec" })
     end,
   },
 }

--- a/lua/astrocommunity/pack/thrift/init.lua
+++ b/lua/astrocommunity/pack/thrift/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
@@ -6,13 +5,15 @@ return {
     opts = function(_, opts)
       -- Ensure that opts.ensure_installed exists and is a table or string "all".
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "thrift")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "thrift")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "thriftls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "thriftls")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/toml/init.lua
+++ b/lua/astrocommunity/pack/toml/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
@@ -6,14 +5,16 @@ return {
     opts = function(_, opts)
       -- Ensure that opts.ensure_installed exists and is a table or string "all".
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "toml")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "toml")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "taplo") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "taplo")
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",

--- a/lua/astrocommunity/pack/typescript-deno/init.lua
+++ b/lua/astrocommunity/pack/typescript-deno/init.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 return {
   {
     "AstroNvim/astrolsp",
@@ -15,19 +13,24 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "javascript", "typescript", "tsx" })
+        opts.ensure_installed =
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "javascript", "typescript", "tsx" })
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "denols") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "denols")
+    end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "js") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "js")
+    end,
   },
   {
     "sigmasd/deno-nvim",

--- a/lua/astrocommunity/pack/typescript/dap.lua
+++ b/lua/astrocommunity/pack/typescript/dap.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 return {
   "mfussenegger/nvim-dap",
   optional = true,
@@ -38,7 +36,7 @@ return {
     if not dap.configurations.javascript then
       dap.configurations.javascript = js_config
     else
-      utils.extend_tbl(dap.configurations.javascript, js_config)
+      require("astrocore").extend_tbl(dap.configurations.javascript, js_config)
     end
   end,
 }

--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 local function check_json_key_exists(filename, key)
   -- Open the file in read mode
   local file = io.open(filename, "r")
@@ -30,14 +28,14 @@ return {
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed =
-          utils.list_insert_unique(opts.ensure_installed, { "javascript", "typescript", "tsx", "jsdoc" })
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "javascript", "typescript", "tsx", "jsdoc" })
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "tsserver", "eslint" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "tsserver", "eslint" })
 
       vim.api.nvim_create_autocmd("LspAttach", {
         group = vim.api.nvim_create_augroup("eslint_fix_creator", { clear = true }),
@@ -61,7 +59,8 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "prettierd", "eslint-lsp" })
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "prettierd", "eslint-lsp" })
       if not opts.handlers then opts.handlers = {} end
 
       local has_prettier = function(util)
@@ -89,7 +88,9 @@ return {
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "js") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "js")
+    end,
   },
   {
     "vuki656/package-info.nvim",

--- a/lua/astrocommunity/pack/typst/init.lua
+++ b/lua/astrocommunity/pack/typst/init.lua
@@ -1,9 +1,9 @@
-local utils = require "astrocore"
-
 return {
   { "kaarmu/typst.vim", ft = { "typst" } },
   {
     "williamboman/mason-lspconfig.nvim",
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "typst_lsp") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "typst_lsp")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/vue/init.lua
+++ b/lua/astrocommunity/pack/vue/init.lua
@@ -1,22 +1,25 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "vue")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "vue")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "volar") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "volar")
+    end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "js") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "js")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/wgsl/init.lua
+++ b/lua/astrocommunity/pack/wgsl/init.lua
@@ -1,13 +1,16 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "wgsl") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "wgsl")
+    end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "wgsl_analyzer") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "wgsl_analyzer")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/yaml/init.lua
+++ b/lua/astrocommunity/pack/yaml/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   {
     "b0o/SchemaStore.nvim",
@@ -29,18 +28,22 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "yaml")
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "yaml")
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "yamlls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "yamlls")
+    end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "prettierd") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "prettierd")
+    end,
   },
 }

--- a/lua/astrocommunity/pack/zig/init.lua
+++ b/lua/astrocommunity/pack/zig/init.lua
@@ -1,19 +1,19 @@
-local utils = require "astrocore"
-
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "zig" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "zig" })
       end
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
-    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "zls") end,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "zls")
+    end,
   },
 
   {

--- a/lua/astrocommunity/programming-language-support/rest-nvim/init.lua
+++ b/lua/astrocommunity/programming-language-support/rest-nvim/init.lua
@@ -1,4 +1,3 @@
-local utils = require "astrocore"
 return {
   {
     "rest-nvim/rest.nvim",
@@ -26,7 +25,7 @@ return {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "http", "json" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "http", "json" })
       end
     end,
   },

--- a/lua/astrocommunity/scrolling/satellite-nvim/init.lua
+++ b/lua/astrocommunity/scrolling/satellite-nvim/init.lua
@@ -1,5 +1,3 @@
-local utils = require "astrocore"
-
 return {
   {
     -- scrollbar
@@ -11,6 +9,7 @@ return {
     "folke/zen-mode.nvim",
     optional = true,
     opts = function(_, opts)
+      local utils = require "astrocore"
       local old_on_open, old_on_close = opts.on_open, opts.on_close
       opts.on_open = function()
         utils.conditional_func(old_on_open, true)

--- a/lua/astrocommunity/utility/noice-nvim/init.lua
+++ b/lua/astrocommunity/utility/noice-nvim/init.lua
@@ -1,11 +1,12 @@
-local utils = require "astrocore"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed =
-          utils.list_insert_unique(opts.ensure_installed, { "bash", "markdown", "markdown_inline", "regex", "vim" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(
+          opts.ensure_installed,
+          { "bash", "markdown", "markdown_inline", "regex", "vim" }
+        )
       end
     end,
   },
@@ -14,6 +15,7 @@ return {
     event = "VeryLazy",
     dependencies = { "MunifTanjim/nui.nvim" },
     opts = function(_, opts)
+      local utils = require "astrocore"
       return utils.extend_tbl(opts, {
         lsp = {
           -- override markdown rendering so that **cmp** and other plugins use **Treesitter**


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Now that utils come from `astrocore` which is a plugin, we shouldn't load it at the top of files. It should be loaded within functions so that it happens after all of the AstroCore configuration has happened rather than loading before `lazy.nvim` is finished.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
