### PR TITLE
fix(sql): drop `sqlfluff` as `sqls` supports formatting

### DIFF
--- a/lua/astrocommunity/pack/sql/README.md
+++ b/lua/astrocommunity/pack/sql/README.md
@@ -4,5 +4,4 @@ This plugin pack does the following:
 
 - Adds `sql` Treesitter parser
 - Adds `sqls` language server
-- Adds `sqlfluff` formatter
 - Adds [sqls.nvim](https://github.com/nanotee/sqls.nvim) for language specific tooling

--- a/lua/astrocommunity/pack/sql/init.lua
+++ b/lua/astrocommunity/pack/sql/init.lua
@@ -16,17 +16,10 @@ return {
     end,
   },
   {
-    "jay-babu/mason-null-ls.nvim",
-    optional = true,
-    opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "sqlfluff" })
-    end,
-  },
-  {
     "WhoIsSethDaniel/mason-tool-installer.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "sqlfluff", "sqls" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "sqls" })
     end,
   },
   {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

`sqls` supports formatting so we don't need to add `sqlfluff`.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
