### PR TITLE
fix(coc-nvim): fix heirline with coc list

### DIFF
--- a/lua/astrocommunity/lsp/coc-nvim/init.lua
+++ b/lua/astrocommunity/lsp/coc-nvim/init.lua
@@ -40,10 +40,17 @@ return {
         if not opts.autocmds then opts.autocmds = {} end
         opts.autocmds.coc_settings = {
           {
-            event = "FileType",
-            pattern = "list",
-            desc = "disable foldcolumn for coc lists",
-            callback = function() vim.wo.foldcolumn = "0" end,
+            event = { "BufWinEnter", "BufWinLeave" },
+            pattern = "*",
+            desc = "disable foldcolumn and statusline for coc lists",
+            callback = function()
+              if vim.bo.filetype == [[list]] then
+                vim.wo.foldcolumn = "0"
+                vim.o.laststatus = (vim.o.laststatus == opts.options.opt.laststatus) and 0 or vim.o.laststatus
+              else
+                vim.o.laststatus = (vim.o.laststatus == 0) and opts.options.opt.laststatus or vim.o.laststatus
+              end
+            end,
           },
         }
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Fix a very annoying issue where CoC would overwrite heirline. Note that we do lose the count information, so we'll have to integrate it into heirline, probably by looking at how it is done internally

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

### Before:
![image](https://github.com/AstroNvim/astrocommunity/assets/91024200/8db6524c-5dc4-4016-b92b-90370653c485)

### After:
![image](https://github.com/AstroNvim/astrocommunity/assets/91024200/fb2cda21-d5ef-452a-b89a-03a5ded209c2)


