### PR TITLE
fix(go): Remove iferr package from jay-babu/mason-null-ls.nvim and WhoIsSethDaniel/mason-tool-installer.nvim lists

### DIFF
--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -72,7 +72,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(
         opts.ensure_installed,
-        { "gomodifytags", "gofumpt", "iferr", "impl", "goimports" }
+        { "gomodifytags", "gofumpt", "impl", "goimports" }
       )
     end,
   },
@@ -89,7 +89,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(
         opts.ensure_installed,
-        { "delve", "gopls", "gomodifytags", "gofumpt", "iferr", "impl", "goimports" }
+        { "delve", "gopls", "gomodifytags", "gofumpt", "impl", "goimports" }
       )
     end,
   },


### PR DESCRIPTION
## 📑 Description

The iferr package install currently fails with the following error msg: 
```sh
$ go install github.com/koron/iferr@latest
go: github.com/koron/iferr@latest (in github.com/koron/iferr@v0.0.0-20240122035601-9c3e2fbe4bd1): go.mod:3: invalid go version '1.21.5': must match format 1.23
$ 
```
Until the package maintainer fixes it, we should remove this package from the list to avoid a bad user experience.
