### PR TITLE
docs(project-nvim): add note about built-in functionality

### DIFF
--- a/lua/astrocommunity/project/project-nvim/README.md
+++ b/lua/astrocommunity/project/project-nvim/README.md
@@ -3,3 +3,5 @@
 The superior project management solution for neovim.
 
 **Repository:** <https://github.com/jay-babu/project.nvim>
+
+_Note_: The functionality of this plugin is part of AstroNvim as of [v4.0.0](https://github.com/AstroNvim/AstroNvim/releases/tag/v4.0.0). To enable automatic `:cd` or chdir to project root, or to configure other options, see the [project rooter documentation](https://docs.astronvim.com/recipes/rooter/). Enabling this plugin will disable the built-in project rooter.


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
Adds a brief note to the project-nvim README.md file that AstroNvim contains a built-in Project Rooter, and if the community plugin is enabled, the built-in functionality will be disabled.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

This PR originated from a discord conversation in the #astrocommunity channel.

> @rocode: Should community plugins have a note on them if their functionality was already upstreamed or incorporated into AstroCore? For example, I just realized I didn't need project-nvim after seeing the Project Rooter recipe in the docs, but trying to migrate over caused confusion because it isn't documented that it turns off the built-in functionality.
>[...]
>@mehalter: yeah that would be great! If you open a PR it would be good to note on that plugin (and maybe the other project plugins) that there is a new rooter in AstroNvim that is on demand by default and opt in for automatic root changing
