### PR TITLE
fix(java): update for the latest settings hierarchy

### DIFF
--- a/lua/astrocommunity/pack/java/init.lua
+++ b/lua/astrocommunity/pack/java/init.lua
@@ -93,23 +93,23 @@ return {
             implementationsCodeLens = { enabled = true },
             referencesCodeLens = { enabled = true },
             inlayHints = { parameterNames = { enabled = "all" } },
-          },
-          signatureHelp = { enabled = true },
-          completion = {
-            favoriteStaticMembers = {
-              "org.hamcrest.MatcherAssert.assertThat",
-              "org.hamcrest.Matchers.*",
-              "org.hamcrest.CoreMatchers.*",
-              "org.junit.jupiter.api.Assertions.*",
-              "java.util.Objects.requireNonNull",
-              "java.util.Objects.requireNonNullElse",
-              "org.mockito.Mockito.*",
+            signatureHelp = { enabled = true },
+            completion = {
+              favoriteStaticMembers = {
+                "org.hamcrest.MatcherAssert.assertThat",
+                "org.hamcrest.Matchers.*",
+                "org.hamcrest.CoreMatchers.*",
+                "org.junit.jupiter.api.Assertions.*",
+                "java.util.Objects.requireNonNull",
+                "java.util.Objects.requireNonNullElse",
+                "org.mockito.Mockito.*",
+              },
             },
-          },
-          sources = {
-            organizeImports = {
-              starThreshold = 9999,
-              staticStarThreshold = 9999,
+            sources = {
+              organizeImports = {
+                starThreshold = 9999,
+                staticStarThreshold = 9999,
+              },
             },
           },
         },


### PR DESCRIPTION

## 📑 Description

`jdtls` changed the settings hierarchy; for instance, they moved `settings.completion` to `settings.java.completion`. 
This PR moved these settings.

## ℹ Additional Information

This document described the most recent setting hierarchy:
[Jdtls Initialize Request](https://github.com/eclipse-jdtls/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#initialize-request)
