### PR TITLE
fix(bash): fix duplicate diagnostics in bash pack

### DIFF
--- a/lua/astrocommunity/pack/bash/init.lua
+++ b/lua/astrocommunity/pack/bash/init.lua
@@ -14,9 +14,7 @@ return {
   },
   {
     "jay-babu/mason-null-ls.nvim",
-    opts = function(_, opts)
-      opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "shellcheck", "shfmt" })
-    end,
+    opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, { "shfmt" }) end,
   },
   {
     "jay-babu/mason-nvim-dap.nvim",


### PR DESCRIPTION
## 📑 Description

While using the bash pack, I came across a this odd behavior: Bash diagnostics showing up as duplicates: 
<img width="1551" alt="Screenshot 2024-03-18 at 12 33 08" src="https://github.com/AstroNvim/astrocommunity/assets/6126301/326f9f1a-d46d-4a3b-8a0d-7c6f6f52df7c">

This takes place because, as referenced [here](https://github.com/jose-elias-alvarez/null-ls.nvim/discussions/951#discussioncomment-3141217) and [here](https://github.com/bash-lsp/bash-language-server/commit/71c6a4ae2891cdbdfbbfb8ca0d11a566c900f6d2), `bash-ls` has a shellcheck integration by default. So there is no need to set it up as a secondary source. 

This PR removes `shellcheck` from the list of language servers installed by mason to be configured and used by null-ls/none-ls
