### PR TITLE
feat(java): enable inlay hints by default

### DIFF
--- a/lua/astrocommunity/pack/java/init.lua
+++ b/lua/astrocommunity/pack/java/init.lua
@@ -92,6 +92,7 @@ return {
             maven = { downloadSources = true },
             implementationsCodeLens = { enabled = true },
             referencesCodeLens = { enabled = true },
+            inlayHints = { parameterNames = { enabled = "all" } },
           },
           signatureHelp = { enabled = true },
           completion = {


### PR DESCRIPTION
## 📑 Description

With the release of Neovim 0.10 we should enable inlay hints by default. Without this, toggling AstroNvim inlay hints (\<leader\>uh/\<leader\>uH) will not have any effect on Java project.