### PR TITLE
feat(mini.files): replicate toggling behaviour of astronvim neotree

### DIFF
--- a/lua/astrocommunity/file-explorer/mini-files/init.lua
+++ b/lua/astrocommunity/file-explorer/mini-files/init.lua
@@ -9,7 +9,11 @@ return {
         opts = {
           mappings = {
             n = {
-              ["<Leader>e"] = { function() require("mini.files").open() end, desc = "Explorer" },
+              ["<Leader>e"] = {
+                function()
+                  if not require("mini.files").close() then require("mini.files").open() end
+                end,
+                desc = "Explorer",
             },
           },
         },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

A small change so that mini.files toggles when pressing `<leader>e` just as neotree in vanilla astronvim.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
