### PR TITLE
fix(pack): disable `go.nvim` defaults to prevent conflicts

### DIFF
--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -64,12 +64,18 @@ return {
     opts = {},
   },
   {
-    "olexsmir/gopher.nvim",
-    dependencies = { -- dependencies
-      "nvim-lua/plenary.nvim",
+    "ray-x/go.nvim",
+    dependencies = {
+      "ray-x/guihua.lua",
+      "neovim/nvim-lspconfig",
       "nvim-treesitter/nvim-treesitter",
     },
-    build = ":GoInstallDeps",
+    opts = {
+      disable_defaults = true,
+    },
+    event = { "CmdlineEnter" },
+    ft = { "go", "gomod" },
+    build = ':lua require("go.install").update_all_sync()',
   },
   {
     "nvim-neotest/neotest",

--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -64,16 +64,12 @@ return {
     opts = {},
   },
   {
-    "ray-x/go.nvim",
-    dependencies = {
-      "ray-x/guihua.lua",
-      "neovim/nvim-lspconfig",
+    "olexsmir/gopher.nvim",
+    dependencies = { -- dependencies
+      "nvim-lua/plenary.nvim",
       "nvim-treesitter/nvim-treesitter",
     },
-    opts = {},
-    event = { "CmdlineEnter" },
-    ft = { "go", "gomod" },
-    build = ':lua require("go.install").update_all_sync()',
+    build = ":GoInstallDeps",
   },
   {
     "nvim-neotest/neotest",


### PR DESCRIPTION
This replace `x-ray/go.nvim` with a much more simpler alternative `olexsmir/gopher.nvim`.