### PR TITLE
Update init.lua

### DIFF
--- a/lua/astrocommunity/pack/dart/init.lua
+++ b/lua/astrocommunity/pack/dart/init.lua
@@ -3,6 +3,7 @@ return {
   { import = "astrocommunity.pack.yaml" },
   {
     "nvim-treesitter/nvim-treesitter",
+    commit = "f2778bd1a28b74adf5b1aa51aa57da85adfa3d16",
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "dart")


### PR DESCRIPTION
Currently, there is an issue with treesitter for Dart, which makes it extremely slow on basic editing tasks (like inserting new line takes 1 second on my M3 Pro).

The issue is tracked here: https://github.com/nvim-treesitter/nvim-treesitter/issues/4945

One of the proposed solutions in the comments that worked for me is to use a latest working version of treesitter: https://github.com/nvim-treesitter/nvim-treesitter/issues/4945#issuecomment-1691168369

Until this is fixed, I propose to switch this pack to use working version as per the comment above.