### PR TITLE
added dependency FixCursorHold

### DIFF
--- a/lua/astrocommunity/test/neotest/init.lua
+++ b/lua/astrocommunity/test/neotest/init.lua
@@ -6,6 +6,7 @@ return {
     dependencies = {
       "nvim-lua/plenary.nvim",
       "nvim-neotest/nvim-nio",
+      "antoinemadec/FixCursorHold.nvim",
       {
         "AstroNvim/astrocore",
         opts = {


### PR DESCRIPTION
## 📑 Description
Recommendation per [neotest installation]](https://github.com/nvim-neotest/neotest?tab=readme-ov-file#installation)
> Neotest uses the CursorHold event. This uses the updatetime setting which is by default very high, and lowering this can lead to excessive writes to disk. It's recommended to use https://github.com/antoinemadec/FixCursorHold.nvim which allows detaching updatetime from the frequency of the CursorHold event. The repo claims it is no longer needed but it is still recommended (See this issue)
