### PR TITLE
fix(neogen): keymap for type-aware automatic comment generation

### DIFF
--- a/lua/astrocommunity/editing-support/neogen/init.lua
+++ b/lua/astrocommunity/editing-support/neogen/init.lua
@@ -8,7 +8,7 @@ return {
         local maps = opts.mappings
         local prefix = "<Leader>a"
         maps.n[prefix] = { desc = require("astroui").get_icon("Neogen", 1, true) .. "Annotation" }
-        maps.n[prefix .. "<CR>"] = { function() require("neogen").generate { type = "current" } end, desc = "Current" }
+        maps.n[prefix .. "<CR>"] = { function() require("neogen").generate { type = "any" } end, desc = "Current" }
         maps.n[prefix .. "c"] = { function() require("neogen").generate { type = "class" } end, desc = "Class" }
         maps.n[prefix .. "f"] = { function() require("neogen").generate { type = "func" } end, desc = "Function" }
         maps.n[prefix .. "t"] = { function() require("neogen").generate { type = "type" } end, desc = "Type" }


### PR DESCRIPTION
Keyboard shortcut **(leader + a + CR)** for automatic comment generation did not correctly detect element type (function, class, etc.). This commit fixes the bug so that the shortcut correctly detects element type and generates the appropriate comment.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The "keymap" **(leader + a + CR)** that triggers the automatic neogen generation does not work and throws an error message saying "current type is not supported".

## ℹ Additional Information

### current behavior

https://github.com/AstroNvim/astrocommunity/assets/51010598/e9d9cabf-54be-4b6e-a7c0-ca116e988fcb

### expected behavior

https://github.com/AstroNvim/astrocommunity/assets/51010598/5d63fa71-c803-48f0-aa32-50dfcf0e9da8
