### PR TITLE
feat(vue): configure volar as tsserver plugin

### DIFF
--- a/lua/astrocommunity/pack/vue/init.lua
+++ b/lua/astrocommunity/pack/vue/init.lua
@@ -1,4 +1,5 @@
 return {
+  { import = "astrocommunity.pack.typescript" },
   {
     "AstroNvim/astrolsp",
     optional = true,
@@ -36,6 +37,33 @@ return {
               },
             },
           },
+        },
+        vtsls = {
+          settings = {
+            vtsls = {
+              tsserver = {
+                globalPlugins = {},
+              },
+            },
+          },
+          before_init = function(_, config)
+            local astrocore_ok, astrocore = pcall(require, "astrocore")
+            local registry_ok, registry = pcall(require, "mason-registry")
+            if not astrocore_ok or not registry_ok then return end
+
+            local volar_install_path = registry.get_package("vue-language-server"):get_install_path()
+              .. "/node_modules/@vue/language-server"
+
+            local vue_plugin_config = {
+              name = "@vue/typescript-plugin",
+              location = volar_install_path,
+              languages = { "vue" },
+              configNamespace = "typescript",
+              enableForWorkspaceTypeScriptVersions = true,
+            }
+
+            astrocore.list_insert_unique(config.settings.vtsls.tsserver.globalPlugins, { vue_plugin_config })
+          end,
         },
       },
     },


### PR DESCRIPTION

## 📑 Description
Add Volar as a tsserver plugin, configured with vtsls.

## ℹ Additional Information

In  [`volar >= 2.0`](https://github.com/vuejs/language-tools/tree/master/packages/typescript-plugin), some synchronization problems between tsserver and volar appear, causing errors when working with .ts and .vue files at the same time.

An issue for this is being tracked (yioneko/vtsls#148)