### PR TITLE
feat(coc): add v-mode selection format

### DIFF
--- a/lua/astrocommunity/lsp/coc-nvim/init.lua
+++ b/lua/astrocommunity/lsp/coc-nvim/init.lua
@@ -39,7 +39,8 @@ return {
         maps.n.gr = { "<Plug>(coc-references)", desc = "Show the references of current symbol" }
         maps.n["<Leader>lR"] = maps.n.gr
         maps.n["<Leader>lr"] = { "<Plug>(coc-rename)", desc = "Rename current symbol" }
-        maps.n["<Leader>lf"] = { function() vim.cmd.Format() end, desc = "Format buffer", nowait = true }
+        maps.n["<Leader>lf"] = { function() vim.cmd.Format() end, desc = "Format buffer" }
+        maps.x["<Leader>lF"] = { "<Plug>(coc-format-selected)", desc = "Format selection" }
         maps.n["<Leader>la"] = { "<Plug>(coc-codeaction-cursor)", desc = "LSP code action" }
         maps.n["<Leader>lL"] = { "<Plug>(coc-codelens-action)", desc = "LSP CodeLens run" }
         maps.n.K = {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

Add `<leader>l;` to format selected lines in visual mode.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## Additional Information

I believe `<leader>;` would be more natural here, but I opted to follow the mnemonic as it was already established
