### PR TITLE
fix(rust): preserve loading of rust-analyzer.json

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -86,7 +86,23 @@ return {
       end
 
       local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
-      return { server = astrolsp_avail and astrolsp.lsp_opts "rust_analyzer", dap = { adapter = adapter } }
+      local astrolsp_opts = (astrolsp_avail and astrolsp.lsp_opts "rust_analyzer") or {}
+      local server = {
+        ---@type table | (fun(project_root:string|nil, default_settings: table|nil):table) -- The rust-analyzer settings or a function that creates them.
+        settings = function(project_root, default_settings)
+          local astrolsp_settings = astrolsp_opts.settings or {}
+
+          local merge_table = require("astrocore").extend_tbl(default_settings or {}, astrolsp_settings)
+          local ra = require "rustaceanvim.config.server"
+          -- load_rust_analyzer_settings merges any found settings with the passed in default settings table and then returns that table
+          return ra.load_rust_analyzer_settings(project_root, {
+            settings_file_pattern = "rust-analyzer.json",
+            default_settings = merge_table,
+          })
+        end,
+      }
+      local final_server = require("astrocore").extend_tbl(astrolsp_opts, server)
+      return { server = final_server, dap = { adapter = adapter } }
     end,
     config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
   },


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

merge astrolsp settings in such a way as to preserve the default behavior of loading local project settings from rust-analyzer.json

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

The default behavior of rustaceanvim is to load a `rust-analyzer.json` at the project root to load rust-anlyzer settings
see:
[rustaceanvim/config/server.lua#L15](https://github.com/mrcjkb/rustaceanvim/blob/b5d6ac50b3f87a6e8fae27cb8d8e49a6ca653aa6/lua/rustaceanvim/config/server.lua#L15)
[rustaceanvim/config/internal.lua#L287](https://github.com/mrcjkb/rustaceanvim/blob/b5d6ac50b3f87a6e8fae27cb8d8e49a6ca653aa6/lua/rustaceanvim/config/internal.lua#L287)

this file can have any of the keys defined in https://rust-analyzer.github.io/manual.html#configuration
either at the top level of the json or under a `'rust-analyzer'` top level key

This is done by having `server.settings` be a function that takes the project root path and the default settings configured at `server.default_settings` and calling rustaceanvim's `rustaceanvim.config.server.load_rust_analyzer_settings(root, opts)` function.

This change configures rustaceanvim by merging the astrolsp configured opts *around* a similar function that itself merges the astrolsp configured settings table with the defaults before loading the `rust-analyzer.json`

![image](https://github.com/AstroNvim/astrocommunity/assets/508861/0dce9cfa-1ad3-4763-a721-52932a9c8a22)

as you can see, it's working as expected
