### PR TITLE
fix(tailwindcss): add root_dir detection to tailwindcss pack

### DIFF
--- a/lua/astrocommunity/pack/tailwindcss/init.lua
+++ b/lua/astrocommunity/pack/tailwindcss/init.lua
@@ -12,20 +12,18 @@ return {
         optional = true,
         ---@type AstroLSPOpts
         opts = {
-          handlers = {
-            tailwindcss = function()
-              require("lspconfig").tailwindcss.setup {
-                root_dir = function(fname)
-                  local root_pattern = require("lspconfig").util.root_pattern(
-                    "tailwind.config.cjs",
-                    "tailwind.config.js",
-                    "tailwind.config.ts",
-                    "postcss.config.js"
-                  )
-                  return root_pattern(fname)
-                end,
-              }
-            end,
+          config = {
+            tailwindcss = {
+              root_dir = function(fname)
+                local root_pattern = require("lspconfig").util.root_pattern(
+                  "tailwind.config.cjs",
+                  "tailwind.config.js",
+                  "tailwind.config.ts",
+                  "postcss.config.js"
+                )
+                return root_pattern(fname)
+              end,
+            },
           },
         },
       },

--- a/lua/astrocommunity/pack/tailwindcss/init.lua
+++ b/lua/astrocommunity/pack/tailwindcss/init.lua
@@ -6,6 +6,30 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "tailwindcss" })
     end,
+    dependencies = {
+      {
+        "AstroNvim/astrolsp",
+        optional = true,
+        ---@type AstroLSPOpts
+        opts = {
+          handlers = {
+            tailwindcss = function()
+              require("lspconfig").tailwindcss.setup {
+                root_dir = function(fname)
+                  local root_pattern = require("lspconfig").util.root_pattern(
+                    "tailwind.config.cjs",
+                    "tailwind.config.js",
+                    "tailwind.config.ts",
+                    "postcss.config.js"
+                  )
+                  return root_pattern(fname)
+                end,
+              }
+            end,
+          },
+        },
+      },
+    },
   },
   {
     "WhoIsSethDaniel/mason-tool-installer.nvim",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The tailwindcss-language-server is currently always up and running. I believe it should only run when a Tailwind CSS config is found. 

This PR fixes that.
## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
