### PR TITLE
fix(pack): use lsp_opts to get server config for typescript

### DIFF
--- a/lua/astrocommunity/pack/typescript-all-in-one/init.lua
+++ b/lua/astrocommunity/pack/typescript-all-in-one/init.lua
@@ -26,7 +26,7 @@ return {
           end
         end,
       })
-      opts.server = require("astrolsp").config "denols"
+      opts.server = require("astrolsp").lsp_opts "denols"
       opts.server.root_dir = require("lspconfig.util").root_pattern("deno.json", "deno.jsonc")
     end,
   },

--- a/lua/astrocommunity/pack/typescript-deno/init.lua
+++ b/lua/astrocommunity/pack/typescript-deno/init.lua
@@ -35,6 +35,6 @@ return {
   {
     "sigmasd/deno-nvim",
     ft = { "javascript", "typescript", "javascriptreact", "typescriptreact" },
-    opts = function() return { server = require("astrolsp").config "denols" } end,
+    opts = function() return { server = require("astrolsp").lsp_opts "denols" } end,
   },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The typescript packs `all-in-one` and `deno` use an incorrect method to get lsp options from AstroLsp. This PR updates them to use the `lsp_opts` method to get the server configuration.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
