### PR TITLE
fix(nvim-coverage): updated old keyword

### DIFF
--- a/lua/astrocommunity/test/nvim-coverage/init.lua
+++ b/lua/astrocommunity/test/nvim-coverage/init.lua
@@ -1,5 +1,5 @@
 return {
   "andythigpen/nvim-coverage",
   event = "User AstroFile",
-  requires = { "nvim-lua/plenary.nvim" },
+  dependencies = { "nvim-lua/plenary.nvim" },
 }


### PR DESCRIPTION
changed requires to dependencies as per lazy.nvim


## 📑 Description

Changes init.lua in test/nvim-coverage 
