### PR TITLE
fix(vim-visual-multi): dependencies name correction

### DIFF
--- a/lua/astrocommunity/editing-support/vim-visual-multi/init.lua
+++ b/lua/astrocommunity/editing-support/vim-visual-multi/init.lua
@@ -2,7 +2,7 @@ return {
   "mg979/vim-visual-multi",
   event = { "User AstroFile", "InsertEnter" },
   dependencies = {
-    "astronvim/astrocore",
+    "AstroNvim/astrocore",
     ---@param opts astrocoreopts
     opts = function(_, opts)
       if not opts.options then opts.options = {} end


### PR DESCRIPTION
## 📑 Description

`AstroNvim/astrocore` dependencies name replacing incorrect `astronvim/astrocore` name

## ℹ Additional Information

Causes `:checkhealth` to fail due to the same plugin being referred to by two different URLs
