### PR TITLE
fix(rust): Fix rust-analyzer check to clippy

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -20,7 +20,7 @@ return {
         rust_analyzer = {
           settings = {
             ["rust-analyzer"] = {
-              checkOnSave = {
+              check = {
                 command = "clippy",
               },
               assist = {


### PR DESCRIPTION

## 📑 Description

`checkOnSave` is supposed to be a boolean: https://rust-analyzer.github.io/manual.html#rust-analyzer.checkOnSave

The right place to put `command = "clippy"` is under `check`: https://rust-analyzer.github.io/manual.html#clippy
