### PR TITLE
fix(harpoon) : fix deprecated function in configuration

### DIFF
--- a/lua/astrocommunity/motion/harpoon/init.lua
+++ b/lua/astrocommunity/motion/harpoon/init.lua
@@ -14,7 +14,7 @@ return {
           local prefix = "<Leader><Leader>"
           maps.n[prefix] = { desc = require("astroui").get_icon("Harpoon", 1, true) .. "Harpoon" }
 
-          maps.n[prefix .. "a"] = { function() require("harpoon"):list():append() end, desc = "Add file" }
+          maps.n[prefix .. "a"] = { function() require("harpoon"):list():add() end, desc = "Add file" }
           maps.n[prefix .. "e"] = {
             function() require("harpoon").ui:toggle_quick_menu(require("harpoon"):list()) end,
             desc = "Toggle quick menu",


### PR DESCRIPTION
## 📑 Description

changed `replace` to `add` function due to `replace` function being deprecated in harpoon.

## ℹ Additional Information

old behaviour when trying to use "prefix .. a" keymap it would say "append is deprecated, use add instead". new behaviour - when using "prefix .. a" keymap current buffer would get added to harpoon list.
