### PR TITLE
feat(chatgpt-nvim): add mappings

### DIFF
--- a/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
@@ -2,7 +2,41 @@ return {
   "jackMort/ChatGPT.nvim",
   cmd = { "ChatGPT", "ChatGPTActAs", "ChatGPTEditWithInstructions", "ChatGPTRun" },
   dependencies = {
+    {
+      "AstroNvim/astrocore",
+      ---@param opts AstroCoreOpts
+      opts = function(_, opts)
+        local astrocore = require "astrocore"
+        local get_icon = require("astroui").get_icon
+        local maps = {
+          ["<Leader>m"] = { desc = get_icon("ChatGPT", 1, true) .. "ChatGPT" },
+          ["<Leader>mc"] = { "<Cmd>ChatGPT<CR>", desc = "ChatGPT" },
+          ["<Leader>mC"] = { "<Cmd>ChatGPTActAs<CR>", desc = "ChatGPT Acts As ..." },
+          ["<Leader>me"] = { "<Cmd>ChatGPTEditWithInstruction<CR>", desc = "Edit with instruction" },
+          ["<Leader>mg"] = { "<Cmd>ChatGPTRun grammar_correction<CR>", desc = "Grammar Correction" },
+          ["<Leader>mt"] = { "<Cmd>ChatGPTRun translate<CR>", desc = "Translate" },
+          ["<Leader>mk"] = { "<Cmd>ChatGPTRun keywords<CR>", desc = "Keywords" },
+          ["<Leader>md"] = { "<Cmd>ChatGPTRun docstring<CR>", desc = "Docstring" },
+          ["<Leader>ma"] = { "<Cmd>ChatGPTRun add_tests<CR>", desc = "Add Tests" },
+          ["<Leader>mo"] = { "<Cmd>ChatGPTRun optimize_code<CR>", desc = "Optimize Code" },
+          ["<Leader>ms"] = { "<Cmd>ChatGPTRun summarize<CR>", desc = "Summarize" },
+          ["<Leader>mf"] = { "<Cmd>ChatGPTRun fix_bugs<CR>", desc = "Fix Bugs" },
+          ["<Leader>mx"] = { "<Cmd>ChatGPTRun explain_code<CR>", desc = "Explain Code" },
+          ["<Leader>mr"] = { "<Cmd>ChatGPTRun roxygen_edit<CR>", desc = "Roxygen Edit" },
+          ["<Leader>ml"] = { "<Cmd>ChatGPTRun code_readability_analysis<CR>", desc = "Code Readability Analysis" },
+        }
+
+        return astrocore.extend_tbl({
+          mappings = {
+            n = maps,
+            v = maps,
+          },
+        }, opts)
+      end,
+    },
+    { "AstroNvim/astroui", opts = { icons = { ChatGPT = "󰭹" } } },
     "MunifTanjim/nui.nvim",
+    "folke/trouble.nvim",
     "nvim-lua/plenary.nvim",
     "nvim-telescope/telescope.nvim",
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

This adds the mappings for ChatGPT.nvim: [jackMort/ChatGPT.nvim#whichkey-plugin-mappings](https://github.com/jackMort/ChatGPT.nvim#whichkey-plugin-mappings)

I chose the prefix `m` since `c` is already taken for "Close buffer" and that places it right after the "Language Tools" in the whichkey menu (`l`), but I am open to change it for something else if needed

The icon is `nf-md-chat` (visualize at [nerdfonts.com/cheat-sheet](https://www.nerdfonts.com/cheat-sheet))

This also adds the `folke/trouble.nvim` missing dependency.


## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
