### PR TITLE
fix(noice-nvim)!: disabled the signature to fix the overwritten lsp signature

### DIFF
--- a/lua/astrocommunity/utility/noice-nvim/init.lua
+++ b/lua/astrocommunity/utility/noice-nvim/init.lua
@@ -44,6 +44,9 @@ return {
       local utils = require "astrocore"
       return utils.extend_tbl(opts, {
         lsp = {
+          signature = {
+            enabled = false,
+          },
           -- override markdown rendering so that **cmp** and other plugins use **Treesitter**
           override = {
             ["vim.lsp.util.convert_input_to_markdown_lines"] = true,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
when first opening neovim v0.10.0 with noice plugin installed it will throws error like this 
`vim.lsp.handlers["textDocument/signatureHelp"] has been overwritten by another plugin?`

add ```lsp = { signature = { enabled = false } }``` to disabled the overwritten lsp signature

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
