### PR TITLE
fix(projectmgr-nvim): disable lazy loading

### DIFF
--- a/lua/astrocommunity/project/projectmgr-nvim/init.lua
+++ b/lua/astrocommunity/project/projectmgr-nvim/init.lua
@@ -2,6 +2,7 @@ return {
   {
     "charludo/projectmgr.nvim",
     event = "VeryLazy",
+    lazy = false, -- important!
     dependencies = {
       {
         "AstroNvim/astrocore",

--- a/lua/astrocommunity/project/projectmgr-nvim/init.lua
+++ b/lua/astrocommunity/project/projectmgr-nvim/init.lua
@@ -1,7 +1,6 @@
 return {
   {
     "charludo/projectmgr.nvim",
-    event = "VeryLazy",
     lazy = false, -- important!
     dependencies = {
       {


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

redo #605



## ℹ Additional Information


prevent errors like 
```
E5108: Error executing lua: ...nvim-data/lazy/projectmgr.nvim/lua/projectmgr/manage.lua:20: attempt to index field 'config' (a nil value)
stack traceback:
	...nvim-data/lazy/projectmgr.nvim/lua/projectmgr/manage.lua:20: in function 'open_project'
	...lazy/projectmgr.nvim/lua/projectmgr/telescope_picker.lua:46: in function 'run_replace_or_original'
	...im-data/lazy/telescope.nvim/lua/telescope/actions/mt.lua:65: in function 'key_func'
	...nvim-data/lazy/telescope.nvim/lua/telescope/mappings.lua:253: in function <...nvim-data/lazy/telescope.nvim/lua/telescope/mappings.lua:252>
```
