### PR TITLE
fix(java): fix mason package `clang_format` not found

### DIFF
--- a/lua/astrocommunity/pack/java/init.lua
+++ b/lua/astrocommunity/pack/java/init.lua
@@ -19,7 +19,7 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "clang_format" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "clang-format" })
     end,
   },
   {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

there is a typo for the mason package `clang_format`, the correct package name is `clang-format`.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

![image](https://github.com/AstroNvim/astrocommunity/assets/2855338/3e63c99b-ce7a-4a06-b47e-72417abb6f58)

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
