### PR TITLE
fix(python): incorrect path for windows debugpy

### DIFF
--- a/lua/astrocommunity/pack/python/init.lua
+++ b/lua/astrocommunity/pack/python/init.lua
@@ -74,7 +74,12 @@ return {
     dependencies = "mfussenegger/nvim-dap",
     ft = "python", -- NOTE: ft: lazy-load on filetype
     config = function(_, opts)
-      local path = require("mason-registry").get_package("debugpy"):get_install_path() .. "/venv/bin/python"
+      local path = require("mason-registry").get_package("debugpy"):get_install_path()
+      if vim.fn.has "win32" == 1 then
+        path = path .. "/venv/Scripts/python"
+      else
+        path = path .. "/venv/bin/python"
+      end
       require("dap-python").setup(path, opts)
     end,
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

fix incorrect path for windows debugpy.
The path for installing debugpy on Mason under Windows is`~/<mason pkg path>/debugpy/venv/Scripts/python.exe`

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
