### PR TITLE
fix(diffview-nvim): use diffview winbar and disable view activation

### DIFF
--- a/lua/astrocommunity/git/diffview-nvim/init.lua
+++ b/lua/astrocommunity/git/diffview-nvim/init.lua
@@ -3,6 +3,14 @@ return {
     "sindrets/diffview.nvim",
     event = "User AstroGitFile",
     cmd = { "DiffviewOpen" },
+    opts = {
+      enhanced_diff_hl = true,
+      view = {
+        default = { winbar_info = true },
+        file_history = { winbar_info = true },
+      },
+      hooks = { diff_buf_read = function(bufnr) vim.b[bufnr].view_activated = false end },
+    },
   },
   {
     "NeogitOrg/neogit",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This fixes an issue where the default AstroNvim `winbar` causes rows to be misaligned. This also disables the default view activation so that AstroNvim doesn't try to restore cursor position and fold state when entering buffers.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
