### PR TITLE
refactor(comment): update mini.comment using custom_commentstring

### DIFF
--- a/lua/astrocommunity/comment/mini-comment/init.lua
+++ b/lua/astrocommunity/comment/mini-comment/init.lua
@@ -2,8 +2,8 @@ return {
   { "numToStr/Comment.nvim", enabled = false },
   {
     "echasnovski/mini.comment",
-    event = "User AstroFile",
     dependencies = { "JoosepAlviste/nvim-ts-context-commentstring", opts = { enable_autocmd = false } },
+    event = "User AstroFile",
     opts = {
       custom_commentstring = function()
         return require("ts_context_commentstring").calculate_commentstring() or vim.bo.commentstring

--- a/lua/astrocommunity/comment/mini-comment/init.lua
+++ b/lua/astrocommunity/comment/mini-comment/init.lua
@@ -2,12 +2,12 @@ return {
   { "numToStr/Comment.nvim", enabled = false },
   {
     "echasnovski/mini.comment",
-    dependencies = { "JoosepAlviste/nvim-ts-context-commentstring" },
-    event = "User AstroFile",
+    event = "BufReadPost",
+    dependencies = { "JoosepAlviste/nvim-ts-context-commentstring", opts = { enable_autocmd = false } },
     opts = {
-      hooks = {
-        pre = function() require("ts_context_commentstring.internal").update_commentstring {} end,
-      },
+      custom_commentstring = function()
+        return require("ts_context_commentstring").calculate_commentstring() or vim.bo.commentstring
+      end,
     },
   },
   {

--- a/lua/astrocommunity/comment/mini-comment/init.lua
+++ b/lua/astrocommunity/comment/mini-comment/init.lua
@@ -2,7 +2,7 @@ return {
   { "numToStr/Comment.nvim", enabled = false },
   {
     "echasnovski/mini.comment",
-    event = "BufReadPost",
+    event = "User AstroFile",
     dependencies = { "JoosepAlviste/nvim-ts-context-commentstring", opts = { enable_autocmd = false } },
     opts = {
       custom_commentstring = function()


### PR DESCRIPTION
## 📑 Description

While the pre-hook appears to work, `custom_commentstring` is recommended: <https://github.com/JoosepAlviste/nvim-ts-context-commentstring/wiki/Integrations#minicomment>

From the recommended configuration, the `autocmd` should also be turned off