### PR TITLE
fix(bufferline-nvim): add bufferline cycle bindings

### DIFF
--- a/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
@@ -1,6 +1,19 @@
 return {
   {
     "akinsho/bufferline.nvim",
+    dependencies = {
+      {
+        "AstroNvim/astrocore",
+        opts = {
+          mappings = {
+            n = {
+              ["]b"] = { function() require("bufferline.commands").cycle(1) end, desc = "Next buffer" },
+              ["[b"] = { function() require("bufferline.commands").cycle(-1) end, desc = "Previous buffer" },
+            },
+          },
+        },
+      },
+    },
     event = "VeryLazy",
     opts = {
       options = {


### PR DESCRIPTION
Map `[b` and `]b` to the bufferline-specific calls for cycling buffers.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

I included `astrocommunity.bars-and-lines.bufferline-nvim` and observed the `]b` and `[b` bindings not behaving correctly. They were switching buffers, but out-of-order w.r.t. how they were displayed in bufferline. This PR remaps those to call bufferline's specific API for cycling through tabs. With this custom binding added, I now observe the correct behavior.


## ℹ Additional Information

It's not super straightforward to repro. Sometimes, I open a project, open various buffers, and press `]b` and the ordering is correct. Other times, after opening some buffers, say with `gd` or from telescope searches, the buffer navigation starts happening out of order.
