### PR TITLE
fix(rest-nvim)!: update to rest.nvim v2

### DIFF
--- a/lua/astrocommunity/programming-language-support/rest-nvim/init.lua
+++ b/lua/astrocommunity/programming-language-support/rest-nvim/init.lua
@@ -1,31 +1,34 @@
 return {
   {
     "rest-nvim/rest.nvim",
-    ft = { "http", "json" },
-    cmd = {
-      "RestNvim",
-      "RestNvimPreview",
-      "RestNvimLast",
-    },
+    ft = "http",
+    cmd = "Rest",
     dependencies = {
-      "nvim-lua/plenary.nvim",
+      {
+        "vhyrro/luarocks.nvim",
+        priority = 1000,
+        config = true,
+      },
       {
         "AstroNvim/astrocore",
         opts = function(_, opts)
           local maps = opts.mappings
           local prefix = "<Leader>r"
           maps.n[prefix] = { desc = "RestNvim" }
-          maps.n[prefix .. "r"] = { "<Plug>RestNvim", desc = "Run request" }
+          maps.n[prefix .. "r"] = { "<cmd>Rest run<cr>", desc = "Run request under the cursor" }
+          maps.n[prefix .. "l"] = { "<cmd>Rest run last<cr>", desc = "Re-run latest request" }
         end,
       },
     },
+    main = "rest-nvim",
     opts = {},
   },
   {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "http", "json" })
+        opts.ensure_installed =
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "lua", "xml", "http", "json", "graphql" })
       end
     end,
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
Update needed as [rest.nvim](https://github.com/rest-nvim/rest.nvim) v2 has been released. Followed instructions in their README.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
- Dependencies changed: `vhyrro/luarocks.nvim` added [[ref](https://github.com/rest-nvim/rest.nvim/blob/fd16650a55fb1035c82e15484edd514bf6c66a3c/README.md#lazynvim)]
- Command and keybindings updated [[ref](https://github.com/rest-nvim/rest.nvim/blob/fd16650a55fb1035c82e15484edd514bf6c66a3c/README.md#keybindings)]
- Treesitter parser list updated [[ref](https://github.com/rest-nvim/rest.nvim/blob/fd16650a55fb1035c82e15484edd514bf6c66a3c/README.md#tree-sitter-parsing)]