### PR TITLE
fix(blame-nvim): adjust to the new rewrite

### DIFF
--- a/lua/astrocommunity/git/blame-nvim/init.lua
+++ b/lua/astrocommunity/git/blame-nvim/init.lua
@@ -1,7 +1,7 @@
 return {
   "FabijanZulj/blame.nvim",
   cmd = "BlameToggle",
-  config = function(_, opts) require("blame").setup(opts) end,
+  opts = {},
   dependencies = {
     {
       "AstroNvim/astrocore",

--- a/lua/astrocommunity/git/blame-nvim/init.lua
+++ b/lua/astrocommunity/git/blame-nvim/init.lua
@@ -1,6 +1,7 @@
 return {
   "FabijanZulj/blame.nvim",
-  event = "User AstroGitFile",
+  cmd = "BlameToggle",
+  config = function(_, opts) require("blame").setup(opts) end,
   dependencies = {
     {
       "AstroNvim/astrocore",
@@ -9,7 +10,7 @@ return {
         mappings = {
           n = {
             ["<Leader>gB"] = {
-              "<cmd>ToggleBlame<cr>",
+              "<cmd>BlameToggle<cr>",
               desc = "Toggle git blame",
             },
           },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The blame.nvim plugin has been rewritten and "broke" this spec. Updated to this state https://github.com/FabijanZulj/blame.nvim/tree/39f6123b78bde45917de071a07eba17b136d9f2c.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
