### PR TITLE
fix(catppuccin): set name to "catppuccin"

### DIFF
--- a/lua/astrocommunity/bars-and-lines/dropbar-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/dropbar-nvim/init.lua
@@ -7,6 +7,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { dropbar = { enabled = true } } },

--- a/lua/astrocommunity/bars-and-lines/dropbar-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/dropbar-nvim/init.lua
@@ -6,8 +6,7 @@ return {
     opts = function(_, opts) opts.winbar = nil end,
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { dropbar = { enabled = true } } },

--- a/lua/astrocommunity/bars-and-lines/vim-illuminate/init.lua
+++ b/lua/astrocommunity/bars-and-lines/vim-illuminate/init.lua
@@ -7,6 +7,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { illuminate = true } },

--- a/lua/astrocommunity/bars-and-lines/vim-illuminate/init.lua
+++ b/lua/astrocommunity/bars-and-lines/vim-illuminate/init.lua
@@ -6,8 +6,7 @@ return {
     config = function(_, opts) require("illuminate").configure(opts) end,
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { illuminate = true } },

--- a/lua/astrocommunity/code-runner/overseer-nvim/init.lua
+++ b/lua/astrocommunity/code-runner/overseer-nvim/init.lua
@@ -38,6 +38,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { overseer = true } },

--- a/lua/astrocommunity/code-runner/overseer-nvim/init.lua
+++ b/lua/astrocommunity/code-runner/overseer-nvim/init.lua
@@ -37,8 +37,7 @@ return {
     },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { overseer = true } },

--- a/lua/astrocommunity/color/headlines-nvim/init.lua
+++ b/lua/astrocommunity/color/headlines-nvim/init.lua
@@ -7,6 +7,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { headlines = true } },

--- a/lua/astrocommunity/color/headlines-nvim/init.lua
+++ b/lua/astrocommunity/color/headlines-nvim/init.lua
@@ -6,8 +6,7 @@ return {
     opts = {},
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { headlines = true } },

--- a/lua/astrocommunity/color/mini-hipatterns/init.lua
+++ b/lua/astrocommunity/color/mini-hipatterns/init.lua
@@ -6,6 +6,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/color/mini-hipatterns/init.lua
+++ b/lua/astrocommunity/color/mini-hipatterns/init.lua
@@ -5,8 +5,7 @@ return {
     opts = {},
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/colorscheme/mini-base16/init.lua
+++ b/lua/astrocommunity/colorscheme/mini-base16/init.lua
@@ -1,8 +1,7 @@
 return {
   "echasnovski/mini.base16",
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/colorscheme/mini-base16/init.lua
+++ b/lua/astrocommunity/colorscheme/mini-base16/init.lua
@@ -2,6 +2,7 @@ return {
   "echasnovski/mini.base16",
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/comment/mini-comment/init.lua
+++ b/lua/astrocommunity/comment/mini-comment/init.lua
@@ -12,6 +12,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/comment/mini-comment/init.lua
+++ b/lua/astrocommunity/comment/mini-comment/init.lua
@@ -11,8 +11,7 @@ return {
     },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
@@ -47,6 +47,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { lsp_trouble = true } },

--- a/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
@@ -46,8 +46,7 @@ return {
     end,
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { lsp_trouble = true } },

--- a/lua/astrocommunity/editing-support/mini-splitjoin/init.lua
+++ b/lua/astrocommunity/editing-support/mini-splitjoin/init.lua
@@ -6,6 +6,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/editing-support/mini-splitjoin/init.lua
+++ b/lua/astrocommunity/editing-support/mini-splitjoin/init.lua
@@ -5,8 +5,7 @@ return {
     opts = {},
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/editing-support/nvim-ts-rainbow2/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-ts-rainbow2/init.lua
@@ -13,8 +13,7 @@ return {
     opts = { rainbow = { enable = true } },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { ts_rainbow2 = true } },

--- a/lua/astrocommunity/editing-support/nvim-ts-rainbow2/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-ts-rainbow2/init.lua
@@ -14,6 +14,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { ts_rainbow2 = true } },

--- a/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
@@ -6,8 +6,7 @@ return {
     main = "rainbow-delimiters.setup",
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { rainbow_delimiters = true } },

--- a/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
@@ -7,6 +7,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { rainbow_delimiters = true } },

--- a/lua/astrocommunity/file-explorer/mini-files/init.lua
+++ b/lua/astrocommunity/file-explorer/mini-files/init.lua
@@ -24,6 +24,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/file-explorer/mini-files/init.lua
+++ b/lua/astrocommunity/file-explorer/mini-files/init.lua
@@ -23,8 +23,7 @@ return {
     opts = {},
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/git/neogit/init.lua
+++ b/lua/astrocommunity/git/neogit/init.lua
@@ -37,8 +37,7 @@ return {
     end,
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { neogit = true } },

--- a/lua/astrocommunity/git/neogit/init.lua
+++ b/lua/astrocommunity/git/neogit/init.lua
@@ -38,6 +38,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { neogit = true } },

--- a/lua/astrocommunity/git/octo-nvim/init.lua
+++ b/lua/astrocommunity/git/octo-nvim/init.lua
@@ -81,8 +81,7 @@ return {
     },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { octo = true } },

