### PR TITLE
chore(rust): pin rustaceanvim to ^v4 

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -60,7 +60,7 @@ return {
   },
   {
     "mrcjkb/rustaceanvim",
-    version = "^3",
+    version = "^4",
     ft = "rust",
     opts = function()
       local adapter


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Setting the version for rustaceanvim to ^v4 since it's recommended by the maninater 
![CleanShot 2024-03-10 at 23 07 22@2x](https://github.com/AstroNvim/astrocommunity/assets/17254073/7f2c462d-0c39-4203-8030-a06b1cefe1c0)


<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

I'm not sure if this will introduce breaking changes this is what is listed in the release note

![CleanShot 2024-03-10 at 23 08 07@2x](https://github.com/AstroNvim/astrocommunity/assets/17254073/d054872f-77be-4a51-aba2-c65ee14d976d)
 

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
