### PR TITLE
fix(gitlinker-nvim): Point repository link to correct repository

### DIFF
--- a/lua/astrocommunity/git/gitlinker-nvim/README.md
+++ b/lua/astrocommunity/git/gitlinker-nvim/README.md
@@ -3,4 +3,4 @@
 A lua neovim plugin to generate shareable file permalinks (with line ranges)
 for several git web frontend hosts. Inspired by tpope/vim-fugitive's :GBrowse
 
-**Repository**: <https://github.com/ruifm/gitlinker.nvim>
+**Repository**: <https://github.com/linrongbin16/gitlinker.nvim>


### PR DESCRIPTION
The link was to the incorrect repo which would lead to using the wrong documentation for configuration
