### PR TITLE
docs(rust): Update docs to reflect the pack

### DIFF
--- a/lua/astrocommunity/pack/rust/README.md
+++ b/lua/astrocommunity/pack/rust/README.md
@@ -5,7 +5,7 @@ this pack is not officially supported by the rust foundation
 This plugin pack does the following:
 
 - Adds `rust` Treesitter parsers
-- Adds [rust-tools.nvim](https://github.com/simrat39/rust-tools.nvim) for language specific tooling
+- Adds [rustaceanvim](https://github.com/mrcjkb/rustaceanvim) for language specific tooling
 - Adds [crates.nvim](https://github.com/Saecki/crates.nvim) for crate management
 - Adds [TOML language support](../toml)
 
@@ -34,29 +34,6 @@ The first three levels of this are AstronVim-specific configurations, the rest i
            cargo = {
               extraEnv = { CARGO_PROFILE_RUST_ANALYZER_INHERITS = 'dev', },
               extraArgs = { "--profile", "rust-analyzer", },
-            },
-          },
-        },
-      },
-    },
-  },
-```
-
-## Use clippy instead of cargo check
-
-If you'd like to run cargo clippy instead of cargo check on safe, add the following:
-
-```
-  lsp = {
-    config = {
-      rust_analyzer = {
-        settings = {
-          -- Add clippy lints for Rust.
-          ["rust-analyzer"] = {
-            checkOnSave = {
-              allFeatures = true,
-              command = "clippy",
-              extraArgs = { "--no-deps" },
             },
           },
         },


### PR DESCRIPTION
# Update Rust pack README
## 📑 Description
 [] Not Completed
--> [x] Completed

The Rust pack already uses the rustacenvim plugin instead of the rust-tools.nvim plugin, since that is deprecated.
The configuration uses cargo clippy, the most sensible default in my opinion, the paragraph detailing how it can be setup is useless.

## ℹ Additional Information

