### PR TITLE
fix(java): use builtin nvim 0.10 "go to definition/declaration" function

### DIFF
--- a/lua/astrocommunity/pack/java/init.lua
+++ b/lua/astrocommunity/pack/java/init.lua
@@ -1,5 +1,25 @@
 return {
   {
+    "AstroNvim/astrolsp",
+    ---@type AstroLSPOpts
+    opts = {
+      mappings = {
+        n = {
+          gD = {
+            function() vim.lsp.buf.declaration() end,
+            desc = "Declaration of current symbol",
+            cond = "textDocument/declaration",
+          },
+          gd = {
+            function() vim.lsp.buf.definition() end,
+            desc = "Show definition of current symbol",
+            cond = "textDocument/declaration",
+          },
+        },
+      },
+    },
+  },
+  {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)


### PR DESCRIPTION
## 📑 Description

Using Neovim 0.10 and java-pack, the default keybinding for go to definition "gd" and go to declaration "gD" is no longer working.

The following error message is shown:
```
[telescope.builtin.lsp_*]: server does not support definitionProvider
```

To fix this the default "gd" and "gD" need to be mapped to the following command:
```
vim.lsp.buf.definition()
vim.lsp.buf.declaration()
```

List of changes:
- [x] added config to override default telescope "gd" and "gD" key binding.