### PR TITLE
fix(fish): none-ls `opts.sources` not being created if it doesn't exist

### DIFF
--- a/lua/astrocommunity/pack/fish/init.lua
+++ b/lua/astrocommunity/pack/fish/init.lua
@@ -12,12 +12,13 @@ return {
     optional = true,
     opts = function(_, opts)
       local nls = require "null-ls"
-      if type(opts.sources) == "table" then
-        opts.sources = vim.list_extend(opts.sources, {
-          nls.builtins.formatting.fish_indent,
-          nls.builtins.diagnostics.fish,
-        })
+      if not opts.sources then
+        opts.sources = {}
       end
+      opts.sources = vim.list_extend(opts.sources, {
+        nls.builtins.formatting.fish_indent,
+        nls.builtins.diagnostics.fish,
+      })
     end,
   },
   {

--- a/lua/astrocommunity/pack/fish/init.lua
+++ b/lua/astrocommunity/pack/fish/init.lua
@@ -12,9 +12,7 @@ return {
     optional = true,
     opts = function(_, opts)
       local nls = require "null-ls"
-      if not opts.sources then
-        opts.sources = {}
-      end
+      if not opts.sources then opts.sources = {} end
       opts.sources = vim.list_extend(opts.sources, {
         nls.builtins.formatting.fish_indent,
         nls.builtins.diagnostics.fish,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

If `opts.sources` is not a table (or didn't exist, for that matter), fish linter and formatter didn't get added, they now do.

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
