### PR TITLE
fix(nvim-coverage): Call nvim-coverage's setup

### DIFF
--- a/lua/astrocommunity/test/nvim-coverage/init.lua
+++ b/lua/astrocommunity/test/nvim-coverage/init.lua
@@ -2,4 +2,5 @@ return {
   "andythigpen/nvim-coverage",
   event = "User AstroFile",
   dependencies = { "nvim-lua/plenary.nvim" },
+  opts = {},
 }


### PR DESCRIPTION

## 📑 Description

nvim-coverage requires `setup` to be called. The current version doesn't work unless adding this:
```lua
  { import = "astrocommunity.test.nvim-coverage" },
  {
    "andythigpen/nvim-coverage",
    opts = {},
  },
```

