### PR TITLE
docs(hop-nvim): Point repo URL to correct repository

### DIFF
--- a/lua/astrocommunity/motion/hop-nvim/README.md
+++ b/lua/astrocommunity/motion/hop-nvim/README.md
@@ -2,6 +2,6 @@
 
 Neovim motions on speed!
 
-**Repository:** <https://github.com/phaazon/hop.nvim>
+**Repository:** <https://github.com/smoka7/hop.nvim>
 
 Hop is an EasyMotion-like plugin allowing you to jump anywhere in a document with as few keystrokes as possible. It does so by annotating text in your buffer with hints, short string sequences for which each character represents a key to type to jump to the annotated text. Most of the time, those sequences’ lengths will be between 1 to 3 characters, making every jump target in your document reachable in a few keystrokes.


### PR DESCRIPTION
## 📑 Description

The init.lua file has been updated to point to the fork by smoka7, but the README still points to the original.