### PR TITLE
feat(recipes): add auto-session-restore

### DIFF
--- a/lua/astrocommunity/recipes/auto-session-restore/README.md
+++ b/lua/astrocommunity/recipes/auto-session-restore/README.md
@@ -1,0 +1,6 @@
+# AstroLSP - Automatically Restore Previous Session
+
+**Website:** <https://docs.astronvim.com/recipes/sessions/#automatically-restore-previous-session>
+
+This plugin specification configures AstroLSP to automatically
+restore their previous session for a given directory when opening Neovim with no arguments.

--- a/lua/astrocommunity/recipes/auto-session-restore/init.lua
+++ b/lua/astrocommunity/recipes/auto-session-restore/init.lua
@@ -1,0 +1,33 @@
+local read_from_stdin = false
+return {
+  {
+    "AstroNvim/astrocore",
+    ---@type AstroCoreOpts
+    opts = {
+      autocmds = {
+        -- disable alpha autostart
+        alpha_autostart = false,
+        restore_session = {
+          {
+            event = "StdinReadPost",
+            desc = "Check if we are reading from stdin",
+            nested = true,
+            callback = function() read_from_stdin = true end,
+          },
+          {
+            event = "VimEnter",
+            desc = "Restore previous directory session if neovim opened with no arguments",
+            nested = true, -- trigger other autocommands as buffers open
+            callback = function()
+              -- Only load the session if nvim was started with no args
+              if not read_from_stdin and vim.fn.argc(-1) == 0 then
+                -- try to load a directory session using the current working directory
+                require("resession").load(vim.fn.getcwd(), { dir = "dirsession", silence_errors = true })
+              end
+            end,
+          },
+        },
+      },
+    },
+  },
+}

--- a/lua/astrocommunity/recipes/auto-session-restore/init.lua
+++ b/lua/astrocommunity/recipes/auto-session-restore/init.lua
@@ -1,4 +1,3 @@
-local read_from_stdin = false
 return {
   {
     "AstroNvim/astrocore",
@@ -9,20 +8,37 @@ return {
         alpha_autostart = false,
         restore_session = {
           {
-            event = "StdinReadPost",
-            desc = "Check if we are reading from stdin",
-            nested = true,
-            callback = function() read_from_stdin = true end,
-          },
-          {
             event = "VimEnter",
             desc = "Restore previous directory session if neovim opened with no arguments",
             nested = true, -- trigger other autocommands as buffers open
             callback = function()
-              -- Only load the session if nvim was started with no args
-              if not read_from_stdin and vim.fn.argc(-1) == 0 then
-                -- try to load a directory session using the current working directory
-                require("resession").load(vim.fn.getcwd(), { dir = "dirsession", silence_errors = true })
+              -- Logic copied from https://github.com/AstroNvim/AstroNvim/blob/365aa6e083dcd25fa3d1c8a2515d7e71a03d51d3/lua/astronvim/plugins/alpha.lua#L49
+              local should_skip
+              local lines = vim.api.nvim_buf_get_lines(0, 0, 2, false)
+              if
+                vim.fn.argc() > 0 -- don't start when opening a file
+                or #lines > 1 -- don't open if current buffer has more than 1 line
+                or (#lines == 1 and lines[1]:len() > 0) -- don't open the current buffer if it has anything on the first line
+                or #vim.tbl_filter(function(bufnr) return vim.bo[bufnr].buflisted end, vim.api.nvim_list_bufs()) > 1 -- don't open if any listed buffers
+                or not vim.o.modifiable -- don't open if not modifiable
+              then
+                should_skip = true
+              else
+                for _, arg in pairs(vim.v.argv) do
+                  if arg == "-b" or arg == "-c" or vim.startswith(arg, "+") or arg == "-S" then
+                    should_skip = true
+                    break
+                  end
+                end
+              end
+              if should_skip then return end
+              -- if possible, load session
+              if not pcall(function() require("resession").load(vim.fn.getcwd(), { dir = "dirsession" }) end) then
+                -- if session was not loaded, if possible, load alpha
+                require("lazy").load { plugins = { "alpha-nvim" } }
+                if pcall(function() require("alpha").start(true) end) then
+                  vim.schedule(function() vim.cmd.doautocmd "FileType" end)
+                end
               end
             end,
           },


### PR DESCRIPTION
## 📑 Description

Adds auto-session-restore like in documentation, but also detect if nvim has been started with stdin redirected, like `stream | nvim` or like `export MAPAGER='nvim +Man!'; man man`.

The stdin detection is taken from https://github.com/thaerkh/vim-workspace/blob/master/plugin/workspace.vim#L268 .

## ℹ Additional Information

Would be nice to add the stdin input handling also to documentation.