### PR TITLE
feat(chatgpt-nvim): add which-key mappings below <leader>G

### DIFF
--- a/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
@@ -35,6 +35,7 @@ return {
         },
       },
     },
+    { "AstroNvim/astroui", opts = { icons = { ChatGPT = "󰭹" } } },
   },
   opts = {},
 }

--- a/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
@@ -5,6 +5,36 @@ return {
     "MunifTanjim/nui.nvim",
     "nvim-lua/plenary.nvim",
     "nvim-telescope/telescope.nvim",
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        mappings = {
+          n = {
+            -- G like GPT
+            ["<Leader>G"] = {
+              name = "🤖ChatGPT",
+              c = { "<cmd>ChatGPT<CR>", "ChatGPT" },
+              e = { "<cmd>ChatGPTEditWithInstruction<CR>", "Edit with instruction", mode = { "n", "v" } },
+              g = { "<cmd>ChatGPTRun grammar_correction<CR>", "Grammar Correction", mode = { "n", "v" } },
+              t = { "<cmd>ChatGPTRun translate<CR>", "Translate", mode = { "n", "v" } },
+              k = { "<cmd>ChatGPTRun keywords<CR>", "Keywords", mode = { "n", "v" } },
+              d = { "<cmd>ChatGPTRun docstring<CR>", "Docstring", mode = { "n", "v" } },
+              a = { "<cmd>ChatGPTRun add_tests<CR>", "Add Tests", mode = { "n", "v" } },
+              o = { "<cmd>ChatGPTRun optimize_code<CR>", "Optimize Code", mode = { "n", "v" } },
+              s = { "<cmd>ChatGPTRun summarize<CR>", "Summarize", mode = { "n", "v" } },
+              f = { "<cmd>ChatGPTRun fix_bugs<CR>", "Fix Bugs", mode = { "n", "v" } },
+              x = { "<cmd>ChatGPTRun explain_code<CR>", "Explain Code", mode = { "n", "v" } },
+              r = { "<cmd>ChatGPTRun roxygen_edit<CR>", "Roxygen Edit", mode = { "n", "v" } },
+              l = {
+                "<cmd>ChatGPTRun code_readability_analysis<CR>",
+                "Code Readability Analysis",
+                mode = { "n", "v" },
+              },
+            },
+          },
+        },
+      },
+    },
   },
   opts = {},
 }

