### PR TITLE
fix(transparent-nvim): transparent keymap

### DIFF
--- a/lua/astrocommunity/color/transparent-nvim/init.lua
+++ b/lua/astrocommunity/color/transparent-nvim/init.lua
@@ -19,7 +19,7 @@ return {
       opts = {
         mappings = {
           n = {
-            ["<Leader>uT"] = { desc = "Toggle transparency" },
+            ["<Leader>uT"] = { "<Cmd>TransparentToggle<CR>", desc = "Toggle transparency" },
           },
         },
       },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

As suggested by the title, transparent keymap is actually not working. This pr is a one line fix to make it works!
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
