### PR TITLE
Allow `conform.nvim` and `nvim-lint` to work alongside `mason-null-ls`

### DIFF
--- a/lua/astrocommunity/editing-support/conform-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/conform-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   { "AstroNvim/astrolsp", opts = { formatting = { disabled = true } } },
+  { "jay-babu/mason-null-ls.nvim", optional = true, opts = { methods = { formatting = false } } },
   {
     "stevearc/conform.nvim",
     event = "User AstroFile",

--- a/lua/astrocommunity/lsp/nvim-lint/init.lua
+++ b/lua/astrocommunity/lsp/nvim-lint/init.lua
@@ -1,51 +1,54 @@
 ---@type LazySpec
 return {
-  "mfussenegger/nvim-lint",
-  event = "User AstroFile",
-  dependencies = { "williamboman/mason.nvim" },
-  opts = {},
-  config = function(_, opts)
-    local lint = require "lint"
+  { "jay-babu/mason-null-ls.nvim", optional = true, opts = { methods = { diagnostics = false } } },
+  {
+    "mfussenegger/nvim-lint",
+    event = "User AstroFile",
+    dependencies = { "williamboman/mason.nvim" },
+    opts = {},
+    config = function(_, opts)
+      local lint = require "lint"
 
-    lint.linters_by_ft = opts.linters_by_ft or {}
-    for name, linter in pairs(opts.linters or {}) do
-      local base = lint.linters[name]
-      lint.linters[name] = (type(linter) == "table" and type(base) == "table")
-          and vim.tbl_deep_extend("force", base, linter)
-        or linter
-    end
+      lint.linters_by_ft = opts.linters_by_ft or {}
+      for name, linter in pairs(opts.linters or {}) do
+        local base = lint.linters[name]
+        lint.linters[name] = (type(linter) == "table" and type(base) == "table")
+            and vim.tbl_deep_extend("force", base, linter)
+          or linter
+      end
 
-    local function try_lint()
-      local names = lint._resolve_linter_by_ft(vim.bo.filetype)
+      local function try_lint()
+        local names = lint._resolve_linter_by_ft(vim.bo.filetype)
 
-      -- Add fallback linters and global linters.
-      if #names == 0 then names = lint.linters_by_ft["_"] or {} end
-      vim.list_extend(names, lint.linters_by_ft["*"] or {})
+        -- Add fallback linters and global linters.
+        if #names == 0 then names = lint.linters_by_ft["_"] or {} end
+        vim.list_extend(names, lint.linters_by_ft["*"] or {})
 
-      -- Filter out linters that don't exist or don't match the condition.
-      local ctx = { filename = vim.api.nvim_buf_get_name(0) }
-      ctx.dirname = vim.fn.fnamemodify(ctx.filename, ":h")
-      names = vim.tbl_filter(function(name)
-        local linter = lint.linters[name]
-        return linter
-          and vim.fn.executable(linter.cmd) == 1
-          and not (type(linter) == "table" and linter.condition and not linter.condition(ctx))
-      end, names)
+        -- Filter out linters that don't exist or don't match the condition.
+        local ctx = { filename = vim.api.nvim_buf_get_name(0) }
+        ctx.dirname = vim.fn.fnamemodify(ctx.filename, ":h")
+        names = vim.tbl_filter(function(name)
+          local linter = lint.linters[name]
+          return linter
+            and vim.fn.executable(linter.cmd) == 1
+            and not (type(linter) == "table" and linter.condition and not linter.condition(ctx))
+        end, names)
 
-      lint.try_lint(names)
-    end
+        lint.try_lint(names)
+      end
 
-    try_lint() -- start linter immediately
-    local timer = vim.loop.new_timer()
-    vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave", "TextChanged" }, {
-      group = vim.api.nvim_create_augroup("auto_lint", { clear = true }),
-      desc = "Automatically try linting",
-      callback = function()
-        timer:start(100, 0, function()
-          timer:stop()
-          vim.schedule(try_lint)
-        end)
-      end,
-    })
-  end,
+      try_lint() -- start linter immediately
+      local timer = vim.loop.new_timer()
+      vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave", "TextChanged" }, {
+        group = vim.api.nvim_create_augroup("auto_lint", { clear = true }),
+        desc = "Automatically try linting",
+        callback = function()
+          timer:start(100, 0, function()
+            timer:stop()
+            vim.schedule(try_lint)
+          end)
+        end,
+      })
+    end,
+  },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This makes `conform.nvim` and `nvim-lint` play nicely with `null-ls` without having to fully disable it.

### Waiting On:

- [x] #753
- [x] https://github.com/jay-babu/mason-null-ls.nvim/pull/94

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
