### PR TITLE
feat(go): change ray-x/go.nvim back to olexsmir/gopher.nvim

### DIFF
--- a/lua/astrocommunity/pack/go/README.md
+++ b/lua/astrocommunity/pack/go/README.md
@@ -13,4 +13,4 @@ This plugin pack does the following:
   - [iferr](https://github.com/koron/iferr)
   - [impl](https://github.com/josharian/impl)
 - Adds [nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for debugging
-- Adds [go.nvim](https://github.com/ray-x/go.nvim) for language specific tools
+- Adds [gopher.nvim](https://github.com/olexsmir/gopher.nvim) for language specific tools

--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -109,22 +109,10 @@ return {
     opts = {},
   },
   {
-    "ray-x/go.nvim",
-    dependencies = {
-      "ray-x/guihua.lua",
-      "neovim/nvim-lspconfig",
-      "nvim-treesitter/nvim-treesitter",
-    },
-    opts = {
-      disable_defaults = true,
-      diagnostic = false,
-      go = "go",
-    },
-    event = { "CmdlineEnter" },
-    ft = { "go", "gomod" },
-    -- Prevents Neovim from freezing on plugin installation/update.
-    -- See: <https://github.com/ray-x/go.nvim/issues/433>
-    build = function() require("go.install").update_all() end,
+    "olexsmir/gopher.nvim",
+    dependencies = { "nvim-lua/plenary.nvim", "nvim-treesitter/nvim-treesitter" },
+    ft = "go",
+    opts = {},
   },
   {
     "nvim-neotest/neotest",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

> Not sure about x-rayz plugins… Most plugins are a bit messy
_@luxus in https://github.com/AstroNvim/astrocommunity/pull/325#issuecomment-1612466608_

> Honestly at this point, I'm more eager to just purge go.nvim
_@Uzaaft in https://github.com/AstroNvim/astrocommunity/issues/1044#issuecomment-2178662610_

Reverts #325, superseding #1054.

## ℹ Additional Information

We're moving towards fewer included batteries, but I believe the stability outweighs features, and hopefully we can get them back via `astrocommunity` if the community really needs them.
