### PR TITLE
fix(markmap-nvim): Fix issue with pack due to wrongly named null-ls package, and load on `md` file

### DIFF
--- a/lua/astrocommunity/markdown-and-latex/markmap-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/markmap-nvim/init.lua
@@ -1,16 +1,19 @@
 --  [markdown markmap]
 --  https://github.com/Zeioth/markmap.nvim
 return {
-  "Zeioth/markmap.nvim",
-  cmd = { "MarkmapOpen", "MarkmapSave", "MarkmapWatch", "MarkmapWatchStop" },
-  opts = {
-    hide_toolbar = "false",
+  {
+    "Zeioth/markmap.nvim",
+    cmd = { "MarkmapOpen", "MarkmapSave", "MarkmapWatch", "MarkmapWatchStop" },
+    ft = "markdown",
+    opts = {
+      hide_toolbar = "false",
+    },
   },
   {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "markmap" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "markmap-cli" })
     end,
   },
 }


### PR DESCRIPTION
## 📑 Description

* Also place `"Zeioth/markmap.nvim"` with specs inside brackets.
* And load only with markdown files.