### PR TITLE
fix(pack): replace deprecated none-ls builtins

### DIFF
--- a/lua/astrocommunity/pack/bash/README.md
+++ b/lua/astrocommunity/pack/bash/README.md
@@ -5,5 +5,5 @@ This plugin pack does the following:
 - Adds `bash` Treesitter parser
 - Adds `bashls` language server
 - Adds `shfmt` formatter
-- Adds `shellcheck` linter
+- Adds `bashls` linter
 - Adds `bash` debugger

--- a/lua/astrocommunity/pack/bash/README.md
+++ b/lua/astrocommunity/pack/bash/README.md
@@ -5,5 +5,4 @@ This plugin pack does the following:
 - Adds `bash` Treesitter parser
 - Adds `bashls` language server
 - Adds `shfmt` formatter
-- Adds `bashls` linter
 - Adds `bash` debugger

--- a/lua/astrocommunity/pack/bash/init.lua
+++ b/lua/astrocommunity/pack/bash/init.lua
@@ -29,7 +29,7 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "bashls", "shfmt" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "shfmt" })
     end,
   },
   {
@@ -45,15 +45,6 @@ return {
     opts = {
       formatters_by_ft = {
         sh = { "shfmt" },
-      },
-    },
-  },
-  {
-    "mfussenegger/nvim-lint",
-    optional = true,
-    opts = {
-      linters_by_ft = {
-        sh = { "bashls" },
       },
     },
   },

--- a/lua/astrocommunity/pack/bash/init.lua
+++ b/lua/astrocommunity/pack/bash/init.lua
@@ -14,7 +14,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(
         opts.ensure_installed,
-        { "bash-language-server", "shellcheck", "shfmt", "bash-debug-adapter" }
+        { "bash-language-server", "bashls", "shfmt", "bash-debug-adapter" }
       )
     end,
   },
@@ -29,7 +29,7 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "shellcheck", "shfmt" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "bashls", "shfmt" })
     end,
   },
   {
@@ -53,7 +53,7 @@ return {
     optional = true,
     opts = {
       linters_by_ft = {
-        sh = { "shellcheck" },
+        sh = { "bashls" },
       },
     },
   },

--- a/lua/astrocommunity/pack/lua/README.md
+++ b/lua/astrocommunity/pack/lua/README.md
@@ -5,3 +5,4 @@ This plugin pack does the following:
 - Adds `lua` Treesitter parser
 - Adds `lua_ls` language server
 - Adds `stylua` formatter
+- Adds `selene` linter

--- a/lua/astrocommunity/pack/lua/init.lua
+++ b/lua/astrocommunity/pack/lua/init.lua
@@ -27,7 +27,7 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "stylua", "luacheck" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "stylua", "selene" })
     end,
   },
   {
@@ -35,7 +35,7 @@ return {
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "lua-language-server", "stylua", "luacheck" })
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "lua-language-server", "stylua", "selene" })
     end,
   },
   {
@@ -52,7 +52,7 @@ return {
     optional = true,
     opts = {
       linters_by_ft = {
-        lua = { "luacheck" },
+        lua = { "selene" },
       },
     },
   },

--- a/lua/astrocommunity/pack/python-ruff/init.lua
+++ b/lua/astrocommunity/pack/python-ruff/init.lua
@@ -11,7 +11,6 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ruff" })
       opts.ensure_installed = vim.tbl_filter(
         function(v) return not vim.tbl_contains({ "black", "isort" }, v) end,
         opts.ensure_installed
@@ -22,7 +21,7 @@ return {
     "WhoIsSethDaniel/mason-tool-installer.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ruff-lsp", "ruff" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ruff-lsp" })
       opts.ensure_installed = vim.tbl_filter(
         function(v) return not vim.tbl_contains({ "black", "isort" }, v) end,
         opts.ensure_installed

--- a/lua/astrocommunity/pack/python-ruff/init.lua
+++ b/lua/astrocommunity/pack/python-ruff/init.lua
@@ -31,10 +31,8 @@ return {
   {
     "stevearc/conform.nvim",
     optional = true,
-    opts = {
-      formatters_by_ft = {
-        python = { "ruff_format" },
-      },
-    },
+    opts = function(_, opts)
+      if opts.formatters_by_ft then opts.formatters_by_ft.python = nil end
+    end,
   },
 }

--- a/lua/astrocommunity/pack/quarto/init.lua
+++ b/lua/astrocommunity/pack/quarto/init.lua
@@ -13,25 +13,22 @@ return {
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = require("astrocore").list_insert_unique(
-          opts.ensure_installed,
-          {
-            "r",
-            "python",
-            "markdown",
-            "markdown_inline",
-            "julia",
-            "bash",
-            "yaml",
-            "lua",
-            "vim",
-            "query",
-            "vimdoc",
-            "latex",
-            "html",
-            "css",
-          }
-        )
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+          "r",
+          "python",
+          "markdown",
+          "markdown_inline",
+          "julia",
+          "bash",
+          "yaml",
+          "lua",
+          "vim",
+          "query",
+          "vimdoc",
+          "latex",
+          "html",
+          "css",
+        })
       end
     end,
   },

--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -42,8 +42,7 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "prettierd", "eslint-lsp" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "prettierd" })
       if not opts.handlers then opts.handlers = {} end
 
       local has_prettier = function(util)


### PR DESCRIPTION
## 📑 Description

I started getting deprecation warnings from `null-ls`. It seems `null-ls` wants to clean unmaintained builtins, see: https://github.com/nvimtools/none-ls.nvim/issues/58

This PR replaces some of the deprecated builtins with the suggested alternatives, but is by no means exhaustive. For example, I am not sure about `eslint`, as I don't use it.
