### PR TITLE
fix(go): set default go binary to `"go"`

### DIFF
--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -118,6 +118,7 @@ return {
     opts = {
       disable_defaults = true,
       diagnostic = false,
+      go = "go",
     },
     event = { "CmdlineEnter" },
     ft = { "go", "gomod" },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This prevents the error message that comes with the newer versions of `go.nvim`:

```lua
  if vim.fn.empty(_GO_NVIM_CFG.go) == 1 then
    vim.notify('go.nvim go binary is not setup', vim.log.levels.ERROR)
  end
```
_https://github.com/ray-x/go.nvim/blob/b3ee7aea17d5b7acd1e3007efa7ac0e43947ad0c/lua/go.lua#L233-L235_

## ℹ Additional Information

I think the author could've given a good default to this value and make it overridable instead of issuing a hard error, but alas...
