### PR TITLE
fix(go): don't purge go.nvim default config tables

### DIFF
--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -116,7 +116,6 @@ return {
       "nvim-treesitter/nvim-treesitter",
     },
     opts = {
-      disable_defaults = true,
       diagnostic = false,
       go = "go",
     },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #1044
-->
Closes #1044

## 📑 Description
- Remove `disable_defaults` flag for go.nvim

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
`disable_defaults` empties all of the configuration tables for go.nvim. With this flag enabled, all configurations must be set manually, or the plugin will produce an error. Please see the [configuration documentation](https://github.com/ray-x/go.nvim?tab=readme-ov-file#configuration).

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