--- a/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
@@ -13,7 +13,7 @@ return {
         maps.n[prefix] = { desc = require("astroui").get_icon("ChatGPT", 1, true) .. "ChatGPT" }
         maps.v[prefix] = { desc = require("astroui").get_icon("ChatGPT", 1, true) .. "ChatGPT" }
         maps.n[prefix .. "c"] = { "<cmd>ChatGPT<CR>", desc = "ChatGPT" }
-        maps.n[prefix .. "C"] = { "<Cmd>ChatGPTActAs<CR>", desc = "ChatGPT Acts As ..." },
+        maps.n[prefix .. "C"] = { "<Cmd>ChatGPTActAs<CR>", desc = "ChatGPT Acts As ..." }
 
         maps.n[prefix .. "e"] = { "<cmd>ChatGPTEditWithInstruction<CR>", desc = "Edit with instruction" }
         maps.v[prefix .. "e"] = { "<cmd>ChatGPTEditWithInstruction<CR>", desc = "Edit with instruction" }

--- a/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
@@ -13,6 +13,7 @@ return {
         maps.n[prefix] = { desc = require("astroui").get_icon("ChatGPT", 1, true) .. "ChatGPT" }
         maps.v[prefix] = { desc = require("astroui").get_icon("ChatGPT", 1, true) .. "ChatGPT" }
         maps.n[prefix .. "c"] = { "<cmd>ChatGPT<CR>", desc = "ChatGPT" }
+        maps.n[prefix .. "C"] = { "<Cmd>ChatGPTActAs<CR>", desc = "ChatGPT Acts As ..." },
 
         maps.n[prefix .. "e"] = { "<cmd>ChatGPTEditWithInstruction<CR>", desc = "Edit with instruction" }
         maps.v[prefix .. "e"] = { "<cmd>ChatGPTEditWithInstruction<CR>", desc = "Edit with instruction" }

--- a/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/chatgpt-nvim/init.lua
@@ -7,33 +7,49 @@ return {
     "nvim-telescope/telescope.nvim",
     {
       "AstroNvim/astrocore",
-      opts = {
-        mappings = {
-          n = {
-            -- G like GPT
-            ["<Leader>G"] = {
-              name = "🤖ChatGPT",
-              c = { "<cmd>ChatGPT<CR>", "ChatGPT" },
-              e = { "<cmd>ChatGPTEditWithInstruction<CR>", "Edit with instruction", mode = { "n", "v" } },
-              g = { "<cmd>ChatGPTRun grammar_correction<CR>", "Grammar Correction", mode = { "n", "v" } },
-              t = { "<cmd>ChatGPTRun translate<CR>", "Translate", mode = { "n", "v" } },
-              k = { "<cmd>ChatGPTRun keywords<CR>", "Keywords", mode = { "n", "v" } },
-              d = { "<cmd>ChatGPTRun docstring<CR>", "Docstring", mode = { "n", "v" } },
-              a = { "<cmd>ChatGPTRun add_tests<CR>", "Add Tests", mode = { "n", "v" } },
-              o = { "<cmd>ChatGPTRun optimize_code<CR>", "Optimize Code", mode = { "n", "v" } },
-              s = { "<cmd>ChatGPTRun summarize<CR>", "Summarize", mode = { "n", "v" } },
-              f = { "<cmd>ChatGPTRun fix_bugs<CR>", "Fix Bugs", mode = { "n", "v" } },
-              x = { "<cmd>ChatGPTRun explain_code<CR>", "Explain Code", mode = { "n", "v" } },
-              r = { "<cmd>ChatGPTRun roxygen_edit<CR>", "Roxygen Edit", mode = { "n", "v" } },
-              l = {
-                "<cmd>ChatGPTRun code_readability_analysis<CR>",
-                "Code Readability Analysis",
-                mode = { "n", "v" },
-              },
-            },
-          },
-        },
-      },
+      opts = function(_, opts)
+        local maps = opts.mappings
+        local prefix = "<Leader>G"
+        maps.n[prefix] = { desc = require("astroui").get_icon("ChatGPT", 1, true) .. "ChatGPT" }
+        maps.v[prefix] = { desc = require("astroui").get_icon("ChatGPT", 1, true) .. "ChatGPT" }
+        maps.n[prefix .. "c"] = { "<cmd>ChatGPT<CR>", desc = "ChatGPT" }
+
+        maps.n[prefix .. "e"] = { "<cmd>ChatGPTEditWithInstruction<CR>", desc = "Edit with instruction" }
+        maps.v[prefix .. "e"] = { "<cmd>ChatGPTEditWithInstruction<CR>", desc = "Edit with instruction" }
+
+        maps.n[prefix .. "g"] = { "<cmd>ChatGPTRun grammar_correction<CR>", desc = "Grammar Correction" }
+        maps.v[prefix .. "g"] = { "<cmd>ChatGPTRun grammar_correction<CR>", desc = "Grammar Correction" }
+
+        maps.n[prefix .. "t"] = { "<cmd>ChatGPTRun translate<CR>", desc = "Translate" }
+        maps.v[prefix .. "t"] = { "<cmd>ChatGPTRun translate<CR>", desc = "Translate" }
+
+        maps.n[prefix .. "k"] = { "<cmd>ChatGPTRun keywords<CR>", desc = "Keywords" }
+        maps.v[prefix .. "k"] = { "<cmd>ChatGPTRun keywords<CR>", desc = "Keywords" }
+
+        maps.n[prefix .. "d"] = { "<cmd>ChatGPTRun docstring<CR>", desc = "Docstring" }
+        maps.v[prefix .. "d"] = { "<cmd>ChatGPTRun docstring<CR>", desc = "Docstring" }
+
+        maps.n[prefix .. "a"] = { "<cmd>ChatGPTRun add_tests<CR>", desc = "Add Tests" }
+        maps.v[prefix .. "a"] = { "<cmd>ChatGPTRun add_tests<CR>", desc = "Add Tests" }
+
+        maps.n[prefix .. "o"] = { "<cmd>ChatGPTRun optimize_code<CR>", desc = "Optimize Code" }
+        maps.v[prefix .. "o"] = { "<cmd>ChatGPTRun optimize_code<CR>", desc = "Optimize Code" }
+
+        maps.n[prefix .. "s"] = { "<cmd>ChatGPTRun summarize<CR>", desc = "Summarize" }
+        maps.v[prefix .. "s"] = { "<cmd>ChatGPTRun summarize<CR>", desc = "Summarize" }
+
+        maps.n[prefix .. "f"] = { "<cmd>ChatGPTRun fix_bugs<CR>", desc = "Fix Bugs" }
+        maps.v[prefix .. "f"] = { "<cmd>ChatGPTRun fix_bugs<CR>", desc = "Fix Bugs" }
+
+        maps.n[prefix .. "x"] = { "<cmd>ChatGPTRun explain_code<CR>", desc = "Explain Code" }
+        maps.v[prefix .. "x"] = { "<cmd>ChatGPTRun explain_code<CR>", desc = "Explain Code" }
+
+        maps.n[prefix .. "r"] = { "<cmd>ChatGPTRun roxygen_edit<CR>", desc = "Roxygen Edit" }
+        maps.v[prefix .. "r"] = { "<cmd>ChatGPTRun roxygen_edit<CR>", desc = "Roxygen Edit" }
+
+        maps.n[prefix .. "l"] = { "<cmd>ChatGPTRun code_readability_analysis<CR>", desc = "Code Readability Analysis" }
+        maps.v[prefix .. "l"] = { "<cmd>ChatGPTRun code_readability_analysis<CR>", desc = "Code Readability Analysis" }
+      end,
     },
     { "AstroNvim/astroui", opts = { icons = { ChatGPT = "󰭹" } } },
   },


### PR DESCRIPTION
## 📑 Description

Chatgpt.nvim has mapping recommendation in their readme. I think it makes a nice addition under `<leader>G`, `G` like gpt. I typically use `<space>Gc` to start a chat. Let me know what you think.

![image](https://github.com/AstroNvim/astrocommunity/assets/15679217/6c667801-3dbf-4545-883c-34aa996957d1)

![image](https://github.com/AstroNvim/astrocommunity/assets/15679217/9d8987ec-bf0d-414b-ae40-30ea46f5fa2f)

## ℹ Additional Information