### PR TITLE
feat(ts-error-translator-nvim): `svelte` and `astro` support added

### DIFF
--- a/lua/astrocommunity/lsp/ts-error-translator-nvim/init.lua
+++ b/lua/astrocommunity/lsp/ts-error-translator-nvim/init.lua
@@ -11,7 +11,17 @@ return {
       local orig = opts.lsp_handlers[event] or vim.lsp.handlers[event]
       opts.lsp_handlers[event] = function(err, result, ctx, config)
         local client = vim.lsp.get_client_by_id(ctx.client_id)
-        if client and vim.tbl_contains({ "tsserver", "vtsls", "typescript-tools", "volar" }, client.name) then
+        if
+          client
+          and vim.tbl_contains({
+            "astro",
+            "svelte",
+            "tsserver",
+            "typescript-tools",
+            "volar",
+            "vtsls",
+          }, client.name)
+        then
           vim.tbl_map(require("ts-error-translator").translate, result.diagnostics)
         end
         orig(err, result, ctx, config)


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The Svelte and Astro language servers are running `tsserver` under the hood so we should also enable this when `svelte` support gets added to ts-error-transltor.nvim.

Dependent on: https://github.com/dmmulroy/ts-error-translator.nvim/pull/26

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
