### PR TITLE
fix(neorg): pin version to last commit before v8.0.0's breaking changes

### DIFF
--- a/lua/astrocommunity/note-taking/neorg/init.lua
+++ b/lua/astrocommunity/note-taking/neorg/init.lua
@@ -1,6 +1,9 @@
 return {
   "nvim-neorg/neorg",
   build = ":Neorg sync-parsers",
+  -- Pinned to last commit before v8.0.0's breaking changes as a temp fix
+  -- TODO: remove this in AstroNvim v4 when #813 is merged
+  commit = "583a82e",
   dependencies = { "nvim-lua/plenary.nvim" },
   event = "VeryLazy",
   opts = {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Neorg recently released v8.0.0 with some breaking changes. This PR is a temp fix until AstroNvim v4 is released and #813 is merged, since fixing the breaking changes requires a breaking change of our own due to new required system dependencies.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
