### PR TITLE
feat(completion): Add `vim-tabby`

### DIFF
--- a/lua/astrocommunity/completion/tabby-nvim/README.md
+++ b/lua/astrocommunity/completion/tabby-nvim/README.md
@@ -4,16 +4,12 @@ Tabby is a self-hosted AI coding assistant that can suggest multi-line code or f
 
 **Repository:** <https://github.com/TabbyML/vim-tabby>
 
-## Installation
-
-**Repository:** <https://github.com/TabbyML/vim-tabby>
-
 ### Default Mappings
 
-| Mappings    | Action                 |
-|-------------|------------------------|
-| `Tab`       | Accept all suggestions |
-| `Ctrl + \` | Accept line            |
+| Mappings   | Action            |
+|------------|-------------------|
+| `Tab`      | Accept completion |
+| `Ctrl + \` | Trigger/Dismiss   |
 
 ## Known Conflicts
 

--- a/lua/astrocommunity/completion/tabby-nvim/README.md
+++ b/lua/astrocommunity/completion/tabby-nvim/README.md
@@ -1,6 +1,6 @@
 # Installation
 
-https://tabby.tabbyml.com/docs/installation/
+**Repository:** <https://github.com/TabbyML/vim-tabby>
 
 ## Known Conflicts
 

--- a/lua/astrocommunity/completion/tabby-nvim/README.md
+++ b/lua/astrocommunity/completion/tabby-nvim/README.md
@@ -1,6 +1,19 @@
-# Installation
+# tabby-nvim
+
+Tabby is a self-hosted AI coding assistant that can suggest multi-line code or full functions in real-time.
 
 **Repository:** <https://github.com/TabbyML/vim-tabby>
+
+## Installation
+
+**Repository:** <https://github.com/TabbyML/vim-tabby>
+
+### Default Mappings
+
+| Mappings    | Action                 |
+|-------------|------------------------|
+| `Tab`       | Accept all suggestions |
+| `Ctrl + \` | Accept line            |
 
 ## Known Conflicts
 

--- a/lua/astrocommunity/completion/tabby-nvim/README.md
+++ b/lua/astrocommunity/completion/tabby-nvim/README.md
@@ -13,6 +13,6 @@ Tabby is a self-hosted AI coding assistant that can suggest multi-line code or f
 
 ## Known Conflicts
 
-    For the default settings, Tabby will attempt to set up the <Tab> key mapping. If Tabby's inline completion is not displayed, it will fall back to the original mapping. However, this approach might not work when there is a conflict with other plugins that also map the <Tab> key, as they could overwrite Tabby's mapping. In such cases, you can use a different keybinding to accept the completion and avoid conflicts.
+- For the default settings, Tabby will attempt to set up the `<Tab>` key mapping. If Tabby's inline completion is not displayed, it will fall back to the original mapping. However, this approach might not work when there is a conflict with other plugins that also map the `<Tab>` key, as they could overwrite Tabby's mapping. In such cases, you can use a different keybinding to accept the completion and avoid conflicts.
 
-    Tabby internally utilizes the <C-R><C-O> command to insert the completion. If you have mapped <C-R> to other functions, you won't be able to accept the completion. In such scenarios, you may need to manually modify the function tabby#Accept() in autoload/tabby.vim.
+- Tabby internally utilizes the `<C-R><C-O>` command to insert the completion. If you have mapped `<C-R>` to other functions, you won't be able to accept the completion. In such scenarios, you may need to manually modify the function `tabby#Accept()` in [`autoload/tabby.vim`](https://github.com/TabbyML/tabby/tree/main/clients/vim/autoload/tabby.vim).

--- a/lua/astrocommunity/completion/tabby-nvim/README.md
+++ b/lua/astrocommunity/completion/tabby-nvim/README.md
@@ -1,54 +1,8 @@
-# Mac/Windows Installation
+# Installation
 
 https://tabby.tabbyml.com/docs/installation/
 
