### PR TITLE
feat(completion): add `nvim-cmp-buffer-lines`

### DIFF
--- a/lua/astrocommunity/completion/nvim-cmp-buffer-lines/README.md
+++ b/lua/astrocommunity/completion/nvim-cmp-buffer-lines/README.md
@@ -1,0 +1,5 @@
+# nvim-cmp-buffer-lines
+
+_Replaces_ the `<C-x><C-l>` whole line complete, to use nvim-cmp instead, using the following source:
+
+**Repository:** <https://github.com/amarakon/nvim-cmp-buffer-lines>

--- a/lua/astrocommunity/completion/nvim-cmp-buffer-lines/README.md
+++ b/lua/astrocommunity/completion/nvim-cmp-buffer-lines/README.md
@@ -3,3 +3,5 @@
 _Replaces_ the `<C-x><C-l>` whole line complete, to use nvim-cmp instead, using the following source:
 
 **Repository:** <https://github.com/amarakon/nvim-cmp-buffer-lines>
+
+- _Replaces_ the `<C-x><C-l>` whole line complete, to use nvim-cmp instead.

--- a/lua/astrocommunity/completion/nvim-cmp-buffer-lines/README.md
+++ b/lua/astrocommunity/completion/nvim-cmp-buffer-lines/README.md
@@ -3,3 +3,5 @@
 nvim-cmp source for buffer lines
 
 **Repository:** <https://github.com/amarakon/nvim-cmp-buffer-lines>
+
+_Replaces_ the `<C-x><C-l>` whole line complete, instead of being included in the usual completion menu.

--- a/lua/astrocommunity/completion/nvim-cmp-buffer-lines/README.md
+++ b/lua/astrocommunity/completion/nvim-cmp-buffer-lines/README.md
@@ -1,7 +1,5 @@
 # nvim-cmp-buffer-lines
 
-_Replaces_ the `<C-x><C-l>` whole line complete, to use nvim-cmp instead, using the following source:
+nvim-cmp source for buffer lines
 
 **Repository:** <https://github.com/amarakon/nvim-cmp-buffer-lines>
-
-- _Replaces_ the `<C-x><C-l>` whole line complete, to use nvim-cmp instead.

--- a/lua/astrocommunity/completion/nvim-cmp-buffer-lines/init.lua
+++ b/lua/astrocommunity/completion/nvim-cmp-buffer-lines/init.lua
@@ -1,0 +1,27 @@
+---@type LazySpec
+return {
+  "hrsh7th/nvim-cmp",
+  dependencies = {
+    { "amarakon/nvim-cmp-buffer-lines" },
+  },
+  opts = function(_, opts)
+    local cmp = require "cmp"
+    return require("astrocore").extend_tbl(opts, {
+      mapping = {
+        ["<C-x><C-l>"] = cmp.mapping.complete { -- this could've been a more ergonomic hotkey, but it would be a reach to try to make up one, that would fit everyone.
+          config = {
+            sources = {
+              {
+                name = "buffer-lines",
+                priority = 50,
+                option = {
+                  leading_whitespace = false,
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  end,
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Adds the `nvim-cmp-buffer-lines` nvim-cmp source, but instead of just adding it to normal completions, keeps it local to a hotkey.

The reasoning for this is that, even with a low priority, whole line completions end up being super annoying, when mixed in with all the other (usually more useful) suggestions. So it's for this reason that this source is effectively "opt-in".

The mapping used is `<C-x><C-l>`, because that's the default way to do whole line completions. What you basically get with this community pack, is you replace built in whole line completions with ones that use nvim-cmp.

The hotkey is wack, but it is default! So I think it makes the most sense, even if there could be other, more ergonomic mappings.

At the very least, if a person wants the functionality, but on a different mapping, they now have the option to take a peek at this community pack, copy paste it into their config, and change the mapping to what they want.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
