### PR TITLE
feat(nvim-devdocs): bundled `js/node` docs for typescript files

### DIFF
--- a/lua/astrocommunity/editing-support/nvim-devdocs/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-devdocs/init.lua
@@ -34,6 +34,9 @@ return {
       cmd_args = { "-s", "dark", "-w", "80" },
       picker_cmd = true,
       picker_cmd_args = { "-p" },
+      filetypes = {
+        typescript = { "node", "javascript", "typescript" },
+      },
     },
   },
 }


### PR DESCRIPTION
## 📑 Description

Previously, executing `:DevdocsOpenCurrentFloat` in a typescript file would only provide the Typescript docs. This is desirable, but most of the docs TS devs are interested in are normally under `javascript` (MDN) or `node`. You could work around this by opening up all docs, but if you use multiple languages docs, this could be a cumbersome experience.

This change bundles all three sets of docs to be available under current `ts` floats, which should be a sane default for 99% of devs.

