### PR TITLE
refactor(typescript): set autocmd with AstroLSP

### DIFF
--- a/lua/astrocommunity/pack/typescript/README.md
+++ b/lua/astrocommunity/pack/typescript/README.md
@@ -14,7 +14,7 @@ This plugin pack does the following:
 
 ## How do I disable Eslint format on save?
 
-Do opt out of the Eslint format on save behaviour, you can disable the autocmd setup with the pack with this:
+To opt out of the Eslint format on save behaviour, you can disable the autocmd setup with the pack with this:
 
 ```lua
 return {

--- a/lua/astrocommunity/pack/typescript/README.md
+++ b/lua/astrocommunity/pack/typescript/README.md
@@ -10,3 +10,19 @@ This plugin pack does the following:
 - Adds [typescript.nvim](https://github.com/jose-elias-alvarez/typescript.nvim) for language specific tooling
 - Adds [package-info.nvim](https://github.com/vuki656/package-info.nvim) for project package management
 - Adds [nvim-lsp-file-operations](https://github.com/antosha417/nvim-lsp-file-operations) to handles file imports on rename or move within neo-tree
+
+
+## How do I disable Eslint format on save?
+
+Do opt out of the Eslint format on save behaviour, you can disable the autocmd setup with the pack with this:
+
+```lua
+return {
+  "AstroNvim/astrolsp",
+  opts = {
+    autocmds = {
+      eslint_fix_on_save = false
+    }
+  }
+}
+```

--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -36,23 +36,6 @@ return {
     "williamboman/mason-lspconfig.nvim",
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "tsserver", "eslint" })
-
-      vim.api.nvim_create_autocmd("LspAttach", {
-        group = vim.api.nvim_create_augroup("eslint_fix_creator", { clear = true }),
-        desc = "Create autocommand in buffers where eslint attaches",
-        callback = function(args)
-          if assert(vim.lsp.get_client_by_id(args.data.client_id)).name == "eslint" then
-            vim.api.nvim_create_autocmd("BufWritePost", {
-              desc = "Fix all eslint errors",
-              buffer = args.buf,
-              group = vim.api.nvim_create_augroup(("eslint_fix_%d"):format(args.buf), { clear = true }),
-              callback = function()
-                if vim.fn.exists ":EslintFixAll" > 0 then vim.cmd.EslintFixAll() end
-              end,
-            })
-          end
-        end,
-      })
     end,
   },
   {
@@ -105,6 +88,16 @@ return {
       "AstroNvim/astrolsp",
       ---@diagnostic disable: missing-fields
       opts = {
+        autocmds = {
+          eslint_fix_on_save = {
+            cond = function(client) return client.name == "eslint" and vim.fn.exists ":EslintFixAll" > 0 end,
+            {
+              event = "BufWritePost",
+              desc = "Fix all eslint errors",
+              callback = function() vim.cmd.EslintFixAll() end,
+            },
+          },
+        },
         handlers = { tsserver = false }, -- disable tsserver setup, this plugin does it
         config = {
           ["typescript-tools"] = { -- enable inlay hints by default for `typescript-tools`


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This uses the new notation in AstroLSP for setting up autocommands when attaching a language server. This makes it easy for users to opt out of the "ESLintFixAll" autocommand with something like this in their user plugins:

```lua
return {
  "AstroNvim/astrolsp",
  opts = {
    autocmds = {
      eslint_fix_on_save = false
    }
  }
}
```

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
