### PR TITLE
feat(lsp): add `ts-error-translator.nvim` with nice lazy loading

### DIFF
--- a/lua/astrocommunity/lsp/ts-error-translator-nvim/README.md
+++ b/lua/astrocommunity/lsp/ts-error-translator-nvim/README.md
@@ -1,0 +1,5 @@
+# ts-error-translator.nvim
+
+A Neovim port of [Matt Pocock's ts-error-translator for VSCode](https://github.com/mattpocock/ts-error-translator) for turning messy and confusing TypeScript errors into plain English.
+
+**Repository:** <https://github.com/dmmulroy/ts-error-translator.nvim>

--- a/lua/astrocommunity/lsp/ts-error-translator-nvim/init.lua
+++ b/lua/astrocommunity/lsp/ts-error-translator-nvim/init.lua
@@ -1,0 +1,24 @@
+return {
+  -- TODO: move back to upstream after PR: https://github.com/dmmulroy/ts-error-translator.nvim/pull/18
+  -- "dmmulroy/ts-error-translator.nvim",
+  "mehalter/ts-error-translator.nvim",
+  branch = "reuse_existing_handler",
+  lazy = true,
+  dependencies = {
+    "AstroNvim/astrolsp",
+    ---@param opts AstroLSPOpts
+    opts = function(_, opts)
+      if not opts.lsp_handlers then opts.lsp_handlers = {} end
+      local event = "textDocument/publishDiagnostics"
+      local orig = opts.lsp_handlers[event] or vim.lsp.handlers[event]
+      opts.lsp_handlers[event] = function(err, result, ctx, config)
+        local client = vim.lsp.get_client_by_id(ctx.client_id)
+        if client and vim.tbl_contains({ "tsserver", "vtsls" }, client.name) then
+          require("ts-error-translator").translate_diagnostics(err, result, ctx, config)
+        end
+        orig(err, result, ctx, config)
+      end
+    end,
+  },
+  opts = { auto_override_publish_diagnostics = false },
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This adds the new [ts-error-translator.nvim](https://github.com/dmmulroy/ts-error-translator.nvim) plugin with some pretty nice lazy loading all the way up until a diagnostic message is published by a supported language server

- [x] Waiting on https://github.com/dmmulroy/ts-error-translator.nvim/pull/18

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
