### PR TITLE
feat(pack): add Lean language pack

### DIFF
--- a/lua/astrocommunity/pack/lean/README.md
+++ b/lua/astrocommunity/pack/lean/README.md
@@ -1,0 +1,4 @@
+# Lean Language Pack
+This plugin pack does the following:
+
+- Adds [lean.nvim](https://github.com/Julian/lean.nvim) for language specific tooling

--- a/lua/astrocommunity/pack/lean/init.lua
+++ b/lua/astrocommunity/pack/lean/init.lua
@@ -1,0 +1,16 @@
+---@type LazySpec
+return {
+  {
+    "Julian/lean.nvim",
+    ft = { "lean" },
+    opts = {
+      lsp = {
+        on_attach = function(...)
+          local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
+          if astrolsp_avail then astrolsp.on_attach(...) end
+        end,
+      },
+      mappings = true,
+    },
+  },
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This PR adds language support for the [Lean theorem prover](https://leanprover.github.io) via the [`lean.nvim`](https://github.com/Julian/lean.nvim) extension.

This is an intentionally trivial PR to get my feet wet with config upstreaming :)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

The `lean.nvim` plugin explicitly requires an `on_attach()` callback to be set, so I relied on the `astrolsp`-provided one.
