### PR TITLE
fix(pack-java): remove clang-formatter

### DIFF
--- a/lua/astrocommunity/pack/java/README.md
+++ b/lua/astrocommunity/pack/java/README.md
@@ -11,20 +11,18 @@ This plugin pack does the following:
 - Adds `jdtls` language server
 - Adds `lemminx` language server (XML)
 - Adds [nvim-jdtls](https://github.com/mfussenegger/nvim-jdtls) for language specific tooling
-  - Enables [hot reloading](https://github.com/mfussenegger/nvim-jdtls/issues/80)
-- Adds `clang_format` through null-ls
+- Enables [hot reloading](https://github.com/mfussenegger/nvim-jdtls/issues/80)
 - Adds `javadbg` and `javatest` debug adapters for nvim-dap
 
 ## Note
 
-We require that the root folder of your projects inlude one of these files/folders([Reference](https://github.com/AstroNvim/astrocommunity/blob/49e9a3961bba079d7f413b8d5567382dd6f55392/lua/astrocommunity/pack/java/java.lua#LL37C96-L37C96)):  
+We require that the root folder of your projects include one of these files/folders([Reference](https://github.com/AstroNvim/astrocommunity/blob/49e9a3961bba079d7f413b8d5567382dd6f55392/lua/astrocommunity/pack/java/java.lua#LL37C96-L37C96)):  
 `.git`, `mvnw`, `gradlew`, `pom.xml`, `build.gradle` or `.project`
-
-
 
 ## Tips
 
-`jdtls` requires Java 11+ but can be used to develop on any Java version. If you develop  using different Java runtimes, you can set the runtimes  you have available in the settings of `jdtls`. Here is a simple example:
+`jdtls` requires Java 11+ but can be used to develop on any Java version. If you develop using different Java runtimes, you can set the runtimes you have available in the settings of `jdtls`.
+Here is a simple example:
 
 ```lua
   "AstroNvim/astrocommunity",
@@ -43,7 +41,14 @@ We require that the root folder of your projects inlude one of these files/folde
             },
           },
         },
+        format = {
+          enabled = true,
+          settings = { -- you can use your preferred format style
+            url = os.getenv "HOME" .. ".config/nvim/formatter/eclipse-java-google-style.xml",
+            profile = "GoogleStyle",
+          },
+        },
       },
     },
-  },
+  }
 ```

--- a/lua/astrocommunity/pack/java/init.lua
+++ b/lua/astrocommunity/pack/java/init.lua
@@ -16,13 +16,6 @@ return {
     end,
   },
   {
-    "jay-babu/mason-null-ls.nvim",
-    optional = true,
-    opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "clang_format" })
-    end,
-  },
-  {
     "jay-babu/mason-nvim-dap.nvim",
     optional = true,
     opts = function(_, opts)
@@ -35,7 +28,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(
         opts.ensure_installed,
-        { "jdtls", "lemminx", "clang-format", "java-debug-adapter", "java-test" }
+        { "jdtls", "lemminx", "java-debug-adapter", "java-test" }
       )
     end,
   },
@@ -161,14 +154,5 @@ return {
         end,
       })
     end,
-  },
-  {
-    "stevearc/conform.nvim",
-    optional = true,
-    opts = {
-      formatters_by_ft = {
-        java = { "clang-format" },
-      },
-    },
   },
 }


### PR DESCRIPTION

## 📑 Description

In the java pack, clang_formatter is unnecessary. It also overrides the formatting capability of "mfussenegger/nvim-jdtls". 

Having clang_formatter for java pack does not make sense, as the default formatter works just fine.

list of changes:
- [x] removed unnecessary clang_formatter and everything related to it. 
- [x] updated readme to include custom formatter example.
