### PR TITLE
fix(coq_nvim): fix coq bindings

### DIFF
--- a/lua/astrocommunity/completion/coq_nvim/init.lua
+++ b/lua/astrocommunity/completion/coq_nvim/init.lua
@@ -17,7 +17,7 @@ return {
             g = {
               coq_settings = {
                 auto_start = "shut-up",
-                keymap = { jump_to_mark = "<C-T>" },
+                keymap = { jump_to_mark = "<Tab>" },
               },
             },
           },

--- a/lua/astrocommunity/completion/coq_nvim/init.lua
+++ b/lua/astrocommunity/completion/coq_nvim/init.lua
@@ -12,9 +12,16 @@ return {
       { "ms-jpq/coq.artifacts", branch = "artifacts" },
       {
         "AstroNvim/astrocore",
-        opts = { options = { g = { coq_settings = {
-          auto_start = "shut-up",
-        } } } },
+        opts = {
+          options = {
+            g = {
+              coq_settings = {
+                auto_start = "shut-up",
+                keymap = { jump_to_mark = "<C-T>" },
+              },
+            },
+          },
+        },
       },
       {
         "AstroNvim/astrolsp",


### PR DESCRIPTION
## 📑 Description

After coq is lazy loaded, meaning after the first autocompletion is triggered, it's default binding `<C-h>` for `jump_to_mark` (https://github.com/ms-jpq/coq_nvim/blob/coq/docs/SNIPS.md#snippets) clashes with AstroNVims window movement. Basically, as soon as coq is loaded, you can't switch to the left window anymore.

This is an attempt to fix that. I chose `<C-t>` to jump to the next snippet edit, which is absolutely a debatable choice. I think this clashes the least with both AstroNVims and Neovims default bindings.