### PR TITLE
feat(pack): add `blade` pack for Laravel Blade support

### DIFF
--- a/lua/astrocommunity/pack/blade/README.md
+++ b/lua/astrocommunity/pack/blade/README.md
@@ -1,0 +1,11 @@
+# Laravel Blade Language Pack
+
+Requires:
+
+- `laravel-dev-generators` in your path
+
+This plugin pack does the following:
+
+- Adds `blade` Treesitter parser: <https://github.com/EmranMR/tree-sitter-blade>
+- Adds `blade` language server: <https://github.com/haringsrob/laravel-dev-tools>
+- Adds [blade-formatter](https://github.com/shufo/blade-formatter) to `null-ls` or `conform`

--- a/lua/astrocommunity/pack/blade/init.lua
+++ b/lua/astrocommunity/pack/blade/init.lua
@@ -1,0 +1,57 @@
+vim.filetype.add {
+  pattern = {
+    [".*.php.blade"] = "blade",
+  },
+}
+
+return {
+  {
+    "AstroNvim/astrolsp",
+    ---@param opts AstroLSPOpts
+    opts = function(_, opts)
+      opts.config.blade = {
+        cmd = { "laravel-dev-generators", "lsp" },
+        filetypes = { "blade" },
+        root_dir = function(fname) return require("lspconfig").util.find_git_ancestor(fname) end,
+      }
+
+      if vim.fn.executable "laravel-dev-generators" == 1 then
+        opts.servers = require("astrocore").list_insert_unique(opts.servers, "blade")
+      end
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter",
+    optional = true,
+    opts = function(_, opts)
+      local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+
+      parser_config.blade = {
+        install_info = {
+          url = "https://github.com/EmranMR/tree-sitter-blade",
+          files = { "src/parser.c" },
+          branch = "main",
+        },
+        filetype = "blade",
+      }
+
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "blade")
+    end,
+  },
+  {
+    "jay-babu/mason-null-ls.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "blade_formatter")
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        blade = { "blade-formatter" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This adds a language pack for Laravel Blade. Targeted for AstroNvim v4 just because it does use a custom language server. We could make a pack in v3 that just provides the nnull-ls and treesitter, but seems like most of the benefit would come from the LSP.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
