### PR TITLE
feat: add several new plugins and modularize the clojure pack

### DIFF
--- a/lua/astrocommunity/code-runner/conjure/README.md
+++ b/lua/astrocommunity/code-runner/conjure/README.md
@@ -1,0 +1,5 @@
+# Conjure
+
+Interactive evaluation for Neovim (Clojure, Fennel, Janet, Racket, Hy, MIT Scheme, Guile, Python and more!)
+
+**Repository:** <https://github.com/Olical/conjure>

--- a/lua/astrocommunity/code-runner/conjure/init.lua
+++ b/lua/astrocommunity/code-runner/conjure/init.lua
@@ -1,0 +1,4 @@
+return {
+  "Olical/conjure",
+  ft = { "clojure", "janet", "fennel", "racket", "hy", "scheme", "guile", "julia", "lua", "lisp" },
+}

--- a/lua/astrocommunity/editing-support/nvim-parinfer/README.md
+++ b/lua/astrocommunity/editing-support/nvim-parinfer/README.md
@@ -1,0 +1,7 @@
+## nvim-parinfer
+
+parinfer for Neovim
+
+Supported Languages: Clojure, Scheme, LISP, Racket, Hy, Fennel, Janet, Carp, Wast, Yuck, Dune
+
+**Repository:** <https://github.com/gpanders/nvim-parinfer>

--- a/lua/astrocommunity/editing-support/nvim-parinfer/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-parinfer/init.lua
@@ -1,0 +1,12 @@
+return {
+  "gpanders/nvim-parinfer",
+  ft = { "clojure", "scheme", "lisp", "racket", "hy", "fennel", "janet", "carp", "wast", "yuck", "dune" },
+  dependencies = {
+    "AstroNvim/astrocore",
+    opts = {
+      options = { g = {
+        parinfer_force_balance = true,
+      } },
+    },
+  },
+}

--- a/lua/astrocommunity/editing-support/nvim-treesitter-sexp/README.md
+++ b/lua/astrocommunity/editing-support/nvim-treesitter-sexp/README.md
@@ -1,0 +1,7 @@
+## nvim-treesitter-sexp
+
+A plugin for Neovim for editing code by manipulating the Treesitter AST. Basically a reimplementation of vim-sexp using treesitter queries. This is particularly useful for editing Lisps and manipulating data structures
+
+Supported Languages: Clojure, Fennel, Janet, Query
+
+**Repository:** <https://github.com/PaterJason/nvim-treesitter-sexp>

--- a/lua/astrocommunity/editing-support/nvim-treesitter-sexp/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-treesitter-sexp/init.lua
@@ -1,0 +1,7 @@
+return {
+  "PaterJason/nvim-treesitter-sexp",
+  dependencies = { "nvim-treesitter/nvim-treesitter" },
+  ft = { "clojure", "fennel", "janet", "query" },
+  cmd = "TSSexp",
+  opts = {},
+}

--- a/lua/astrocommunity/pack/clojure/README.md
+++ b/lua/astrocommunity/pack/clojure/README.md
@@ -1,33 +1,26 @@
 # Clojure Language Pack
 
-Requires:
+Include the Clojure language pack in the `lua/community.lua` file
 
