### PR TITLE
fix(toggleterm-manager): add missing keybindings documented

### DIFF
--- a/lua/astrocommunity/terminal-integration/toggleterm-manager-nvim/init.lua
+++ b/lua/astrocommunity/terminal-integration/toggleterm-manager-nvim/init.lua
@@ -32,6 +32,12 @@ return {
           ["d"] = { action = actions.delete_term, exit_on_action = false }, -- deletes a terminal buffer
           ["n"] = { action = actions.create_term, exit_on_action = false }, -- creates a new terminal buffer
         },
+        i = {
+          ["<CR>"] = { action = actions.toggle_term, exit_on_action = true }, -- toggles terminal open/closed
+          ["<C-r>"] = { action = actions.rename_term, exit_on_action = false }, -- provides a prompt to rename a terminal
+          ["<C-d>"] = { action = actions.delete_term, exit_on_action = false }, -- deletes a terminal buffer
+          ["<C-n>"] = { action = actions.create_term, exit_on_action = false }, -- creates a new terminal buffer
+        },
       },
     })
   end,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

As described in the title, I added two set of keybindings for the telescope interface, which were already documented in the README, but the insert mode keybindings were mistakenly removed during the handling of my initial PR. Therefore this pr try to fix this problem by reintroducing the keybindings.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
