### PR TITLE
Mason LSP buf was rename to buf-language-server

### DIFF
--- a/lua/astrocommunity/pack/proto/init.lua
+++ b/lua/astrocommunity/pack/proto/init.lua
@@ -13,7 +13,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "bufls" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf-language-server" })
     end,
   },
   {


### PR DESCRIPTION
## 📑 Description

While trying to import the `pack.proto` file, Mason failed to install the `bufls` LSP package. It seems like the package was rename as `buf-language-server`:
```
Available (223)
    ...
    ✗ buf-language-server bufls (keywords: protobuf)
```
