### PR TITLE
fix(mason-tool-installer-nvim): Use mappings function for null-ls names

### DIFF
--- a/lua/astrocommunity/utility/mason-tool-installer-nvim/init.lua
+++ b/lua/astrocommunity/utility/mason-tool-installer-nvim/init.lua
@@ -24,11 +24,17 @@ return {
           if plugin == "mason-lspconfig.nvim" then
             mappings = require("mason-lspconfig").get_mappings().lspconfig_to_mason
           elseif plugin == "mason-null-ls.nvim" then
-            mappings = require("mason-null-ls.mappings.source").null_ls_to_package
+            mappings = require("mason-null-ls.mappings.source").getPackageFromNullLs
           elseif plugin == "mason-nvim-dap.nvim" then
             mappings = require("mason-nvim-dap.mappings.source").nvim_dap_to_package
           end
-          if mappings and mappings[target] then target = mappings[target] end
+          if mappings then
+            if type(mappings) == "table" and mappings[target] then
+              target = mappings[target]
+            elseif type(mappings) == "function" and mappings(target) then
+              target = mappings(target)
+            end
+          end
           if not target_lookup[target] then table.insert(opts.ensure_installed, target) end
         end
       end


### PR DESCRIPTION
## 📑 Description

Replaces `null_ls_to_package` mappings table with `mason-null-ls`'s provided `getPackageFromNullLs` function for mapping package names to Mason names.

## ℹ Additional Information

* Link to mason-null-ls function used: [here](https://github.com/jay-babu/mason-null-ls.nvim/blob/main/lua/mason-null-ls/mappings/source.lua#L23-L27)
   - This function uses the `null_ls_to_package` table under the hood while also fixing the names of package names following "normal" conventions
   - This function was introduced [here](https://github.com/jay-babu/mason-null-ls.nvim/pull/40/files) and a lot of "normal" mappings (including `clang_format` -> `clang-format`) got removed from the mapping sources as a result
* This provides an alternative fix to the issue I was having in https://github.com/AstroNvim/astrocommunity/pull/837