### PR TITLE
fix(yanky-nvim)!: change conflicting mapping `<Leader>p` → `<Leader>fy`

### DIFF
--- a/lua/astrocommunity/editing-support/yanky-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/yanky-nvim/init.lua
@@ -7,7 +7,7 @@ return {
       opts = {
         mappings = {
           n = {
-            ["<Leader>p"] = { "<Cmd>Telescope yank_history<CR>", desc = "Open Yank History" },
+            ["<Leader>fy"] = { "<Cmd>Telescope yank_history<CR>", desc = "Find yanks" },
             ["y"] = { "<Plug>(YankyYank)", desc = "Yank text" },
             ["p"] = { "<Plug>(YankyPutAfter)", desc = "Put yanked text after cursor" },
             ["P"] = { "<Plug>(YankyPutBefore)", desc = "Put yanked text before cursor" },


### PR DESCRIPTION
Closes #830 

## 📑 Description

Map the yanky.nvim/Telescope yank history picker to <kbd>&lt;Leader&gt;fy</kbd> (mnemonic: “find yanks”) and change its description to `Find yanks`.