### PR TITLE
fix(pack): update typescript-all-in-one disable typescript-tools to denols

### DIFF
--- a/lua/astrocommunity/lsp/actions-preview-nvim/init.lua
+++ b/lua/astrocommunity/lsp/actions-preview-nvim/init.lua
@@ -6,6 +6,7 @@ return {
     "nvim-telescope/telescope.nvim",
     {
       "AstroNvim/astrolsp",
+      optional = true,
       ---@type AstroLSPOpts
       opts = {
         mappings = {

--- a/lua/astrocommunity/pack/elixir-phoenix/init.lua
+++ b/lua/astrocommunity/pack/elixir-phoenix/init.lua
@@ -18,6 +18,7 @@ return {
   },
   {
     "AstroNvim/astrolsp",
+    optional = true,
     opts = {
       config = {
         tailwindcss = {

--- a/lua/astrocommunity/pack/elm/init.lua
+++ b/lua/astrocommunity/pack/elm/init.lua
@@ -1,6 +1,7 @@
 return {
   {
     "nvim-treesitter/nvim-treesitter",
+    optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "elm" })
@@ -9,12 +10,14 @@ return {
   },
   {
     "williamboman/mason-lspconfig.nvim",
+    optional = true,
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "elmls" })
     end,
   },
   {
     "jay-babu/mason-null-ls.nvim",
+    optional = true,
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "elm_format" })
     end,

--- a/lua/astrocommunity/pack/fish/init.lua
+++ b/lua/astrocommunity/pack/fish/init.lua
@@ -1,6 +1,7 @@
 return {
   {
     "nvim-treesitter/nvim-treesitter",
+    optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "fish" })

--- a/lua/astrocommunity/pack/gleam/init.lua
+++ b/lua/astrocommunity/pack/gleam/init.lua
@@ -1,6 +1,7 @@
 return {
   {
     "nvim-treesitter/nvim-treesitter",
+    optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "gleam" })
@@ -9,6 +10,7 @@ return {
   },
   {
     "AstroNvim/astrolsp",
+    optional = true,
     opts = function(_, opts)
       if vim.fn.executable "gleam" == 1 then
         opts.servers = require("astrocore").list_insert_unique(opts.servers, { "gleam" })

--- a/lua/astrocommunity/pack/just/init.lua
+++ b/lua/astrocommunity/pack/just/init.lua
@@ -26,6 +26,7 @@ return {
   },
   {
     "nvim-treesitter/nvim-treesitter",
+    optional = true,
     opts = function(_, opts)
       local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
       parser_config.just = {

--- a/lua/astrocommunity/pack/nim/init.lua
+++ b/lua/astrocommunity/pack/nim/init.lua
@@ -1,12 +1,14 @@
 return {
   {
     "williamboman/mason-lspconfig.nvim",
+    optional = true,
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "nim_langserver" })
     end,
   },
   {
     "nvim-treesitter/nvim-treesitter",
+    optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed =

--- a/lua/astrocommunity/pack/pkl/init.lua
+++ b/lua/astrocommunity/pack/pkl/init.lua
@@ -14,6 +14,7 @@ return {
     dependencies = {
       {
         "nvim-treesitter/nvim-treesitter",
+        optional = true,
         opts = function(_, opts)
           local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
 

--- a/lua/astrocommunity/pack/templ/init.lua
+++ b/lua/astrocommunity/pack/templ/init.lua
@@ -4,6 +4,7 @@ local utils = require "astronvim.utils"
 return {
   {
     "nvim-treesitter/nvim-treesitter",
+    optional = true,
     opts = function(_, opts)
       -- Ensure that opts.ensure_installed exists and is a table or string "all".
       if opts.ensure_installed ~= "all" then
@@ -13,6 +14,7 @@ return {
   },
   {
     "williamboman/mason-lspconfig.nvim",
+    optional = true,
     opts = function(_, opts) opts.ensure_installed = utils.list_insert_unique(opts.ensure_installed, "templ") end,
   },
 }

--- a/lua/astrocommunity/pack/typescript-all-in-one/init.lua
+++ b/lua/astrocommunity/pack/typescript-all-in-one/init.lua
@@ -2,50 +2,49 @@ return {
   { import = "astrocommunity.pack.typescript" },
   { import = "astrocommunity.pack.typescript-deno" },
   {
-    "sigmasd/deno-nvim",
-    -- HACK: This disables tsserver if denols is attached.
-    -- A solution that only enables the required lsp should replace it.
-    opts = function(_, opts)
-      vim.api.nvim_create_autocmd("LspAttach", {
-        callback = function(args)
-          local bufnr = args.buf
-          local curr_client = vim.lsp.get_client_by_id(args.data.client_id)
+    "AstroNvim/astrolsp",
+    opts = {
+      config = {
+        denols = {
+          -- adjust deno ls root directory detection
+          root_dir = function(...) return require("lspconfig.util").root_pattern("deno.json", "deno.jsonc")(...) end,
+        },
+      },
+    },
+  },
+  {
+    "AstroNvim/astrocore",
+    ---@type AstroCoreOpts
+    opts = {
+      autocmds = {
+        -- set up autocommand to choose the correct language server
+        typescript_deno_switch = {
+          {
+            event = "LspAttach",
+            callback = function(args)
+              local bufnr = args.buf
+              local curr_client = vim.lsp.get_client_by_id(args.data.client_id)
 
-          if curr_client and curr_client.name == "denols" then
-            local clients = vim.lsp.get_clients { bufnr = bufnr }
-            for _, client in ipairs(clients) do
-              if client.name == "tsserver" or client.name == "typescript-tools" then
-                vim.lsp.stop_client(client.id, true)
+              if curr_client and curr_client.name == "denols" then
+                local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients) {
+                  bufnr = bufnr,
+                  name = "typescript-tools",
+                }
+                for _, client in ipairs(clients) do
+                  vim.lsp.stop_client(client.id, true)
+                end
               end
-            end
-          end
 
-          -- if tsserver attached, stop it if there is a denols server attached
-          if curr_client and curr_client.name == "tsserver" then
-            local clients = vim.lsp.get_clients { bufnr = bufnr }
-            for _, client in ipairs(clients) do
-              if client.name == "denols" then
-                vim.lsp.stop_client(curr_client.id, true)
-                break
+              -- if tsserver attached, stop it if there is a denols server attached
+              if curr_client and curr_client.name == "typescript-tools" then
+                if next((vim.lsp.get_clients or vim.lsp.get_active_clients) { bufnr = bufnr, name = "denols" }) then
+                  vim.lsp.stop_client(curr_client.id, true)
+                end
               end
-            end
-          end
-
-          -- if typescript-tools attached, stop it if there is a denols server attached
-          if curr_client and curr_client.name == "typescript-tools" then
-            local clients = vim.lsp.get_clients { bufnr = bufnr }
-            for _, client in ipairs(clients) do
-              if client.name == "denols" then
-                vim.lsp.stop_client(curr_client.id, true)
-                break
-              end
-            end
-          end
-        end,
-      })
-      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
-      opts.server = astrolsp_avail and astrolsp.lsp_opts "denols"
-      opts.server.root_dir = require("lspconfig.util").root_pattern("deno.json", "deno.jsonc")
-    end,
+            end,
+          },
+        },
+      },
+    },
   },
 }

--- a/lua/astrocommunity/pack/typescript-all-in-one/init.lua
+++ b/lua/astrocommunity/pack/typescript-all-in-one/init.lua
@@ -3,6 +3,7 @@ return {
   { import = "astrocommunity.pack.typescript-deno" },
   {
     "AstroNvim/astrolsp",
+    optional = true,
     opts = {
       config = {
         denols = {

--- a/lua/astrocommunity/pack/typescript-all-in-one/init.lua
+++ b/lua/astrocommunity/pack/typescript-all-in-one/init.lua
@@ -10,14 +10,31 @@ return {
         callback = function(args)
           local bufnr = args.buf
           local curr_client = vim.lsp.get_client_by_id(args.data.client_id)
-          -- if deno attached, stop all typescript servers
-          if curr_client.name == "denols" then
-            vim.lsp.for_each_buffer_client(bufnr, function(client, client_id)
-              if client.name == "tsserver" then vim.lsp.stop_client(client_id, true) end
-            end)
-            -- if tsserver attached, stop it if there is a denols server attached
-          elseif curr_client.name == "tsserver" then
-            for _, client in ipairs(vim.lsp.get_clients { bufnr = bufnr }) do
+
+          if curr_client and curr_client.name == "denols" then
+            local clients = vim.lsp.get_clients { bufnr = bufnr }
+            for _, client in ipairs(clients) do
+              if client.name == "tsserver" or client.name == "typescript-tools" then
+                vim.lsp.stop_client(client.id, true)
+              end
+            end
+          end
+
+          -- if tsserver attached, stop it if there is a denols server attached
+          if curr_client and curr_client.name == "tsserver" then
+            local clients = vim.lsp.get_clients { bufnr = bufnr }
+            for _, client in ipairs(clients) do
+              if client.name == "denols" then
+                vim.lsp.stop_client(curr_client.id, true)
+                break
+              end
+            end
+          end
+
+          -- if typescript-tools attached, stop it if there is a denols server attached
+          if curr_client and curr_client.name == "typescript-tools" then
+            local clients = vim.lsp.get_clients { bufnr = bufnr }
+            for _, client in ipairs(clients) do
               if client.name == "denols" then
                 vim.lsp.stop_client(curr_client.id, true)
                 break

--- a/lua/astrocommunity/pack/typescript-deno/init.lua
+++ b/lua/astrocommunity/pack/typescript-deno/init.lua
@@ -1,13 +1,4 @@
 return {
-  {
-    "AstroNvim/astrolsp",
-    optional = true,
-    ---@type AstroLSPOpts
-    opts = {
-      ---@diagnostic disable: missing-fields
-      handlers = { denols = false },
-    },
-  },
   { import = "astrocommunity.pack.json" },
   {
     "nvim-treesitter/nvim-treesitter",
@@ -44,6 +35,17 @@ return {
   {
     "sigmasd/deno-nvim",
     ft = { "javascript", "typescript", "javascriptreact", "typescriptreact" },
+    dependencies = {
+      {
+        "AstroNvim/astrolsp",
+        optional = true,
+        ---@type AstroLSPOpts
+        opts = {
+          ---@diagnostic disable: missing-fields
+          handlers = { denols = false },
+        },
+      },
+    },
     opts = function(_, opts)
       local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
       if astrolsp_avail then opts.server = astrolsp.lsp_opts "denols" end

--- a/lua/astrocommunity/pack/typescript-deno/init.lua
+++ b/lua/astrocommunity/pack/typescript-deno/init.lua
@@ -35,17 +35,7 @@ return {
   {
     "sigmasd/deno-nvim",
     ft = { "javascript", "typescript", "javascriptreact", "typescriptreact" },
-    dependencies = {
-      {
-        "AstroNvim/astrolsp",
-        optional = true,
-        ---@type AstroLSPOpts
-        opts = {
-          ---@diagnostic disable: missing-fields
-          handlers = { denols = false },
-        },
-      },
-    },
+    dependencies = { { "AstroNvim/astrolsp", optional = true, opts = { handlers = { denols = false } } } },
     opts = function(_, opts)
       local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
       if astrolsp_avail then opts.server = astrolsp.lsp_opts "denols" end


### PR DESCRIPTION
## 📑 Description
In the pack typescript-all-in-one disable typescript-tools and tsserver to denols. Apparently tsserver is disabled but typescript-tools keeps tsserver errors active again.

## ℹ Additional Information

![Screenshot 2024-04-11 111539](https://github.com/AstroNvim/astrocommunity/assets/1768030/3a7cf1a5-a083-4822-8c89-011db7319a72)
