### PR TITLE
feat(typescript)!: replace `typescript-tools` with `vtsls`

### DIFF
--- a/lua/astrocommunity/pack/typescript-all-in-one/init.lua
+++ b/lua/astrocommunity/pack/typescript-all-in-one/init.lua
@@ -29,7 +29,7 @@ return {
               if curr_client and curr_client.name == "denols" then
                 local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients) {
                   bufnr = bufnr,
-                  name = "typescript-tools",
+                  name = "vtsls",
                 }
                 for _, client in ipairs(clients) do
                   vim.lsp.stop_client(client.id, true)
@@ -37,7 +37,7 @@ return {
               end
 
               -- if tsserver attached, stop it if there is a denols server attached
-              if curr_client and curr_client.name == "typescript-tools" then
+              if curr_client and curr_client.name == "vtsls" then
                 if next((vim.lsp.get_clients or vim.lsp.get_active_clients) { bufnr = bufnr, name = "denols" }) then
                   vim.lsp.stop_client(curr_client.id, true)
                 end

--- a/lua/astrocommunity/pack/typescript/README.md
+++ b/lua/astrocommunity/pack/typescript/README.md
@@ -3,11 +3,11 @@
 This plugin pack does the following:
 
 - Adds `typescript`, `javascript`, `tsx`, and `jsdoc` Treesitter parsers
-- Adds `tsserver` and `vscode-eslint` language server
+- Adds `vtsls` and `eslint` language server
 - Adds `prettierd` formatter
 - Adds [JSON language support](../json)
 - Adds support for dap for JS
-- Adds [typescript.nvim](https://github.com/jose-elias-alvarez/typescript.nvim) for language specific tooling
+- Adds [nvim-vtsls](https://github.com/yioneko/nvim-vtsls) for language specific tooling
 - Adds [package-info.nvim](https://github.com/vuki656/package-info.nvim) for project package management
 - Adds [nvim-lsp-file-operations](https://github.com/antosha417/nvim-lsp-file-operations) to handles file imports on rename or move within neo-tree
 

--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -78,9 +78,57 @@ return {
     end,
   },
   {
+    "AstroNvim/astrolsp",
+    ---@type AstroLSPOpts
+    opts = {
+      autocmds = {
+        eslint_fix_on_save = {
+          cond = function(client) return client.name == "eslint" and vim.fn.exists ":EslintFixAll" > 0 end,
+          {
+            event = "BufWritePost",
+            desc = "Fix all eslint errors",
+            callback = function() vim.cmd.EslintFixAll() end,
+          },
+        },
+      },
+      ---@diagnostic disable: missing-fields
+      config = {
+        vtsls = {
+          settings = {
+            typescript = {
+              updateImportsOnFileMove = { enabled = "always" },
+              inlayHints = {
+                parameterNames = { enabled = "all" },
+                parameterTypes = { enabled = true },
+                variableTypes = { enabled = true },
+                propertyDeclarationTypes = { enabled = true },
+                functionLikeReturnTypes = { enabled = true },
+                enumMemberValues = { enabled = true },
+              },
+            },
+            javascript = {
+              updateImportsOnFileMove = { enabled = "always" },
+              inlayHints = {
+                parameterNames = { enabled = "literals" },
+                parameterTypes = { enabled = true },
+                variableTypes = { enabled = true },
+                propertyDeclarationTypes = { enabled = true },
+                functionLikeReturnTypes = { enabled = true },
+                enumMemberValues = { enabled = true },
+              },
+            },
+            vtsls = {
+              enableMoveToFileCodeAction = true,
+            },
+          },
+        },
+      },
+    },
+  },
+  {
     "williamboman/mason-lspconfig.nvim",
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "tsserver", "eslint" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "vtsls", "eslint" })
     end,
   },
   {
@@ -121,7 +169,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(
         opts.ensure_installed,
-        { "typescript-language-server", "eslint-lsp", "prettierd", "js-debug-adapter" }
+        { "vtsls", "eslint-lsp", "prettierd", "js-debug-adapter" }
       )
     end,
   },
@@ -132,59 +180,28 @@ return {
     event = "BufRead package.json",
   },
   {
-    "pmizio/typescript-tools.nvim",
+    "yioneko/nvim-vtsls",
+    lazy = true,
     dependencies = {
-      {
-        -- HACK: fix issue where `shiftwidth = 0` isn't correctly handled by typescript-tools.nvim
-        --       Remove when PR merged: https://github.com/pmizio/typescript-tools.nvim/pull/270
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local local_vim = opts.options
-          if local_vim.opt.shiftwidth == 0 then local_vim.opt.shiftwidth = local_vim.opt.tabstop end
-        end,
-      },
-      {
-        ---@type AstroLSPOpts
-        "AstroNvim/astrolsp",
-        optional = true,
-        ---@diagnostic disable: missing-fields
-        opts = {
-          autocmds = {
-            eslint_fix_on_save = {
-              cond = function(client) return client.name == "eslint" and vim.fn.exists ":EslintFixAll" > 0 end,
-              {
-                event = "BufWritePost",
-                desc = "Fix all eslint errors",
-                callback = function() vim.cmd.EslintFixAll() end,
-              },
-            },
-          },
-          handlers = { tsserver = false }, -- disable tsserver setup, this plugin does it
-          config = {
-            ["typescript-tools"] = { -- enable inlay hints by default for `typescript-tools`
-              settings = {
-                tsserver_file_preferences = {
-                  includeInlayParameterNameHints = "all",
-                  includeInlayParameterNameHintsWhenArgumentMatchesName = false,
-                  includeInlayFunctionParameterTypeHints = true,
-                  includeInlayVariableTypeHints = true,
-                  includeInlayVariableTypeHintsWhenTypeMatchesName = false,
-                  includeInlayPropertyDeclarationTypeHints = true,
-                  includeInlayFunctionLikeReturnTypeHints = true,
-                  includeInlayEnumMemberValueHints = true,
-                },
-              },
+      "AstroNvim/astrocore",
+      opts = {
+        autocmds = {
+          nvim_vtsls = {
+            {
+              event = "LspAttach",
+              desc = "Load nvim-vtsls with vtsls",
+              callback = function(args)
+                if assert(vim.lsp.get_client_by_id(args.data.client_id)).name == "vtsls" then
+                  require("vtsls")._on_attach(args.data.client_id, args.buf)
+                  vim.api.nvim_del_augroup_by_name "nvim_vtsls"
+                end
+              end,
             },
           },
         },
       },
     },
-    ft = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },
-    -- get AstroLSP provided options like `on_attach` and `capabilities`
-    opts = function()
-      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
-      if astrolsp_avail then return astrolsp.lsp_opts "typescript-tools" end
-    end,
+    config = function(_, opts) require("vtsls").config(opts) end,
   },
   {
     "dmmulroy/tsc.nvim",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This moves from `typescript-tools.nvim` to `vtsls` language server. Let me know if this is desired, I feel like `typescript-tools` always has problems with users

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
