### PR TITLE
feat(angular): Migrate to built-in treesitter

### DIFF
--- a/lua/astrocommunity/pack/angular/init.lua
+++ b/lua/astrocommunity/pack/angular/init.lua
@@ -5,7 +5,6 @@ return {
   { import = "astrocommunity.pack.html-css" },
   {
     "nvim-treesitter/nvim-treesitter",
-    dependencies = { { "elgiano/nvim-treesitter-angular", branch = "topic/jsx-fix" } },
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "angular")


### PR DESCRIPTION
https://github.com/nvim-treesitter/nvim-treesitter-angular is deprecated (and archived) since Angular support is included in `nvim-treesitter` itself.

Without this fix, currently running `:TSUpdate angular` fails with:

```
nvim-treesitter[angular]: Error during tarball extraction.                                                                                                                                     
tar: Error opening archive: Unrecognized archive format  
``` 

It almost seems unrelated, but it is https://github.com/nvim-treesitter/nvim-treesitter/issues/5246
