### PR TITLE
feat(completion): add `copilot-cmp`

### DIFF
--- a/lua/astrocommunity/completion/copilot-cmp/README.md
+++ b/lua/astrocommunity/completion/copilot-cmp/README.md
@@ -1,0 +1,10 @@
+# copilot.lua within CMP
+
+Fully featured & enhanced replacement for copilot.vim complete with API for interacting with Github Copilot
+
+**Repositories:** 
+<https://github.com/zbirenbaum/copilot.lua>
+<https://github.com/zbirenbaum/copilot-cmp>
+
+_Note_: This plugin will also reconfigure `cmp` and add `copilot` as a completion source
+_Note 2_: This configuration adds a nerdfont icon for copilot using `lspkind`. If you are using regular characters, you can change it in your plugin setup, using the key `Copilot` for `lspkind`'s `buffer_map`

--- a/lua/astrocommunity/completion/copilot-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-cmp/init.lua
@@ -1,0 +1,29 @@
+---@type LazySpec
+return {
+  {
+    "zbirenbaum/copilot.lua",
+    opts = {
+      suggestion = { enabled = false },
+      panel = { enabled = false },
+    },
+  },
+  { "zbirenbaum/copilot-cmp", opts = {}, dependencies = { "zbirenbaum/copilot.lua" } },
+  {
+    "hrsh7th/nvim-cmp",
+    dependencies = { "zbirenbaum/copilot-cmp" },
+    opts = function(_, opts)
+      -- Inject copilot into cmp sources, with high priority
+      table.insert(opts.sources, 1, {
+        name = "copilot",
+        group_index = 1,
+        priority = 10000,
+      })
+    end,
+  },
+  {
+    "onsails/lspkind.nvim",
+    optional = true,
+    -- Adds icon for copilot using lspkind
+    opts = function(_, opts) opts.symbol_map.Copilot = "" end,
+  },
+}


### PR DESCRIPTION
## 📑 Description

Adds a new way to integrate copilot with cmp, besides the current options available. This one puts copilot within cmp, instead of setting it up in parallel with it.
