### PR TITLE
fix(bufferline-nvim): add back bufferline leader bindings

### DIFF
--- a/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
@@ -18,6 +18,86 @@ return {
                 function() require("bufferline.commands").move(-vim.v.count1) end,
                 desc = "Move buffer tab left",
               },
+              ["<leader>bb"] = {
+                function()
+                  require("bufferline.commands").pick()
+                end,
+                desc = "Navigate to buffer tab with interactive picker",
+              },
+              ["<leader>bc"] = {
+                function()
+                  require("bufferline.commands").close_others()
+                end,
+                desc = "Close all buffers except the current",
+              },
+              ["<leader>bd"] = {
+                function()
+                  require("bufferline.commands").close_with_pick()
+                end,
+                desc = "Delete a buffer tab with interactive picker",
+              },
+              ["<leader>bl"] = {
+                function()
+                  require("bufferline.commands").close_in_direction("left")
+                end,
+                desc = "Close all buffers to the left of the current",
+              },
+              ["<leader>br"] = {
+                function()
+                  require("bufferline.commands").close_in_direction("right")
+                end,
+                desc = "Close all buffers to the right of the current",
+              },
+              ["<leader>bse"] = {
+                function()
+                  require("bufferline.commands").sort_by("extension")
+                end,
+                desc = "Sort buffers by extension",
+              },
+              ["<leader>bsi"] = {
+                function()
+                  require("bufferline.commands").sort_by("id")
+                end,
+                desc = "Sort buffers by buffer number",
+              },
+              ["<leader>bsm"] = {
+                function()
+                  require("bufferline.commands").sort_by(function(a, b)
+                    return a.modified and not b.modified
+                  end)
+                end,
+                desc = "Sort buffers by last modification",
+              },
+              ["<leader>bsp"] = {
+                function()
+                  require("bufferline.commands").sort_by("directory")
+                end,
+                desc = "Sort buffers by directory",
+              },
+              ["<leader>bsr"] = {
+                function()
+                  require("bufferline.commands").sort_by("relative_directory")
+                end,
+                desc = "Sort buffers by relative directory",
+              },
+              ["<leader>b\\"] = {
+                function()
+                  require("bufferline.pick").choose_then(function(id)
+                    vim.cmd("split")
+                    vim.cmd("buffer " .. id)
+                  end)
+                end,
+                desc = "Open a buffer tab in a new horizontal split with interactive picker",
+              },
+              ["<leader>b|"] = {
+                function()
+                  require("bufferline.pick").choose_then(function(id)
+                    vim.cmd("vsplit")
+                    vim.cmd("buffer " .. id)
+                  end)
+                end,
+                desc = "Open a buffer tab in a new vertical split with interactive picker",
+              },
             },
           },
         },

--- a/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
@@ -19,71 +19,51 @@ return {
                 desc = "Move buffer tab left",
               },
               ["<leader>bb"] = {
-                function()
-                  require("bufferline.commands").pick()
-                end,
+                function() require("bufferline.commands").pick() end,
                 desc = "Navigate to buffer tab with interactive picker",
               },
               ["<leader>bc"] = {
-                function()
-                  require("bufferline.commands").close_others()
-                end,
+                function() require("bufferline.commands").close_others() end,
                 desc = "Close all buffers except the current",
               },
               ["<leader>bd"] = {
-                function()
-                  require("bufferline.commands").close_with_pick()
-                end,
+                function() require("bufferline.commands").close_with_pick() end,
                 desc = "Delete a buffer tab with interactive picker",
               },
               ["<leader>bl"] = {
-                function()
-                  require("bufferline.commands").close_in_direction("left")
-                end,
+                function() require("bufferline.commands").close_in_direction "left" end,
                 desc = "Close all buffers to the left of the current",
               },
               ["<leader>br"] = {
-                function()
-                  require("bufferline.commands").close_in_direction("right")
-                end,
+                function() require("bufferline.commands").close_in_direction "right" end,
                 desc = "Close all buffers to the right of the current",
               },
               ["<leader>bse"] = {
-                function()
-                  require("bufferline.commands").sort_by("extension")
-                end,
+                function() require("bufferline.commands").sort_by "extension" end,
                 desc = "Sort buffers by extension",
               },
               ["<leader>bsi"] = {
-                function()
-                  require("bufferline.commands").sort_by("id")
-                end,
+                function() require("bufferline.commands").sort_by "id" end,
                 desc = "Sort buffers by buffer number",
               },
               ["<leader>bsm"] = {
                 function()
-                  require("bufferline.commands").sort_by(function(a, b)
-                    return a.modified and not b.modified
-                  end)
+                  require("bufferline.commands").sort_by(function(a, b) return a.modified and not b.modified end)
                 end,
                 desc = "Sort buffers by last modification",
               },
               ["<leader>bsp"] = {
-                function()
-                  require("bufferline.commands").sort_by("directory")
-                end,
+                function() require("bufferline.commands").sort_by "directory" end,
                 desc = "Sort buffers by directory",
               },
               ["<leader>bsr"] = {
-                function()
-                  require("bufferline.commands").sort_by("relative_directory")
-                end,
+                function() require("bufferline.commands").sort_by "relative_directory" end,
                 desc = "Sort buffers by relative directory",
               },
               ["<leader>b\\"] = {
                 function()
                   require("bufferline.pick").choose_then(function(id)
-                    vim.cmd("split")
+                    vim.cmd "split"
                     vim.cmd("buffer " .. id)
                   end)
                 end,
@@ -92,7 +72,7 @@ return {
               ["<leader>b|"] = {
                 function()
                   require("bufferline.pick").choose_then(function(id)
-                    vim.cmd("vsplit")
+                    vim.cmd "vsplit"
                     vim.cmd("buffer " .. id)
                   end)
                 end,


### PR DESCRIPTION
## 📑 Description

Since this import uses `astrocommunity.recipes.disable-tabline`, it disables all the `<leader>b` bindings too. This PR adds back the bufferline equivalents of those bindings.

Basically a continuation of #1009.

NOTE: I wasn't able to easily find an equivalent of `<leader>bC` to close _all_ buffers.

## ℹ Additional Information

This takes all the default bindings from [the docs](https://docs.astronvim.com/mappings#buffers) with the exception of `<leader>bC`.
