### PR TITLE
fix(neotest): Add missing dependency due to v5.0.0 release

### DIFF
--- a/lua/astrocommunity/test/neotest/init.lua
+++ b/lua/astrocommunity/test/neotest/init.lua
@@ -3,6 +3,7 @@ return {
     "nvim-neotest/neotest",
     ft = { "go", "rust", "python" },
     dependencies = {
+      "nvim-neotest/nvim-nio",
       "nvim-neotest/neotest-go",
       "nvim-neotest/neotest-python",
       "rouge8/neotest-rust",


### PR DESCRIPTION
## 📑 Description

The latest release of neotest adds a dependency to nvim-nio:

https://github.com/nvim-neotest/neotest/releases/tag/v5.0.0

This PR adds that dependency.