### PR TITLE
fix(tailwindcss): fix TailwindCSS pack not loading when using tailwindcss-rails Ruby Gem

### DIFF
--- a/lua/astrocommunity/pack/tailwindcss/init.lua
+++ b/lua/astrocommunity/pack/tailwindcss/init.lua
@@ -19,7 +19,8 @@ return {
                   "tailwind.config.cjs",
                   "tailwind.config.js",
                   "tailwind.config.ts",
-                  "postcss.config.js"
+                  "postcss.config.js",
+                  "config/tailwind.config.js"
                 )
                 return root_pattern(fname)
               end,


### PR DESCRIPTION
## 📑 Description

#912 caused the Tailwind LSP to not work, when using the tailwindcss-rails Ruby gem.

The tailwindcss-rails Ruby gem keeps the config at config/tailwind.config.js, which is not in the new `root_dir` config.

https://github.com/rails/tailwindcss-rails?tab=readme-ov-file#configuration-and-commands