### PR TITLE
fix(go): modify the `build` callback to avoid freezing on `go.nvim` installation

### DIFF
--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -120,7 +120,9 @@ return {
     },
     event = { "CmdlineEnter" },
     ft = { "go", "gomod" },
-    build = ':lua require("go.install").update_all_sync()',
+    -- Prevents Neovim from freezing on plugin installation/update.
+    -- See: <https://github.com/ray-x/go.nvim/issues/433>
+    build = function() require("go.install").update_all() end,
   },
   {
     "nvim-neotest/neotest",


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Currently, Neovim will freeze when installing/updating `go.nvim` due to the synchronous callback trying to install relevant Golang CLI devtools. This PR stops that from happening via an asynchronous callback instead.

cc https://github.com/ray-x/go.nvim/issues/433

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

I have locally tested this change on my machine using the following override:

```lua
  -- astrocommunity.pack.go
  {
    "ray-x/go.nvim",
    build = function() require("go.install").update_all() end,
  },
```
