### PR TITLE
feat(completion): add cmp-under-comparator

### DIFF
--- a/lua/astrocommunity/completion/cmp-under-comparator/README.md
+++ b/lua/astrocommunity/completion/cmp-under-comparator/README.md
@@ -1,0 +1,7 @@
+# cmp-under-comparator
+
+A tiny function for nvim-cmp to better sort completion items that start with one or more underlines.
+
+In most languages, especially Python, items that start with one or more underlines should be at the end of the completion suggestion.
+
+**Repository:** <https://github.com/lukas-reineke/cmp-under-comparator>

--- a/lua/astrocommunity/completion/cmp-under-comparator/init.lua
+++ b/lua/astrocommunity/completion/cmp-under-comparator/init.lua
@@ -1,0 +1,26 @@
+local function list_index(t, value)
+  for i, v in ipairs(t) do
+    if v == value then return i end
+  end
+  return nil
+end
+
+---@type LazySpec
+return {
+  "hrsh7th/nvim-cmp",
+  optional = true,
+  dependencies = { "lukas-reineke/cmp-under-comparator", lazy = true },
+  opts = function(_, opts)
+    local cmp = require "cmp"
+    opts.sorting = opts.sorting or {}
+    -- If comparators is not set, use the default. get_config() has defaults now.
+    opts.sorting.comparators = opts.sorting.comparators or cmp.get_config().sorting.comparators
+    -- Find element in comparators we will position ourselves after.
+    -- Position after recently_used, fallback to after score, fallback to 4th position.
+    -- recently_used was not in nvim-cmp some time ago.
+    local pos = list_index(opts.sorting.comparators, cmp.config.compare.recently_used)
+    if pos == nil then pos = list_index(opts.sorting.comparators, cmp.config.compare.score) end
+    if pos == nil then pos = 3 end
+    table.insert(opts.sorting.comparators, pos + 1, require("cmp-under-comparator").under)
+  end,
+}


### PR DESCRIPTION
## 📑 Description

Add cmp-under-comparator to completion.

I tried to make the position of the comparator in nvim-cmp what users would "expect", and follow recommendation like from [here](https://github.com/lukas-reineke/cmp-under-comparator/issues/3#issuecomment-2103690672). I think after "recently_used" is the best position, first the ones you used, then the ones not string with dash `_`.

## ℹ Additional Information
