### PR TITLE
feat(image-nvim): use luarocks.nvim for "magick" rock

### DIFF
--- a/lua/astrocommunity/media/image-nvim/README.md
+++ b/lua/astrocommunity/media/image-nvim/README.md
@@ -13,11 +13,8 @@ It can also render image files as images when opened.
 
 These are things you have to setup on your own
 
-* ImageMagick - **mandatory**
-* magick LuaRock - **mandatory** (luarocks --local --lua-version=5.1 install magick)
-    - Magick LuaRock requires Lua 5.1 
-* Kitty >= 28.0 - for the kitty backend
-* ueberzugpp - for the ueberzug backend
-* curl - for remote images
+- Kitty >= 28.0 - for the kitty backend
+- ueberzugpp - for the ueberzug backend
+- curl - for remote images
 
-**This plugin is configured to be used with kitty terminal and lua 5.1**
+**This plugin is configured to be used with kitty terminal**

--- a/lua/astrocommunity/media/image-nvim/init.lua
+++ b/lua/astrocommunity/media/image-nvim/init.lua
@@ -1,6 +1,3 @@
-package.path = package.path .. ";" .. vim.fn.expand "$HOME" .. "/.luarocks/share/lua/5.1/?/init.lua;"
-package.path = package.path .. ";" .. vim.fn.expand "$HOME" .. "/.luarocks/share/lua/5.1/?.lua;"
-
 return {
   "3rd/image.nvim",
   event = "VeryLazy",
@@ -14,6 +11,13 @@ return {
           highlight = { enable = true },
         }
       end,
+    },
+    {
+      "vhyrro/luarocks.nvim",
+      priority = 1000, -- this plugin needs to run before anything else
+      opts = {
+        rocks = { "magick" },
+      },
     },
   },
   opts = {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Change the image.nvim plugin init.lua to use luarocks.nvim for adding the "magick" rock. Removes a step from the installation.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
It adds luarocks.nvim as a dependency
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
