### PR TITLE
feat(neotest): move neotest adapters to language packs

### DIFF
--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -55,4 +55,13 @@ return {
     ft = { "go", "gomod" },
     build = ':lua require("go.install").update_all_sync()',
   },
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    dependencies = { "nvim-neotest/neotest-go" },
+    opts = function(_, opts)
+      if not opts.adapters then opts.adapters = {} end
+      table.insert(opts.adapters, require "neotest-go"(require("astrocore").plugin_opts "neotest-go"))
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -76,14 +76,11 @@ return {
   },
   {
     "nvim-neotest/neotest",
-    ft = haskell_ft,
-    dependencies = {
-      { "mrcjkb/neotest-haskell" },
-    },
-    opts = {
-      adapters = {
-        ["neotest-haskell"] = {},
-      },
-    },
+    optional = true,
+    dependencies = { "mrcjkb/neotest-haskell" },
+    opts = function(_, opts)
+      if not opts.adapters then opts.adapters = {} end
+      table.insert(opts.adapters, require "neotest-haskell"(require("astrocore").plugin_opts "neotest-haskell"))
+    end,
   },
 }

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -55,6 +55,7 @@ return {
   },
   {
     "mrcjkb/haskell-snippets.nvim",
+    enabled = function() return require("astrocore").is_available "LuaSnip" end,
     ft = haskell_ft,
     dependencies = { "L3MON4D3/LuaSnip" },
     config = function()
@@ -64,7 +65,7 @@ return {
   },
   {
     "luc-tielen/telescope_hoogle",
-    optional = true,
+    enabled = function() return require("astrocore").is_available "telescope.nvim" end,
     ft = haskell_ft,
     dependencies = {
       { "nvim-telescope/telescope.nvim" },

--- a/lua/astrocommunity/pack/python/init.lua
+++ b/lua/astrocommunity/pack/python/init.lua
@@ -57,4 +57,13 @@ return {
       require("dap-python").setup(path, opts)
     end,
   },
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    dependencies = { "nvim-neotest/neotest-python" },
+    opts = function(_, opts)
+      if not opts.adapters then opts.adapters = {} end
+      table.insert(opts.adapters, require "neotest-python"(require("astrocore").plugin_opts "neotest-python"))
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -105,4 +105,13 @@ return {
       },
     },
   },
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    dependencies = { "rouge8/neotest-rust" },
+    opts = function(_, opts)
+      if not opts.adapters then opts.adapters = {} end
+      table.insert(opts.adapters, require "neotest-rust"(require("astrocore").plugin_opts "neotest-rust"))
+    end,
+  },
 }

--- a/lua/astrocommunity/test/neotest/init.lua
+++ b/lua/astrocommunity/test/neotest/init.lua
@@ -3,9 +3,6 @@ return {
     "nvim-neotest/neotest",
     ft = { "go", "rust", "python" },
     dependencies = {
-      "nvim-neotest/neotest-go",
-      "nvim-neotest/neotest-python",
-      "rouge8/neotest-rust",
       {
         "folke/neodev.nvim",
         opts = function(_, opts)
@@ -17,19 +14,7 @@ return {
         end,
       },
     },
-    opts = function()
-      return {
-        -- your neotest config here
-        adapters = {
-          require "neotest-go",
-          require "neotest-rust",
-          require "neotest-python",
-        },
-      }
-    end,
     config = function(_, opts)
-      -- get neotest namespace (api call creates or returns namespace)
-      local neotest_ns = vim.api.nvim_create_namespace "neotest"
       vim.diagnostic.config({
         virtual_text = {
           format = function(diagnostic)
@@ -37,7 +22,7 @@ return {
             return message
           end,
         },
-      }, neotest_ns)
+      }, vim.api.nvim_create_namespace "neotest")
       require("neotest").setup(opts)
     end,
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The current setup for neotest chooses a random selection of neotest adapters and installs them. This moves that setup to language packs instead to make it a bit more intelligent to the user's needs. It also allows the user to use the `opts` table in the adapters to configure the adapters easily from a user configuration.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
