### PR TITLE
fix(rust): fix clippy config, add `--no-deps` arg

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -22,6 +22,9 @@ return {
             ["rust-analyzer"] = {
               check = {
                 command = "clippy",
+                extraArgs = {
+                  "--no-deps",
+                },
               },
               assist = {
                 importEnforceGranularity = true,
@@ -102,7 +105,7 @@ return {
         end,
       }
       local final_server = require("astrocore").extend_tbl(astrolsp_opts, server)
-      return { server = final_server, dap = { adapter = adapter } }
+      return { server = final_server, dap = { adapter = adapter }, tools = { enable_clippy = false } }
     end,
     config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
   },


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Prevent rustaceanvim from enabling clippy on it's own. This results in a bad config atm. and would clash with any user provided config / this packs config if it worked.

Add the `--no-deps` clippy arg to not lint dependencies by default

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
this would fix rustacenvim 's bad clippy config but we should still disable it because it on it's side because will overwrite ours when
`load_rust_analyzer_settings` is called
https://github.com/mrcjkb/rustaceanvim/pull/403