--- a/lua/astrocommunity/git/octo-nvim/init.lua
+++ b/lua/astrocommunity/git/octo-nvim/init.lua
@@ -82,6 +82,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { octo = true } },

--- a/lua/astrocommunity/indent/mini-indentscope/init.lua
+++ b/lua/astrocommunity/indent/mini-indentscope/init.lua
@@ -80,8 +80,7 @@ return {
     },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/indent/mini-indentscope/init.lua
+++ b/lua/astrocommunity/indent/mini-indentscope/init.lua
@@ -81,6 +81,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/lsp/coc-nvim/init.lua
+++ b/lua/astrocommunity/lsp/coc-nvim/init.lua
@@ -139,6 +139,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { coc_nvim = true } },

--- a/lua/astrocommunity/lsp/coc-nvim/init.lua
+++ b/lua/astrocommunity/lsp/coc-nvim/init.lua
@@ -138,8 +138,7 @@ return {
     end,
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { coc_nvim = true } },

--- a/lua/astrocommunity/motion/harpoon/init.lua
+++ b/lua/astrocommunity/motion/harpoon/init.lua
@@ -45,8 +45,7 @@ return {
     },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { harpoon = true } },

--- a/lua/astrocommunity/motion/harpoon/init.lua
+++ b/lua/astrocommunity/motion/harpoon/init.lua
@@ -46,6 +46,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { harpoon = true } },

--- a/lua/astrocommunity/motion/hop-nvim/init.lua
+++ b/lua/astrocommunity/motion/hop-nvim/init.lua
@@ -23,6 +23,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { hop = true } },

--- a/lua/astrocommunity/motion/hop-nvim/init.lua
+++ b/lua/astrocommunity/motion/hop-nvim/init.lua
@@ -22,8 +22,7 @@ return {
     },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { hop = true } },

--- a/lua/astrocommunity/motion/leap-nvim/init.lua
+++ b/lua/astrocommunity/motion/leap-nvim/init.lua
@@ -50,6 +50,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { leap = true } },

--- a/lua/astrocommunity/motion/leap-nvim/init.lua
+++ b/lua/astrocommunity/motion/leap-nvim/init.lua
@@ -49,8 +49,7 @@ return {
     opts = {},
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { leap = true } },

