### PR TITLE
fix(java): rename clang_format to clang-format

### DIFF
--- a/lua/astrocommunity/pack/java/init.lua
+++ b/lua/astrocommunity/pack/java/init.lua
@@ -19,7 +19,7 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "clang_format" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "clang-format" })
     end,
   },
   {


### PR DESCRIPTION
## 📑 Description

Update `clang_format` formatter name with `clang-format`.

## ℹ Additional Information

Example of the error I'm currently getting with the latest version of `AstroNvim/astrocommunity`. This fixes that.

```
Error executing vim.schedule lua callback: ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:80: Cannot find p
ackage "clang_format".                                                                                                  
stack traceback:                                                                                                        
        [C]: in function 'error'                                                                                        
        ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:80: in function 'get_package'                       
        ...on-tool-installer.nvim/lua/mason-tool-installer/init.lua:127: in function 'callback'                         
        ...share/nvim/lazy/mason.nvim/lua/mason-core/async/init.lua:87: in function 'step'                              
        ...share/nvim/lazy/mason.nvim/lua/mason-core/async/init.lua:96: in function 'run'                               
        ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:202: in function 'refresh'                          
        ...on-tool-installer.nvim/lua/mason-tool-installer/init.lua:156: in function ''                                 
        vim/_editor.lua: in function ''                                                                                 
        vim/_editor.lua: in function <vim/_editor.lua:0>
```