### PR TITLE
docs(project-nvim): correct link to plugin repository

### DIFF
--- a/lua/astrocommunity/project/project-nvim/README.md
+++ b/lua/astrocommunity/project/project-nvim/README.md
@@ -2,4 +2,4 @@
 
 The superior project management solution for neovim.
 
-**Repository:** <https://github.com/ahmedkhalf/project.nvim>
+**Repository:** <https://github.com/jay-babu/project.nvim>


### PR DESCRIPTION
The plugin actually installed is [jay-babu/project.nvim](https://github.com/jay-babu/project.nvim) which is a fork of [ahmedkhalf/project.nvim](https://github.com/ahmedkhalf/project.nvim).

For users willing to override its configuration, it's better to have the correct link, since the fork may introduce incompatible changes.