### PR TITLE
fix(harpoon): commend out undeclared command

### DIFF
--- a/lua/astrocommunity/motion/harpoon/init.lua
+++ b/lua/astrocommunity/motion/harpoon/init.lua
@@ -3,9 +3,7 @@ local prefix = "<leader><leader>"
 local maps = { n = {} }
 local icon = vim.g.icons_enabled and "󱡀 " or ""
 maps.n[prefix] = { desc = icon .. "Harpoon" }
-
 require("astronvim.utils").set_mappings(maps)
-
 return {
   {
     "ThePrimeagen/harpoon",
@@ -46,5 +44,11 @@ return {
       -- },
     },
     opts = {},
+  },
+  {
+    "catppuccin/nvim",
+    optional = true,
+    ---@type CatppuccinOptions
+    opts = { integrations = { harpoon = true } },
   },
 }

--- a/lua/astrocommunity/motion/harpoon/init.lua
+++ b/lua/astrocommunity/motion/harpoon/init.lua
@@ -1,5 +1,5 @@
 local prefix = "<leader><leader>"
-local term_string = vim.fn.exists "$TMUX" == 1 and "tmux" or "term"
+-- local term_string = vim.fn.exists "$TMUX" == 1 and "tmux" or "term"
 local maps = { n = {} }
 local icon = vim.g.icons_enabled and "󱡀 " or ""
 maps.n[prefix] = { desc = icon .. "Harpoon" }
@@ -32,16 +32,16 @@ return {
       { "<C-p>", function() require("harpoon"):list():prev() end, desc = "Goto previous mark" },
       { "<C-n>", function() require("harpoon"):list():next() end, desc = "Goto next mark" },
       { prefix .. "m", "<cmd>Telescope harpoon marks<CR>", desc = "Show marks in Telescope" },
-      {
-        prefix .. "t",
-        function()
-          vim.ui.input({ prompt = term_string .. " window number: " }, function(input)
-            local num = tonumber(input)
-            if num then require("harpoon").term.gotoTerminal(num) end
-          end)
-        end,
-        desc = "Go to " .. term_string .. " window",
-      },
+      -- {
+      --   prefix .. "t",
+      --   function()
+      --     vim.ui.input({ prompt = term_string .. " window number: " }, function(input)
+      --       local num = tonumber(input)
+      --       if num then require("harpoon").term.gotoTerminal(num) end
+      --     end)
+      --   end,
+      --   desc = "Go to " .. term_string .. " window",
+      -- },
     },
     opts = {},
   },

--- a/lua/astrocommunity/motion/harpoon/init.lua
+++ b/lua/astrocommunity/motion/harpoon/init.lua
@@ -3,7 +3,9 @@ local prefix = "<leader><leader>"
 local maps = { n = {} }
 local icon = vim.g.icons_enabled and "󱡀 " or ""
 maps.n[prefix] = { desc = icon .. "Harpoon" }
+
 require("astronvim.utils").set_mappings(maps)
+
 return {
   {
     "ThePrimeagen/harpoon",
@@ -44,11 +46,5 @@ return {
       -- },
     },
     opts = {},
-  },
-  {
-    "catppuccin/nvim",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { harpoon = true } },
   },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

This PR removes `prefix .. t` option since `term` does not exist in `harpoon2` yet. Instead of completely removing the option it is commended-out. 

Also, this PR removes `catppuccin` config from `harpoon` since it should be in [catppuccin](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/colorscheme/catppuccin).


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
