### PR TITLE
fix(neogit): set correct neogit menu entry in which-key

### DIFF
--- a/lua/astrocommunity/git/neogit/init.lua
+++ b/lua/astrocommunity/git/neogit/init.lua
@@ -9,7 +9,7 @@ return {
         opts = function(_, opts)
           local maps = opts.mappings
           local prefix = "<Leader>g"
-          maps.n[prefix] = { desc = require("astroui").get_icon("Neogit", 1, true) .. "Neogit" }
+          maps.n[prefix .. "n"] = { desc = require("astroui").get_icon("Neogit", 1, true) .. "Neogit" }
           maps.n[prefix .. "nt"] = { "<CMD>Neogit<CR>", desc = "Open Neogit Tab Page" }
           maps.n[prefix .. "nc"] = { "<CMD>Neogit commit<CR>", desc = "Open Neogit Commit Page" }
           maps.n[prefix .. "nd"] = { ":Neogit cwd=", desc = "Open Neogit Override CWD" }


### PR DESCRIPTION
## 📑 Description

The entry for neogit in which-key was off, the main git menu entry was overwritten and no icon/description was set for the neogit sub-menu. Simple fix by modifying key mappings.