--- a/lua/astrocommunity/motion/mini-ai/init.lua
+++ b/lua/astrocommunity/motion/mini-ai/init.lua
@@ -6,6 +6,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/motion/mini-ai/init.lua
+++ b/lua/astrocommunity/motion/mini-ai/init.lua
@@ -5,8 +5,7 @@ return {
     opts = {},
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/motion/mini-basics/init.lua
+++ b/lua/astrocommunity/motion/mini-basics/init.lua
@@ -12,6 +12,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/motion/mini-basics/init.lua
+++ b/lua/astrocommunity/motion/mini-basics/init.lua
@@ -11,8 +11,7 @@ return {
     },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/motion/mini-bracketed/init.lua
+++ b/lua/astrocommunity/motion/mini-bracketed/init.lua
@@ -6,6 +6,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/motion/mini-bracketed/init.lua
+++ b/lua/astrocommunity/motion/mini-bracketed/init.lua
@@ -5,8 +5,7 @@ return {
     opts = {},
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/motion/mini-move/init.lua
+++ b/lua/astrocommunity/motion/mini-move/init.lua
@@ -33,6 +33,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/motion/mini-move/init.lua
+++ b/lua/astrocommunity/motion/mini-move/init.lua
@@ -32,8 +32,7 @@ return {
     },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/motion/mini-surround/init.lua
+++ b/lua/astrocommunity/motion/mini-surround/init.lua
@@ -42,6 +42,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/motion/mini-surround/init.lua
+++ b/lua/astrocommunity/motion/mini-surround/init.lua
@@ -41,8 +41,7 @@ return {
     },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/scrolling/mini-animate/init.lua
+++ b/lua/astrocommunity/scrolling/mini-animate/init.lua
@@ -40,6 +40,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/scrolling/mini-animate/init.lua
+++ b/lua/astrocommunity/scrolling/mini-animate/init.lua
@@ -39,8 +39,7 @@ return {
     end,
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/split-and-window/mini-map/init.lua
+++ b/lua/astrocommunity/split-and-window/mini-map/init.lua
@@ -32,6 +32,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/split-and-window/mini-map/init.lua
+++ b/lua/astrocommunity/split-and-window/mini-map/init.lua
@@ -31,8 +31,7 @@ return {
     end,
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { mini = true } },

--- a/lua/astrocommunity/syntax/vim-sandwich/init.lua
+++ b/lua/astrocommunity/syntax/vim-sandwich/init.lua
@@ -19,8 +19,7 @@ return {
     },
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { sandwich = true } },

--- a/lua/astrocommunity/syntax/vim-sandwich/init.lua
+++ b/lua/astrocommunity/syntax/vim-sandwich/init.lua
@@ -20,6 +20,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { sandwich = true } },

--- a/lua/astrocommunity/test/neotest/init.lua
+++ b/lua/astrocommunity/test/neotest/init.lua
@@ -55,8 +55,7 @@ return {
     end,
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { neotest = true } },

--- a/lua/astrocommunity/test/neotest/init.lua
+++ b/lua/astrocommunity/test/neotest/init.lua
@@ -56,6 +56,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { neotest = true } },

--- a/lua/astrocommunity/utility/noice-nvim/init.lua
+++ b/lua/astrocommunity/utility/noice-nvim/init.lua
@@ -74,8 +74,7 @@ return {
     end,
   },
   {
-    "catppuccin/nvim",
-    name = "catppuccin",
+    "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { noice = true } },

--- a/lua/astrocommunity/utility/noice-nvim/init.lua
+++ b/lua/astrocommunity/utility/noice-nvim/init.lua
@@ -75,6 +75,7 @@ return {
   },
   {
     "catppuccin/nvim",
+    name = "catppuccin",
     optional = true,
     ---@type CatppuccinOptions
     opts = { integrations = { noice = true } },


### PR DESCRIPTION
## 📑 Description
i tried installing hop as astrocommunity package, and in the repo i saw that it had code that supposedly should automatically enable integration for hop in catppuccin theme. yet that didnt work for some reason, and so i just enabled it manually. and today after thinking about it and 10 minutes of experimenting i figured it out. to fix this, all you have to do is set `name = "catppuccin"`, then its going to work. i just took hop as an example, but its with every single astrocommunity package i tried. like mini-clue or trouble and so on.

- [x] fixed for every plugin that had a catppuccin integration.

