### PR TITLE
fix(trouble-nvim): change commands in keymaps to v3 replacements

### DIFF
--- a/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
@@ -11,17 +11,16 @@ return {
           local prefix = "<Leader>x"
           maps.n[prefix] = { desc = require("astroui").get_icon("Trouble", 1, true) .. "Trouble" }
           maps.n[prefix .. "X"] =
-            { "<Cmd>TroubleToggle workspace_diagnostics<CR>", desc = "Workspace Diagnostics (Trouble)" }
-          maps.n[prefix .. "x"] =
-            { "<Cmd>TroubleToggle document_diagnostics<CR>", desc = "Document Diagnostics (Trouble)" }
-          maps.n[prefix .. "l"] = { "<Cmd>TroubleToggle loclist<CR>", desc = "Location List (Trouble)" }
-          maps.n[prefix .. "q"] = { "<Cmd>TroubleToggle quickfix<CR>", desc = "Quickfix List (Trouble)" }
+            { "<cmd>Trouble diagnostics toggle filter.buf=0<cr>", desc = "Buffer Diagnostics (Trouble)" }
+          maps.n[prefix .. "x"] = { "<Cmd>Trouble diagnostics toggle<CR>", desc = "Diagnostics (Trouble)" }
+          maps.n[prefix .. "l"] = { "<cmd>Trouble loclist toggle<cr>", desc = "Location List (Trouble)" }
+          maps.n[prefix .. "q"] = { "Trouble qflist toggle", desc = "Quickfix List (Trouble)" }
           if require("astrocore").is_available "todo-comments.nvim" then
-            maps.n["<leader>xt"] = {
+            maps.n[prefix .. "t"] = {
               "<cmd>TodoTrouble<cr>",
               desc = "Todo (Trouble)",
             }
-            maps.n["<leader>xT"] = {
+            maps.n[prefix .. "T"] = {
               "<cmd>TodoTrouble keywords=TODO,FIX,FIXME<cr>",
               desc = "Todo/Fix/Fixme (Trouble)",
             }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
Changes the commands in keymaps to the v3 replacements.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
