### PR TITLE
fix(typst): added missing command to typst-preview.nvim

### DIFF
--- a/lua/astrocommunity/pack/typst/init.lua
+++ b/lua/astrocommunity/pack/typst/init.lua
@@ -15,7 +15,7 @@ return {
   },
   {
     "chomosuke/typst-preview.nvim",
-    cmd = { "TypstPreview", "TypstPreviewToggle" },
+    cmd = { "TypstPreview", "TypstPreviewToggle", "TypstPreviewUpdate" },
     version = "0.1.*",
     build = function() require("typst-preview").update() end,
     opts = {},


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #907 
-->

## 📑 Description

<!-- Add a brief description of the pr -->
This adds the ability to manually build the binaries for typst-preview.nvim in case it have failed doing so with lazy
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
