### PR TITLE
fix(markdown-preview-nvim): yarn istead of npm

### DIFF
--- a/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
@@ -1,5 +1,5 @@
 return {
-  "iamcco/markdown-preview.nvim",
-  build = "cd app && npm install",
-  ft = "markdown",
+    "iamcco/markdown-preview.nvim",
+    build = "cd app && yarn install",
+    ft = "markdown"
 }

--- a/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
@@ -1,5 +1,5 @@
 return {
-    "iamcco/markdown-preview.nvim",
-    build = "cd app && yarn install",
-    ft = "markdown"
+  "iamcco/markdown-preview.nvim",
+  build = "cd app && yarn install",
+  ft = "markdown"
 }

--- a/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
@@ -1,5 +1,5 @@
 return {
   "iamcco/markdown-preview.nvim",
   build = "cd app && yarn install",
-  ft = "markdown"
+  ft = "markdown",
 }


### PR DESCRIPTION
**Issue**

- iamcco/markdown-preview.nvim#616


## 📑 Description

In the process of updating (lazy sync), an error is provoked where it says markdown-preview.nvim is broken, this is caused by unstashed edit by npm in plugins cloned directory. This has been common problem which is caused **npm**. The actual issue can be found [here](https://github.com/iamcco/markdown-preview.nvim/issues/616).


## ℹ Additional Information

**Error:**
```
You have local changes in `/.../.local/share/nvim/lazy/markdown-preview.nvim`:
  * app/yarn.lock
Please remove them to update.
You can also press `x` to remove the plugin and then `I` to install it again.
```