### PR TITLE
Add Mason tool installer configuration across all pack

### DIFF
--- a/lua/astrocommunity/pack/angular/init.lua
+++ b/lua/astrocommunity/pack/angular/init.lua
@@ -18,4 +18,11 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "angularls")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "angular-language-server")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/ansible/init.lua
+++ b/lua/astrocommunity/pack/ansible/init.lua
@@ -8,6 +8,14 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "ansible-lint", "ansible-language-server")
+    end,
+  },
+  {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)

--- a/lua/astrocommunity/pack/astro/init.lua
+++ b/lua/astrocommunity/pack/astro/init.lua
@@ -23,4 +23,12 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "js")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "astro-language-server", "js-debug-adapter")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/bash/init.lua
+++ b/lua/astrocommunity/pack/bash/init.lua
@@ -9,6 +9,19 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        "bash-language-server",
+        "shellcheck",
+        "shfmt",
+        "bash-debug-adapter"
+      )
+    end,
+  },
+  {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)

--- a/lua/astrocommunity/pack/blade/init.lua
+++ b/lua/astrocommunity/pack/blade/init.lua
@@ -46,6 +46,13 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "blade-formatter")
+    end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/clojure/init.lua
+++ b/lua/astrocommunity/pack/clojure/init.lua
@@ -8,6 +8,13 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "clojure_lsp")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "clojure-lsp")
+    end,
+  },
   -- Clojure parser
   {
     "nvim-treesitter/nvim-treesitter",

--- a/lua/astrocommunity/pack/cmake/init.lua
+++ b/lua/astrocommunity/pack/cmake/init.lua
@@ -15,4 +15,11 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "neocmake")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "neocmakelsp")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/cpp/init.lua
+++ b/lua/astrocommunity/pack/cpp/init.lua
@@ -60,4 +60,11 @@ return {
     },
     opts = {},
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "clangd", "codelldb")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/crystal/init.lua
+++ b/lua/astrocommunity/pack/crystal/init.lua
@@ -17,4 +17,11 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "codelldb")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "crystalline", "codelldb")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/cs/init.lua
+++ b/lua/astrocommunity/pack/cs/init.lua
@@ -30,4 +30,16 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "coreclr")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        "csharp-language-server",
+        "csharpier",
+        "netcoredbg"
+      )
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/cue/init.lua
+++ b/lua/astrocommunity/pack/cue/init.lua
@@ -24,4 +24,11 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "dagger")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "cuelsp", "cueimports")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/dart/init.lua
+++ b/lua/astrocommunity/pack/dart/init.lua
@@ -35,6 +35,13 @@ return {
           opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "dart")
         end,
       },
+      {
+        "WhoIsSethDaniel/mason-tool-installer.nvim",
+        optional = true,
+        opts = function(_, opts)
+          opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "dart-debug-adapter")
+        end,
+      },
     },
   },
   -- Add "flutter" extension to "telescope"

--- a/lua/astrocommunity/pack/docker/init.lua
+++ b/lua/astrocommunity/pack/docker/init.lua
@@ -30,6 +30,18 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        "docker-compose-language-service",
+        "dockerfile-language-server",
+        "hadolint"
+      )
+    end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/elm/init.lua
+++ b/lua/astrocommunity/pack/elm/init.lua
@@ -20,6 +20,14 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "elm-language-server", "elm-format")
+    end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/gleam/init.lua
+++ b/lua/astrocommunity/pack/gleam/init.lua
@@ -13,4 +13,11 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "gleam")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "gleam")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -49,12 +49,34 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        "gopls",
+        "gomodifytags",
+        "gofumpt",
+        "iferr",
+        "impl",
+        "goimports"
+      )
+    end,
+  },
+  {
     "leoluz/nvim-dap-go",
     ft = "go",
     dependencies = {
       "mfussenegger/nvim-dap",
       {
         "jay-babu/mason-nvim-dap.nvim",
+        optional = true,
+        opts = function(_, opts)
+          opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "delve")
+        end,
+      },
+      {
+        "WhoIsSethDaniel/mason-tool-installer.nvim",
         optional = true,
         opts = function(_, opts)
           opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "delve")

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -54,6 +54,17 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        "haskell-debug-adapter",
+        "haskell-language-server"
+      )
+    end,
+  },
+  {
     "mrcjkb/haskell-snippets.nvim",
     enabled = function() return require("astrocore").is_available "LuaSnip" end,
     ft = haskell_ft,

--- a/lua/astrocommunity/pack/helm/init.lua
+++ b/lua/astrocommunity/pack/helm/init.lua
@@ -24,25 +24,13 @@ return {
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "helm_ls")
-
-      local configs = require "lspconfig.configs"
-      local lspconfig = require "lspconfig"
-      local util = require "lspconfig.util"
-
-      if not configs.helm_ls then
-        configs.helm_ls = {
-          default_config = {
-            cmd = { "helm_ls", "serve" },
-            filetypes = { "helm" },
-            root_dir = function(fname) return util.root_pattern "Chart.yaml"(fname) end,
-          },
-        }
-      end
-
-      lspconfig.helm_ls.setup {
-        filetypes = { "helm" },
-        cmd = { "helm_ls", "serve" },
-      }
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "helm-ls")
     end,
   },
   {

--- a/lua/astrocommunity/pack/html-css/init.lua
+++ b/lua/astrocommunity/pack/html-css/init.lua
@@ -25,6 +25,14 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "html-lsp", "css-lsp", "emmet-ls", "prettierd")
+    end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/java/init.lua
+++ b/lua/astrocommunity/pack/java/init.lua
@@ -15,7 +15,6 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "jdtls", "lemminx")
     end,
   },