-- Java Development Kit, e.g. `JDK-17`
+```lua
+  { import = "astrocommunity.pack.clojure" },
+```
+
+The Clojure pack requires:
+
+- Java Development Kit, e.g. [Practicalli - Install Java host for Clojure](https://practical.li/clojure/install/java/)
 - [Clojure CLI](https://clojure.org/guides/install_clojure) or [Leiningen](https://leiningen.org/)
 
-This plugin pack does the following:
+The Clojure language pack includes:
 
-- Adds `clojure` treesitter parsers
-- Adds `clojure_ls` language server
-- Adds [Olical/conjure](https://github.com/Olical/conjure) and [gpanders/nvim-parinfer](https://github.com/gpanders/nvim-parinfer) plugins
+- `clojure` treesitter parsers
+- `clojure-ls` language server
+- Clojure REPL client: [Olical/conjure](https://github.com/Olical/conjure)
+- Structural editing: [gpanders/nvim-parinfer](https://github.com/gpanders/nvim-parinfer) & plugins
 - Add autocmd to disable lsp diagnostics in Conjure log
 - Add autocmd to configure comments to Clojure style guide
 
-## Additional Config
-
-Add a localleader mapping to the user config (if not defined in AstroNvim) to enable Conjure key mappings, e.g. `, e r` to evaluate top level root
-
-Define a localleader mapping in `options.lua`
-
-```lua
-return {
-  g = {
-    mapleader = " ",                 -- sets vim.g.mapleader
-    maplocalleader = ",",            -- Set local leader key binding
-    -- additional options...
-  },
-}
-```
+> NOTE: The conjure HUD is not shown by default. Consider using `,lt` to open the REPL log in its own tab split, with `gt` to toggle between code and REPL log.
 
 ## Clojure Guides
 
@@ -36,3 +29,148 @@ return {
 - [Clojure.org](https://clojure.org/index) API reference and guides
 - [Conjure - Clojure guide](https://github.com/Olical/conjure/wiki/Quick-start:-Clojure)
 - [Practicalli Neovim](https://practical.li/neovim/) Clojure development workflow
+
+## Override Configuration
+
+Configuration in the AstroNvim Community clojure language pack can be overridden and plugins disabled to meet your needs
+
+### Parinfer
+
+By aligning clojure code correctly, parinfer will automatically correct the position of parenthesis and other delimiters, i.e. `()`, `[]`, `{}`
+
+Parinfer can be disabled if preferred and the more traditional slurp/barf structural editing be done via [nvim-treesitter-sexp](#nvim-treesitter-sexp)
+
+Include the Clojure language pack and disable the parinfer plugin by setting the plugin name to equal false
+
+```lua
+  { import = "astrocommunity.pack.clojure" },
+  { "gpanders/nvim-parinfer", enabled = false },
+```
+
+### Conjure
+
+Configure the Clojure REPL client via the conjure plugin.
+
+> NOTE: `:help conjure-client-clojure-nrepl` for full list of Conjure options for Clojure.
+
+Enable the REPL log HUD and set location to full width along the bottom of the sCReen. Note: without setting the location, the HUD will appear in the top right corner of the sCReen.
+
+```lua
+            ["conjure#log#hud#enabled"] = true,  -- enable HUD
+            ["conjure#log#hud#width"] = 1,
+            ["conjure#log#hud#anchor"] = "SE",
+            ["conjure#log#botright"] = true,
+```
+
+Disable the auto repl (babashka) if an nREPL process is not listening, i.e. `.nrepl-port` file does not exist or does not contain a port number.
+
+```lua
+            -- Disable auto repl (babashka)
+            ["conjure#client#clojure#nrepl#connection#auto_repl#enabled"] = false,
+            ["conjure#client#clojure#nrepl#connection#auto_repl#hidden"] = true,
+            ["conjure#client#clojure#nrepl#connection#auto_repl#cmd"] = nil,
+            ["conjure#client#clojure#nrepl#eval#auto_require"] = false,
+
+```
+
+Change the test runner used by Conjure. `clojure.test` runner is used by default
+
+- `"clojure"` clojure.test (default)
+- `"clojuresCRipt" cljs.test
+- `"kaocha"` lambdaisland/kaocha
+
+```lua
+            -- Set Test runner: "clojure", "clojuresCRipt", "kaocha"
+            ["conjure#client#clojure#nrepl#test#runner"] = "kaocha",
+```
+
+Working example with additional configuration options to show HUD along bottom, enable auto repl if no nREPL process found and set test runner to use lambdaisland/kaocha.
+
+```lua
+  { import = "astrocommunity.pack.clojure" },
+  {
+    "AstroNvim/astrocore",
+    opts = {
+      options = {
+        g = {
+          -- Enable HUD and show full lenght along bottom
+          ["conjure#log#hud#enabled"] = true, -- show log by default?
+          ["conjure#log#hud#width"] = 1,
+          ["conjure#log#hud#anchor"] = "SE",
+          ["conjure#log#botright"] = true,
+
+          -- Disable auto repl (babashka)
+          ["conjure#client#clojure#nrepl#connection#auto_repl#enabled"] = false,
+          ["conjure#client#clojure#nrepl#connection#auto_repl#hidden"] = true,
+          ["conjure#client#clojure#nrepl#connection#auto_repl#cmd"] = nil,
+          ["conjure#client#clojure#nrepl#eval#auto_require"] = false,
+
+          -- Set Test runner: "clojure", "clojuresCRipt", "kaocha"
+          ["conjure#client#clojure#nrepl#test#runner"] = "kaocha",
+        },
+      },
+    },
+  },
+```
+
+### nvim-treesitter-sexp
+
+Treesitter based structural editing with normal mode key mappings, which can be set to false to disable. Two commands are disabled in the example.
+
+Additional which-key keymaps can be included for greater discoverability. Example includes keymaps inspired by Spacemacs Lisp mode, `SPC k`.
+
+```lua
+  { import = "astrocommunity.pack.clojure" },
+  {
+    "PaterJason/nvim-treesitter-sexp",
+    dependencies = {
+      "AstroNvim/astrocore",
+      opts = {
+        -- configuration & keymaps overrides:
+        -- https://github.com/PaterJason/nvim-treesitter-sexp#configuration
+        -- enabled = false,  -- Set to false to disable individual keymaps
+        -- set_cursor = true,
+        -- keymaps = {        -- (1)!
+        -- Default key bindings - set to false to disable
+        --   commands = {
+        --     promote_elem = false,
+        --     promote_form = false,
+        --   },
+        --   motions = {
+        --   },
+        --   textobjects = {
+        --   },
+        -- },
+        options = {
+          g = {},
+        },
+        mappings = {       -- (2)!
+          n = {
+            -- Additional Which-key key bindings for nvim-treesitter-sexp
+            ["<Leader>k"] = { name = "Structural Editing" },
+            ["<Leader>kE"] = { "<Cmd>TSSexp swap_prev_elem<CR>", desc = "Swap Previous Element" },
+            ["<Leader>ke"] = { "<Cmd>TSSexp swap_next_elem<CR>", desc = "Swap Previous Element" },
+            ["<Leader>kF"] = { "<Cmd>TSSexp swap_prev_form<CR>", desc = "Swap Previous Form" },
+            ["<Leader>kf"] = { "<Cmd>TSSexp swap_next_form<CR>", desc = "Swap Previous Form" },
+            ["<Leader>kk"] = { "<Cmd>TSSexp promote_elem<CR>", desc = "Promote Element" },
+            ["<Leader>kr"] = { "<Cmd>TSSexp promote_form<CR>", desc = "Promote Form" },
+            ["<Leader>k@"] = { "<Cmd>TSSexp splice<CR>", desc = "Splice" },
+            ["<Leader>kS"] = { "<Cmd>TSSexp slurp_left<CR>", desc = "Slurp Left" },
+            ["<Leader>ks"] = { "<Cmd>TSSexp slurp_right<CR>", desc = "Slurp Right" },
+            ["<Leader>kB"] = { "<Cmd>TSSexp barf_left<CR>", desc = "Barf Left" },
+            ["<Leader>kb"] = { "<Cmd>TSSexp barf_right<CR>", desc = "Barf Right" },
+            ["<Leader>kI"] = { "<Cmd>TSSexp barf_right<CR>", desc = "Insert Head" },
+            ["<Leader>ki"] = { "<Cmd>TSSexp barf_right<CR>", desc = "Insert Tail" },
+          },
+          t = {
+            -- terminal? mode key bindings
+          },
+          v = {
+            -- visual mode key bindings
+          },
+        },
+      },
+    },
+  },
+
+```

--- a/lua/astrocommunity/pack/clojure/init.lua
+++ b/lua/astrocommunity/pack/clojure/init.lua
@@ -1,5 +1,14 @@
--- Clojure support with Conjure plugin
-return {
+-- ------------------------------------------
+-- Clojure language pack
+--
+-- clojure-lsp server via mason
+-- treesitter clojure parser
+-- ts-comment.nvim with `;;` and `;` support
+-- structured editing with parinfer and treesitter-sexp plugins
+-- REPL connected editor with Conjure plugin (log HUD hidden by default)
+-- ------------------------------------------
+
+local plugins = {
   -- Clojure Language Server
   {
     "williamboman/mason-lspconfig.nvim",
@@ -25,60 +34,17 @@ return {
       end
     end,
   },
-  -- Parinfer parens management for Clojure
-  {
-    "gpanders/nvim-parinfer",
-    ft = { "clojure" },
-    dependencies = {
-      "AstroNvim/astrocore",
-      opts = {
-        options = { g = {
-          parinfer_force_balance = true,
-          parinfer_comment_chars = ";;",
-        } },
-      },
-    },
-  },
+
   -- Conjure plugin for Clojure REPL
-  {
-    "Olical/conjure",
-    -- load plugin on filetypes
-    ft = { "clojure" },
-    dependencies = {
-      "AstroNvim/astrocore",
-      opts = {
-        autocmds = {
-          conjure_log_disable_lsp = {
-            {
-              event = "BufNewFile",
-              pattern = { "conjure-log-*" },
-              callback = function() vim.diagnostic.disable(0) end,
-              desc = "Conjure Log disable LSP diagnostics",
-            },
-            {
-              event = "FileType",
-              pattern = { "clojure" },
-              callback = function() vim.bo.commentstring = ";; %s" end,
-              desc = "Lisp style line comment",
-            },
-          },
-        },
-        options = {
-          g = {
-            ["conjure#log#hud#width"] = 1,
-            ["conjure#log#hud#enabled"] = false,
-            ["conjure#log#hud#anchor"] = "SE",
-            ["conjure#log#botright"] = true,
-            ["conjure#extract#context_header_lines"] = 100,
-            ["conjure#eval#comment_prefix"] = ";; ",
-            ["conjure#client#clojure#nrepl#connection#auto_repl#enabled"] = false,
-            ["conjure#client#clojure#nrepl#connection#auto_repl#hidden"] = true,
-            ["conjure#client#clojure#nrepl#connection#auto_repl#cmd"] = nil,
-            ["conjure#client#clojure#nrepl#eval#auto_require"] = false,
-            ["conjure#client#clojure#nrepl#test#runner"] = "kaocha",
-          },
-        },
-      },
-    },
-  },
+  { import = "astrocommunity.code-runner.conjure" },
+
+  -- Parinfer parens management for Clojure
+  { import = "astrocommunity.editing-support.nvim-parinfer" },
+
+  -- Treesitter structural editing
+  { import = "astrocommunity.editing-support.nvim-treesitter-sexp" },
 }
+
+if vim.fn.has "nvim-0.10" then table.insert(plugins, { import = "astrocommunity.comment.ts-comments-nvim" }) end
+
+return plugins


### PR DESCRIPTION
## 📑 Description

Provide both approaches to structural editing Clojure code (paredit & parinfer) and remove the more opinionated configurations for Conjure REPL client.

- add nvim-treesitter-sexp for slurp/barf style structured editing
- add ts-comments.nvim to support `;;` and `;` line & partial line comments (removing need for autocmd)
- drop the more opinionated conjure config overrides
- elaborate on use and overrides in readme

## ℹ Additional Information

Conjure plugin will disable diagnostics in the REPL log (HUD), removing the need to define the autocmd to disable them.

> If you prefer I submit this as 4 separate PR's then let me know...