### PR TITLE
feat(media): add image.nvim

### DIFF
--- a/lua/astrocommunity/media/image-nvim/README.md
+++ b/lua/astrocommunity/media/image-nvim/README.md
@@ -15,6 +15,7 @@ These are things you have to setup on your own
 
 * ImageMagick - **mandatory**
 * magick LuaRock - **mandatory** (luarocks --local --lua-version=5.1 install magick)
+    - Magick LuaRock requires Lua 5.1 
 * Kitty >= 28.0 - for the kitty backend
 * ueberzugpp - for the ueberzug backend
 * curl - for remote images

--- a/lua/astrocommunity/media/image-nvim/README.md
+++ b/lua/astrocommunity/media/image-nvim/README.md
@@ -1,0 +1,22 @@
+# image.nvim
+
+This plugin attempts to add image support to Neovim.
+
+**Repository:** <https://github.com/3rd/image.nvim>
+
+Works with Kitty + Tmux, and it handles painful things like rendering an image at a given position in a buffer, scrolling, windows, etc.
+
+It has built-in Markdown and Neorg integrations that you can use right now.
+It can also render image files as images when opened.
+
+**Requirements**
+
+These are things you have to setup on your own
+
+* ImageMagick - **mandatory**
+* magick LuaRock - **mandatory** (luarocks --local --lua-version=5.1 install magick)
+* Kitty >= 28.0 - for the kitty backend
+* ueberzugpp - for the ueberzug backend
+* curl - for remote images
+
+**This plugin is configured to be used with kitty terminal and lua 5.1**

--- a/lua/astrocommunity/media/image-nvim/init.lua
+++ b/lua/astrocommunity/media/image-nvim/init.lua
@@ -1,0 +1,44 @@
+package.path = package.path .. ";" .. vim.fn.expand "$HOME" .. "/.luarocks/share/lua/5.1/?/init.lua;"
+package.path = package.path .. ";" .. vim.fn.expand "$HOME" .. "/.luarocks/share/lua/5.1/?.lua;"
+
+return {
+  "3rd/image.nvim",
+  event = "VeryLazy",
+  dependencies = {
+    {
+      "nvim-treesitter/nvim-treesitter",
+      build = ":TSUpdate",
+      config = function()
+        require("nvim-treesitter.configs").setup {
+          ensure_installed = { "markdown" },
+          highlight = { enable = true },
+        }
+      end,
+    },
+  },
+  opts = {
+    backend = "kitty",
+    integrations = {
+      markdown = {
+        enabled = true,
+        clear_in_insert_mode = false,
+        download_remote_images = true,
+        only_render_image_at_cursor = false,
+        filetypes = { "markdown", "vimwiki" }, -- markdown extensions (ie. quarto) can go here
+      },
+      neorg = {
+        enabled = true,
+        clear_in_insert_mode = false,
+        download_remote_images = true,
+        only_render_image_at_cursor = false,
+        filetypes = { "norg" },
+      },
+    },
+    max_width = nil,
+    max_height = nil,
+    max_width_window_percentage = nil,
+    max_height_window_percentage = 50,
+    kitty_method = "normal",
+    hijack_file_patterns = { "*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp" }, -- render image files as images when opened
+  },
+}


### PR DESCRIPTION
I recently came across this nvim plugin:
https://github.com/3rd/image.nvim

Which can display images in astronvim via kittys image protocol, which is neat!
Works very well and also prevents astronvim from crashing when opening images :).

It has some requirements, so it does not work out of the box though.
I have only tested it with kitty.

Happy to discuss it or change something if it seems wrong.