-
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
@@ -23,7 +22,6 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "clang_format")
     end,
   },
-
   {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
@@ -31,7 +29,20 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "javadbg", "javatest")
     end,
   },
-
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        "jdtls",
+        "lemminx",
+        "clang-format",
+        "java-debug-adapter",
+        "java-test"
+      )
+    end,
+  },
   {
     "mfussenegger/nvim-jdtls",
     ft = { "java" },

--- a/lua/astrocommunity/pack/json/init.lua
+++ b/lua/astrocommunity/pack/json/init.lua
@@ -37,4 +37,11 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "jsonls")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "json-lsp")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/julia/init.lua
+++ b/lua/astrocommunity/pack/julia/init.lua
@@ -17,6 +17,13 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "julia-lsp")
+    end,
+  },
+  {
     "hrsh7th/nvim-cmp",
     optional = true,
     -- add cmp latex symbols for easier julia editing

--- a/lua/astrocommunity/pack/kotlin/init.lua
+++ b/lua/astrocommunity/pack/kotlin/init.lua
@@ -32,6 +32,18 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        "kotlin-language-server",
+        "ktlint",
+        "kotlin-debug-adapter"
+      )
+    end,
+  },
+  {
     "mfussenegger/nvim-lint",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/lua/init.lua
+++ b/lua/astrocommunity/pack/lua/init.lua
@@ -31,6 +31,14 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "lua-language-server", "stylua", "luacheck")
+    end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/markdown/init.lua
+++ b/lua/astrocommunity/pack/markdown/init.lua
@@ -24,6 +24,13 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "marksman", "prettierd")
+    end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/nim/init.lua
+++ b/lua/astrocommunity/pack/nim/init.lua
@@ -15,9 +15,10 @@ return {
     end,
   },
   {
-    "jay-babu/mason-null-ls.nvim",
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "nimpretty")
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "nimlangserver")
     end,
   },
 }

--- a/lua/astrocommunity/pack/nix/init.lua
+++ b/lua/astrocommunity/pack/nix/init.lua
@@ -16,6 +16,13 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "rnix-lsp")
+    end,
+  },
+  {
     "nvimtools/none-ls.nvim",
     optional = true,
     opts = function(_, opts)

--- a/lua/astrocommunity/pack/php/init.lua
+++ b/lua/astrocommunity/pack/php/init.lua
@@ -30,6 +30,14 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "phpactor", "php-debug-adapter", "php-cs-fixer")
+    end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/prisma/init.lua
+++ b/lua/astrocommunity/pack/prisma/init.lua
@@ -15,4 +15,11 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "prismals")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "prisma-language-server")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/proto/init.lua
+++ b/lua/astrocommunity/pack/proto/init.lua
@@ -24,6 +24,14 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "buf-language-server", "buf")
+    end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/ps1/init.lua
+++ b/lua/astrocommunity/pack/ps1/init.lua
@@ -6,5 +6,13 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "powershell_es")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "powershell-editor-services")
+    end,
+  },
   { "PProvost/vim-ps1", ft = "ps1" },
 }

--- a/lua/astrocommunity/pack/python-ruff/init.lua
+++ b/lua/astrocommunity/pack/python-ruff/init.lua
@@ -19,6 +19,17 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "ruff-lsp", "ruff")
+      opts.ensure_installed = vim.tbl_filter(
+        function(v) return not vim.tbl_contains({ "black", "isort" }, v) end,
+        opts.ensure_installed
+      )
+    end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/python/init.lua
+++ b/lua/astrocommunity/pack/python/init.lua
@@ -44,6 +44,14 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "pyright", "black", "isort", "debugpy")
+    end,
+  },
+  {
     "linux-cultist/venv-selector.nvim",
     dependencies = {
       {

--- a/lua/astrocommunity/pack/ruby/init.lua
+++ b/lua/astrocommunity/pack/ruby/init.lua
@@ -23,6 +23,13 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "solargraph", "standardrb")
+    end,
+  },
+  {
     "mfussenegger/nvim-dap",
     optional = true,
     dependencies = { "suketa/nvim-dap-ruby", config = true },

--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -51,6 +51,13 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "codelldb")
+    end,
+  },
+  {
     "mrcjkb/rustaceanvim",
     version = "^3",
     ft = "rust",

--- a/lua/astrocommunity/pack/svelte/init.lua
+++ b/lua/astrocommunity/pack/svelte/init.lua
@@ -22,4 +22,12 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "js")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "svelte-language-server", "js-debug-adapter")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/swift/init.lua
+++ b/lua/astrocommunity/pack/swift/init.lua
@@ -16,6 +16,13 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "codelldb")
+    end,
+  },
+  {
     "AstroNvim/astrolsp",
     ---@type AstroLSPOpts
     opts = {

--- a/lua/astrocommunity/pack/tailwindcss/init.lua
+++ b/lua/astrocommunity/pack/tailwindcss/init.lua
@@ -8,6 +8,14 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "tailwindcss-language-server")
+    end,
+  },
+  {
     "hrsh7th/nvim-cmp",
     optional = true,
     dependencies = {

--- a/lua/astrocommunity/pack/terraform/init.lua
+++ b/lua/astrocommunity/pack/terraform/init.lua
@@ -19,8 +19,15 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "tflint", "tfsec")
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
       opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, "tflint", "tfsec", "terraform_fmt")
