### PR TITLE
feat(hehe): add `Hydra.nvim`

### DIFF
--- a/lua/astrocommunity/keybinding/hydra-nvim/README.md
+++ b/lua/astrocommunity/keybinding/hydra-nvim/README.md
@@ -1,0 +1,35 @@
+# Hydra.nvim
+
+Create custom submodes and menus
+
+**Repository:** <https://github.com/anuvyklack/hydra.nvim>
+
+This implements configuration of Hydra.nvim through the `opts` table to make it easier for the user to configure various Hydra heads as well as allow AstroCommunity entries to also provide Hydra heads if it makes sense. Here is an example of defining a Hydra using the `opts` table:
+
+```lua
+return {
+  "anuvyklack/hydra.nvim",
+  opts = {
+    -- the first key is the name if name isn't set in the table
+    ["Side scroll"] = {
+      mode = "n",
+      body = "z",
+      heads = {
+        { "h", "5zh", { desc = "←" } },
+        { "l", "5zl", { desc = "→" } },
+        { "H", "zH", { desc = "half screen ←" } },
+        { "L", "zL", { desc = "half screen →" } },
+      },
+    },
+  },
+}
+```
+
+For advanced users, this also makes the resulting Hydra objects available through the use of the AstroCore utility: `plugin_opts`. Here is an example of retrieving the Hydra object during runtime:
+
+```lua
+require("lazy").load { plugins = { "hydra.nvim" } } -- load Hydra before loading opts
+local hydra_opts = require("astrocore").plugin_opts "hydra.nvim" -- get the plugin options
+local side_scroll_hydra = hydra_opts["Side scroll"].hydra -- get the created hydra by key name
+side_scroll_hydra:activate() -- use the object like normal
+```

--- a/lua/astrocommunity/keybinding/hydra-nvim/init.lua
+++ b/lua/astrocommunity/keybinding/hydra-nvim/init.lua
@@ -1,0 +1,13 @@
+return {
+  "anuvyklack/hydra.nvim",
+  event = "VeryLazy",
+  config = function(_, opts)
+    local Hydra = require "hydra"
+    for name, hydra in pairs(opts) do
+      if hydra then
+        if not hydra.name then hydra.name = name end
+        hydra.hydra = Hydra(hydra)
+      end
+    end
+  end,
+}

--- a/lua/astrocommunity/note-taking/venn-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/venn-nvim/init.lua
@@ -1,43 +1,85 @@
+local hint = [[
+ Arrow^^^^^^   Select region with <C-v> 
+ ^ ^ _K_ ^ ^   _f_: surround it with box
+ _H_ ^ ^ _L_
+ ^ ^ _J_ ^ ^                      _<Esc>_
+]]
+
 return {
-  "jbyuki/venn.nvim",
-  cmd = "VBox",
-  dependencies = {
-    "AstroNvim/astrocore",
-    ---@type AstroCoreOpts
+  {
+    "jbyuki/venn.nvim",
+    cmd = "VBox",
+    dependencies = {
+      {
+        "AstroNvim/astrocore",
+        opts = function(_, opts)
+          local astrocore = require "astrocore"
+          if not astrocore.is_available "hydra.nvim" then
+            return astrocore.extend_tbl(opts, {
+              commands = {
+                ToggleVenn = {
+                  function()
+                    local mappings = {
+                      n = { -- draw a line on HJKL keystokes
+                        H = "<C-v>h:VBox<CR>",
+                        J = "<C-v>j:VBox<CR>",
+                        K = "<C-v>k:VBox<CR>",
+                        L = "<C-v>l:VBox<CR>",
+                      },
+                      v = { -- draw a box by pressing "f" with visual selection
+                        f = ":VBox<CR>",
+                      },
+                    }
+                    if vim.b.venn_enabled then
+                      vim.opt_local.virtualedit = ""
+                      for mode, map in pairs(mappings) do
+                        for lhs, _ in pairs(map) do
+                          vim.keymap.del(mode, lhs, { buffer = true })
+                        end
+                      end
+                      vim.b.venn_enabled = nil
+                    else
+                      vim.b.venn_enabled = true
+                      vim.opt_local.virtualedit = "all"
+                      require("astrocore").set_mappings(mappings, { buffer = true })
+                    end
+                    vim.notify(("Venn Diagramming Mode: %s"):format(vim.b.venn_enabled and "Enabled" or "Disabled"))
+                  end,
+                  desc = "Toggle venn diagramming mode",
+                },
+              },
+              mappings = {
+                n = { ["<Leader>v"] = { function() vim.cmd.ToggleVenn() end, desc = "Toggle venn diagramming" } },
+              },
+            })
+          end
+        end,
+      },
+    },
+  },
+  {
+    "anuvyklack/hydra.nvim",
+    optional = true,
     opts = {
-      commands = {
-        ToggleVenn = {
-          function()
-            local mappings = {
-              n = { -- draw a line on HJKL keystokes
-                H = "<C-v>h:VBox<CR>",
-                J = "<C-v>j:VBox<CR>",
-                K = "<C-v>k:VBox<CR>",
-                L = "<C-v>l:VBox<CR>",
-              },
-              v = { -- draw a box by pressing "f" with visual selection
-                f = ":VBox<CR>",
-              },
-            }
-            if vim.b.venn_enabled then
-              vim.opt_local.virtualedit = ""
-              for mode, map in pairs(mappings) do
-                for lhs, _ in pairs(map) do
-                  vim.keymap.del(mode, lhs, { buffer = true })
-                end
-              end
-              vim.b.venn_enabled = nil
-            else
-              vim.b.venn_enabled = true
-              vim.opt_local.virtualedit = "all"
-              require("astrocore").set_mappings(mappings, { buffer = true })
-            end
-            vim.notify(("Venn Diagramming Mode: %s"):format(vim.b.venn_enabled and "Enabled" or "Disabled"))
-          end,
-          desc = "Toggle venn diagramming mode",
+      ["Draw Diagram"] = {
+        hint = hint,
+        config = {
+          color = "pink",
+          invoke_on_body = true,
+          hint = { border = "rounded" },
+          on_enter = function() vim.o.virtualedit = "all" end,
+        },
+        mode = "n",
+        body = "<leader>v",
+        heads = {
+          { "H", "<C-v>h:VBox<CR>" },
+          { "J", "<C-v>j:VBox<CR>" },
+          { "K", "<C-v>k:VBox<CR>" },
+          { "L", "<C-v>l:VBox<CR>" },
+          { "f", ":VBox<CR>", { mode = "v" } },
+          { "<Esc>", nil, { exit = true } },
         },
       },
-      mappings = { n = { ["<Leader>v"] = { function() vim.cmd.ToggleVenn() end, desc = "Toggle venn diagramming" } } },
     },
   },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This adds `Hydra.nvim` and provides an API for configuring it through the `opts` table. This could be useful for AstroCommunity entries to create submenus if hydra is available

I removed the automatic lazy loading based on keys because it is hyper unstable based on how the `body` + `heads` work. It's also not very slow to load so it's ok to just load it on `VeryLazy` like we do which-key

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
