### PR TITLE
fix(blame-nvim): Align the git blame window properly when using heirline

### DIFF
--- a/lua/astrocommunity/git/blame-nvim/init.lua
+++ b/lua/astrocommunity/git/blame-nvim/init.lua
@@ -1,4 +1,21 @@
 return {
   "FabijanZulj/blame.nvim",
   event = "User AstroGitFile",
+  dependencies = {
+    { -- configure heirline with custom hook to enable winbar for 'blame' filetype
+      "rebelot/heirline.nvim",
+      optional = true,
+      opts = function(_, opts)
+        local disable_winbar_cb = vim.tbl_get(opts, "opts", "disable_winbar_cb")
+        return require("astrocore").extend_tbl(opts, {
+          opts = {
+            disable_winbar_cb = function(args)
+              if vim.bo[args.buf].filetype == "blame" then return false end
+              if disable_winbar_cb then return disable_winbar_cb(args) end
+            end,
+          },
+        })
+      end,
+    },
+  },
 }


### PR DESCRIPTION

## 📑 Description

Before fix

![Screenshot 2024-04-10 at 10 34 17 AM](https://github.com/AstroNvim/astrocommunity/assets/22250291/1af67d26-f704-44d6-a23f-453ef159c156)

After fix
![Screenshot 2024-04-10 at 10 35 21 AM](https://github.com/AstroNvim/astrocommunity/assets/22250291/eabdce44-c292-4748-9d2b-25d450df80ee)


## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
