### PR TITLE
chore(mini-surround): remove disabling of vim-sandwich

### DIFF
--- a/lua/astrocommunity/motion/mini-surround/init.lua
+++ b/lua/astrocommunity/motion/mini-surround/init.lua
@@ -4,7 +4,6 @@ local icon = vim.g.icons_enabled and "󰑤 " or ""
 maps.n[prefix] = { desc = icon .. "Surround" }
 require("astronvim.utils").set_mappings(maps)
 return {
-  { "machakann/vim-sandwich", enabled = false },
   {
     "echasnovski/mini.surround",
     keys = function(plugin, keys)


### PR DESCRIPTION
Non-core plugins shouldn't be disabled. Someone would have to explicitly add both plugins to encounter any issues.