+        require("astrocore").list_insert_unique(opts.ensure_installed, "terraform-ls", "tflint", "tfsec")
     end,
   },
   {

--- a/lua/astrocommunity/pack/thrift/init.lua
+++ b/lua/astrocommunity/pack/thrift/init.lua
@@ -16,4 +16,11 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "thriftls")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "thriftls")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/toml/init.lua
+++ b/lua/astrocommunity/pack/toml/init.lua
@@ -25,4 +25,11 @@ return {
       opts.handlers.taplo = function() end
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "taplo")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/typescript-deno/init.lua
+++ b/lua/astrocommunity/pack/typescript-deno/init.lua
@@ -33,6 +33,13 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "deno", "js-debug-adapter")
+    end,
+  },
+  {
     "sigmasd/deno-nvim",
     ft = { "javascript", "typescript", "javascriptreact", "typescriptreact" },
     opts = function() return { server = require("astrolsp").lsp_opts "denols" } end,

--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -75,6 +75,19 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        "typescript-language-server",
+        "eslint-lsp",
+        "prettierd",
+        "js-debug-adapter"
+      )
+    end,
+  },
+  {
     "vuki656/package-info.nvim",
     dependencies = { "MunifTanjim/nui.nvim" },
     opts = {},

--- a/lua/astrocommunity/pack/typst/init.lua
+++ b/lua/astrocommunity/pack/typst/init.lua
@@ -6,4 +6,11 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "typst_lsp")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "typst-lsp")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/vue/init.lua
+++ b/lua/astrocommunity/pack/vue/init.lua
@@ -22,4 +22,12 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "js")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "vue-language-sever", "js-debug-adapter")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/wgsl/init.lua
+++ b/lua/astrocommunity/pack/wgsl/init.lua
@@ -13,4 +13,11 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "wgsl_analyzer")
     end,
   },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "wgsl-analyzer")
+    end,
+  },
 }

--- a/lua/astrocommunity/pack/yaml/init.lua
+++ b/lua/astrocommunity/pack/yaml/init.lua
@@ -47,6 +47,14 @@ return {
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed =
+        require("astrocore").list_insert_unique(opts.ensure_installed, "yaml-language-server", "prettierd")
+    end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/zig/init.lua
+++ b/lua/astrocommunity/pack/zig/init.lua
@@ -15,7 +15,13 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "zls")
     end,
   },
-
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, "zls")
+    end,
+  },
   {
     "https://codeberg.org/NTBBloodbath/zig-tools.nvim",
     -- Load zig-tools.nvim only in Zig buffers

--- a/lua/astrocommunity/utility/mason-tool-installer-nvim/init.lua
+++ b/lua/astrocommunity/utility/mason-tool-installer-nvim/init.lua
@@ -20,6 +20,15 @@ return {
       end
       for _, plugin in ipairs { "mason-nvim-dap.nvim", "mason-lspconfig.nvim", "mason-null-ls.nvim" } do
         for _, target in ipairs(require("astrocore").plugin_opts(plugin).ensure_installed or {}) do
+          local mappings
+          if plugin == "mason-lspconfig.nvim" then
+            mappings = require("mason-lspconfig.mappings.server").lspconfig_to_package
+          elseif plugin == "mason-null-ls.nvim" then
+            mappings = require("mason-null-ls.mappings.source").null_ls_to_package
+          elseif plugin == "mason-nvim-dap.nvim" then
+            mappings = require("mason-nvim-dap.mappings.source").nvim_dap_to_package
+          end
+          if mappings and mappings[target] then target = mappings[target] end
           if not target_lookup[target] then table.insert(opts.ensure_installed, target) end
         end
       end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

If a user decides to disable other mason installation plugins and just use `mason-tool-installer.nvim` the packs should still work.

This also fixes a bug in the mason-tool-installer integration with the other mason plugins where it needs to map names to actual mason packages.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