-# Linux Installation
-
-## Using Docker
-
-### Install the latest version of node (this uses [Node Version Manager](https://github.com/nvm-sh/nvm))
-```bash
-nvm install node
-```
-
-### Install NVIDIA Container Toolkit
-https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
-
-### Run Docker container
-
-Choose <model> from [Tabby Models Registry](https://tabby.tabbyml.com/docs/models/)
-
-```bash
-docker run -it --gpus all \
-  -p 8080:8080 -v $HOME/.tabby:/data \
-  tabbyml/tabby serve --model <model> --device cuda
-```
-
-### Tabby Server
-
-If your Tabby server endpoint is different from the default http://localhost:8080, please set the endpoint in ~/.tabby-client/agent/config.toml
-
-### Example Config
-```lua
-vim.g.tabby_keybinding_accept = '<Tab>'
-vim.g.tabby_keybinding_trigger_or_dismiss = '<C-\\>'
-
-vim.g.tabby_node_binary = '/path/to/node' -- find using `which node`
-
-return {
-  { 'TabbyML/vim-tabby' }
-}
-```
-
-
-# Usage 
-
-After installation, please exit and restart Vim or NeoVim. Then you can check the Tabby plugin status by running :Tabby in your vim command line. If you see any message reported by Tabby, it means the plugin is installed successfully. If you see Not an editor command: Tabby or any other error message, please check the installation steps.
-
-In insert mode, Tabby plugin will show inline completion automatically when you stop typing. You can simply press <Tab> to accept the completion. If you want to dismiss the completion manually, you can press <C-\> to dismiss, and press <C-\> again to show the completion again.
-
-
-# Known Conflicts
+## Known Conflicts
 
     For the default settings, Tabby will attempt to set up the <Tab> key mapping. If Tabby's inline completion is not displayed, it will fall back to the original mapping. However, this approach might not work when there is a conflict with other plugins that also map the <Tab> key, as they could overwrite Tabby's mapping. In such cases, you can use a different keybinding to accept the completion and avoid conflicts.
 

--- a/lua/astrocommunity/completion/tabby-nvim/README.md
+++ b/lua/astrocommunity/completion/tabby-nvim/README.md
@@ -1,0 +1,55 @@
+# Mac/Windows Installation
+
+https://tabby.tabbyml.com/docs/installation/
+
+# Linux Installation
+
+## Using Docker
+
+### Install the latest version of node (this uses [Node Version Manager](https://github.com/nvm-sh/nvm))
+```bash
+nvm install node
+```
+
+### Install NVIDIA Container Toolkit
+https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+
+### Run Docker container
+
+Choose <model> from [Tabby Models Registry](https://tabby.tabbyml.com/docs/models/)
+
+```bash
+docker run -it --gpus all \
+  -p 8080:8080 -v $HOME/.tabby:/data \
+  tabbyml/tabby serve --model <model> --device cuda
+```
+
+### Tabby Server
+
+If your Tabby server endpoint is different from the default http://localhost:8080, please set the endpoint in ~/.tabby-client/agent/config.toml
+
+### Example Config
+```lua
+vim.g.tabby_keybinding_accept = '<Tab>'
+vim.g.tabby_keybinding_trigger_or_dismiss = '<C-\\>'
+
+vim.g.tabby_node_binary = '/path/to/node' -- find using `which node`
+
+return {
+  { 'TabbyML/vim-tabby' }
+}
+```
+
+
+# Usage 
+
+After installation, please exit and restart Vim or NeoVim. Then you can check the Tabby plugin status by running :Tabby in your vim command line. If you see any message reported by Tabby, it means the plugin is installed successfully. If you see Not an editor command: Tabby or any other error message, please check the installation steps.
+
+In insert mode, Tabby plugin will show inline completion automatically when you stop typing. You can simply press <Tab> to accept the completion. If you want to dismiss the completion manually, you can press <C-\> to dismiss, and press <C-\> again to show the completion again.
+
+
+# Known Conflicts
+
+    For the default settings, Tabby will attempt to set up the <Tab> key mapping. If Tabby's inline completion is not displayed, it will fall back to the original mapping. However, this approach might not work when there is a conflict with other plugins that also map the <Tab> key, as they could overwrite Tabby's mapping. In such cases, you can use a different keybinding to accept the completion and avoid conflicts.
+
+    Tabby internally utilizes the <C-R><C-O> command to insert the completion. If you have mapped <C-R> to other functions, you won't be able to accept the completion. In such scenarios, you may need to manually modify the function tabby#Accept() in autoload/tabby.vim.

--- a/lua/astrocommunity/completion/tabby-nvim/README.md
+++ b/lua/astrocommunity/completion/tabby-nvim/README.md
@@ -8,11 +8,9 @@ Tabby is a self-hosted AI coding assistant that can suggest multi-line code or f
 
 | Mappings   | Action            |
 |------------|-------------------|
-| `Tab`      | Accept completion |
+| `<C-e>`    | Accept completion |
 | `Ctrl + \` | Trigger/Dismiss   |
 
 ## Known Conflicts
-
-- For the default settings, Tabby will attempt to set up the `<Tab>` key mapping. If Tabby's inline completion is not displayed, it will fall back to the original mapping. However, this approach might not work when there is a conflict with other plugins that also map the `<Tab>` key, as they could overwrite Tabby's mapping. In such cases, you can use a different keybinding to accept the completion and avoid conflicts.
 
 - Tabby internally utilizes the `<C-R><C-O>` command to insert the completion. If you have mapped `<C-R>` to other functions, you won't be able to accept the completion. In such scenarios, you may need to manually modify the function `tabby#Accept()` in [`autoload/tabby.vim`](https://github.com/TabbyML/tabby/tree/main/clients/vim/autoload/tabby.vim).

--- a/lua/astrocommunity/completion/tabby-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabby-nvim/init.lua
@@ -1,12 +1,3 @@
 return {
   { "TabbyML/vim-tabby" },
-  init = function()
-    -- Configuration settings for vim-tabby
-    vim.g.tabby_keybinding_accept = "<Tab>"
-    vim.g.tabby_keybinding_trigger_or_dismiss = "<C-\\>"
-    vim.g.tabby_node_binary = "/path/to/node"
-
-    -- You can also set key mappings here if vim-tabby requires them
-    -- vim.keymap.set('n', '<your-key>', '<vim-command-or-function>')
-  end,
 }

--- a/lua/astrocommunity/completion/tabby-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabby-nvim/init.lua
@@ -3,6 +3,6 @@ return {
   init = function()
     vim.g.tabby_keybinding_accept = "<C-e>"
     vim.g.tabby_keybinding_trigger_or_dismiss = "<C-\\>"
-    vim.g.tabby_node_binary = "/path/to/node"
+    vim.g.tabby_node_binary = vim.fn.exepath("node")
   end,
 }

--- a/lua/astrocommunity/completion/tabby-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabby-nvim/init.lua
@@ -1,8 +1,16 @@
 return {
   "TabbyML/vim-tabby",
-  init = function()
-    vim.g.tabby_keybinding_accept = "<C-e>"
-    vim.g.tabby_keybinding_trigger_or_dismiss = "<C-\\>"
-    vim.g.tabby_node_binary = vim.fn.exepath("node")
-  end,
+  dependencies = {
+    "AstroNvim/astrocore",
+    ---@type AstroCoreOpts
+    opts = {
+      options = {
+        g = {
+          tabby_keybinding_accept = "<C-e>",
+          tabby_keybinding_trigger_or_dismiss = "<C-\\>",
+          tabby_node_binary = vim.fn.exepath "node",
+        },
+      },
+    },
+  },
 }

--- a/lua/astrocommunity/completion/tabby-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabby-nvim/init.lua
@@ -9,7 +9,6 @@ return {
         g = {
           tabby_keybinding_accept = "<C-e>",
           tabby_keybinding_trigger_or_dismiss = "<C-\\>",
-          tabby_node_binary = vim.fn.exepath "node",
         },
       },
     },

--- a/lua/astrocommunity/completion/tabby-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabby-nvim/init.lua
@@ -1,8 +1,12 @@
-vim.g.tabby_keybinding_accept = "<Tab>"
-vim.g.tabby_keybinding_trigger_or_dismiss = "<C-\\>"
-
-vim.g.tabby_node_binary = "/path/to/node"
-
 return {
   { "TabbyML/vim-tabby" },
+  config = function()
+    -- Configuration settings for vim-tabby
+    vim.g.tabby_keybinding_accept = "<Tab>"
+    vim.g.tabby_keybinding_trigger_or_dismiss = "<C-\\>"
+    vim.g.tabby_node_binary = "/path/to/node"
+
+    -- You can also set key mappings here if vim-tabby requires them
+    -- vim.keymap.set('n', '<your-key>', '<vim-command-or-function>')
+  end,
 }

--- a/lua/astrocommunity/completion/tabby-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabby-nvim/init.lua
@@ -1,6 +1,6 @@
 return {
   "TabbyML/vim-tabby",
-  event = "User AstroFile",
+  lazy = false,
   dependencies = {
     "AstroNvim/astrocore",
     ---@type AstroCoreOpts

--- a/lua/astrocommunity/completion/tabby-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabby-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "TabbyML/vim-tabby",
+  event = "User AstroFile",
   dependencies = {
     "AstroNvim/astrocore",
     ---@type AstroCoreOpts

--- a/lua/astrocommunity/completion/tabby-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabby-nvim/init.lua
@@ -1,3 +1,8 @@
 return {
-  { "TabbyML/vim-tabby" },
+  "TabbyML/vim-tabby",
+  init = function()
+    vim.g.tabby_keybinding_accept = "<C-e>"
+    vim.g.tabby_keybinding_trigger_or_dismiss = "<C-\\>"
+    vim.g.tabby_node_binary = "/path/to/node"
+  end,
 }

--- a/lua/astrocommunity/completion/tabby-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabby-nvim/init.lua
@@ -1,0 +1,8 @@
+vim.g.tabby_keybinding_accept = "<Tab>"
+vim.g.tabby_keybinding_trigger_or_dismiss = "<C-\\>"
+
+vim.g.tabby_node_binary = "/path/to/node"
+
+return {
+  { "TabbyML/vim-tabby" },
+}

--- a/lua/astrocommunity/completion/tabby-nvim/init.lua
+++ b/lua/astrocommunity/completion/tabby-nvim/init.lua
@@ -1,6 +1,6 @@
 return {
   { "TabbyML/vim-tabby" },
-  config = function()
+  init = function()
     -- Configuration settings for vim-tabby
     vim.g.tabby_keybinding_accept = "<Tab>"
     vim.g.tabby_keybinding_trigger_or_dismiss = "<C-\\>"


### PR DESCRIPTION
Closes #872

## 📑 Description

Instructions to use Tabby for an open-source, self-hosted AI coding assistant. With Tabby, every team can set up its own LLM-powered code completion server with ease.

- [x] Install `TabbyML/vim-tabby` with Lazy
- [x] Set proper initial config (non-conflicting key-bindings, etc)
- [x] Clean up README

## Additional Information

I added some steps for installing on Linux with Docker as [Tabby Docs](https://tabby.tabbyml.com/docs/getting-started) demonstrate particularly methods for Windows/Mac. However, maybe this is more suited to putting in their repo? Or maybe the user is just expected to figure this out on their own as Docker is agnostic... Let me know what you think

Otherwise, just want to make sure that the key-bindings are appropriate. I assume <tab> is likely to be conflicting...