### PR TITLE
feat(startup): add mini-starter plugin

### DIFF
--- a/lua/astrocommunity/startup/mini-starter/README.md
+++ b/lua/astrocommunity/startup/mini-starter/README.md
@@ -1,0 +1,5 @@
+# Mini-Starter
+
+Neovim Lua plugin with fast and flexible start screen. Part of 'mini.nvim' library.
+
+**Repository**: <https://github.com/echasnovski/mini.starter>

--- a/lua/astrocommunity/startup/mini-starter/init.lua
+++ b/lua/astrocommunity/startup/mini-starter/init.lua
@@ -7,6 +7,7 @@ return {
   },
   {
     "AstroNvim/astrocore",
+    optional = true,
     ---@type AstroCoreOpts
     opts = {
       mappings = {

--- a/lua/astrocommunity/startup/mini-starter/init.lua
+++ b/lua/astrocommunity/startup/mini-starter/init.lua
@@ -1,0 +1,29 @@
+return {
+  { "goolord/alpha-nvim", enabled = false },
+  {
+    "echasnovski/mini.starter",
+    version = "*", -- stable version
+    config = function() require("mini.starter").setup() end,
+  },
+  {
+    "AstroNvim/astrocore",
+    ---@type AstroCoreOpts
+    opts = {
+      mappings = {
+        n = {
+          ["<Leader>c"] = {
+            function()
+              local bufs = vim.fn.getbufinfo { buflisted = true }
+              require("astrocore.buffer").close(0)
+              if require("astrocore").is_available "mini.starter" and not bufs[2] then
+                require("mini.starter").open()
+                require("astrocore.buffer").close_all(true) -- remove empty buffer
+              end
+            end,
+            desc = "Close buffer",
+          },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Added ['mini-starter'](https://github.com/echasnovski/mini.starter) plugin and configured it for Astronvim.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

Disabled the alpha plugin and configured the buffer close command to open nvim-starter when all buffers are closed.