### PR TITLE
feat(grapple-nvim): better keymaps + add nvim-web-devicons dependency

### DIFF
--- a/lua/astrocommunity/motion/grapple-nvim/init.lua
+++ b/lua/astrocommunity/motion/grapple-nvim/init.lua
@@ -5,14 +5,17 @@ maps.n[prefix] = { desc = icon .. "Grapple" }
 require("astronvim.utils").set_mappings(maps)
 return {
   "cbochs/grapple.nvim",
+  dependencies = {
+    { "nvim-tree/nvim-web-devicons", lazy = true },
+  },
   cmd = { "Grapple" },
   keys = {
     { prefix .. "a", "<cmd>Grapple tag<CR>", desc = "Add file" },
     { prefix .. "d", "<cmd>Grapple untag<CR>", desc = "Remove file" },
     { prefix .. "t", "<cmd>Grapple toggle<CR>", desc = "Toggle a file" },
-    { prefix .. "e", "<cmd>Grapple open_tags<CR>", desc = "Select from tags" },
-    { prefix .. "s", "<cmd>Grapple open_scopes<CR>", desc = "Select a scope" },
-    { prefix .. "l", "<cmd>Grapple open_loaded<CR>", desc = "Select a loaded scope" },
+    { prefix .. "e", "<cmd>Grapple toggle_tags<CR>", desc = "Select from tags" },
+    { prefix .. "s", "<cmd>Grapple toggle_scopes<CR>", desc = "Select a scope" },
+    { prefix .. "l", "<cmd>Grapple toggle_loaded<CR>", desc = "Select a loaded scope" },
     { prefix .. "x", "<cmd>Grapple reset<CR>", desc = "Clear tags from current project" },
     { "<C-n>", "<cmd>Grapple cycle forward<CR>", desc = "Select next tag" },
     { "<C-p>", "<cmd>Grapple cycle backward<CR>", desc = "Select previous tag" },


### PR DESCRIPTION
## 📑 Description

Hello, again 👋 

I received a bit of feedback after releasing the rewrite the other day. Thought I would send one more PR to address that here as well 🙂 

### Changes

- Add `nvim-tree/nvim-web-devicons` as a lazy (optional) dependency
- Use `toggle_*` instead of `open_*` so Grapple windows can be open/closed with the same mapping
