### PR TITLE
feat(cpp): Add `<Leader>lw` keymap to switch between source and header

### DIFF
--- a/lua/astrocommunity/pack/cpp/init.lua
+++ b/lua/astrocommunity/pack/cpp/init.lua
@@ -46,14 +46,6 @@ return {
                 if assert(vim.lsp.get_client_by_id(args.data.client_id)).name == "clangd" then
                   require "clangd_extensions"
                   vim.api.nvim_del_augroup_by_name "clangd_extensions"
-                  require("astrocore").set_mappings({
-                    n = {
-                      ["<Leader>lw"] = {
-                        "<cmd>ClangdSwitchSourceHeader<CR>",
-                        desc = "Clangd: Switch source/header file",
-                      },
-                    },
-                  }, {})
                 end
               end,
             },

--- a/lua/astrocommunity/pack/cpp/init.lua
+++ b/lua/astrocommunity/pack/cpp/init.lua
@@ -46,6 +46,12 @@ return {
                 if assert(vim.lsp.get_client_by_id(args.data.client_id)).name == "clangd" then
                   require "clangd_extensions"
                   vim.api.nvim_del_augroup_by_name "clangd_extensions"
+                  vim.keymap.set(
+                    "n",
+                    "<Leader>lw",
+                    "<cmd>ClangdSwitchSourceHeader<CR>",
+                    { silent = true, desc = "Clangd: Switch source/header file" }
+                  )
                 end
               end,
             },

--- a/lua/astrocommunity/pack/cpp/init.lua
+++ b/lua/astrocommunity/pack/cpp/init.lua
@@ -58,6 +58,21 @@ return {
               end,
             },
           },
+          clangd_extension_mappings = {
+            {
+              event = "LspAttach",
+              desc = "Load clangd_extensions with clangd",
+              callback = function(args)
+                if assert(vim.lsp.get_client_by_id(args.data.client_id)).name == "clangd" then
+                  require("astrocore").set_mappings({
+                    n = {
+                      ["<Leader>lw"] = { "<Cmd>ClangdSwitchSourceHeader<CR>", desc = "Switch source/header file" },
+                    },
+                  }, { buffer = args.buf })
+                end
+              end,
+            },
+          },
         },
       },
     },

--- a/lua/astrocommunity/pack/cpp/init.lua
+++ b/lua/astrocommunity/pack/cpp/init.lua
@@ -46,12 +46,14 @@ return {
                 if assert(vim.lsp.get_client_by_id(args.data.client_id)).name == "clangd" then
                   require "clangd_extensions"
                   vim.api.nvim_del_augroup_by_name "clangd_extensions"
-                  vim.keymap.set(
-                    "n",
-                    "<Leader>lw",
-                    "<cmd>ClangdSwitchSourceHeader<CR>",
-                    { silent = true, desc = "Clangd: Switch source/header file" }
-                  )
+                  require("astrocore").set_mappings({
+                    n = {
+                      ["<Leader>lw"] = {
+                        "<cmd>ClangdSwitchSourceHeader<CR>",
+                        desc = "Clangd: Switch source/header file",
+                      },
+                    },
+                  }, {})
                 end
               end,
             },


### PR DESCRIPTION
<leader>lw to sWitch between source and header.

"w" isn't assigned to any other key currently.

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

Caveat: The keybinding will stay for all LSP although only Clangd supports it. Ideally the keybinding should appear only for buffers Clangd is attached.

