### PR TITLE
fix(conjure): Add missing filetypes

### DIFF
--- a/lua/astrocommunity/code-runner/conjure/init.lua
+++ b/lua/astrocommunity/code-runner/conjure/init.lua
@@ -1,4 +1,18 @@
 return {
   "Olical/conjure",
-  ft = { "clojure", "janet", "fennel", "racket", "hy", "scheme", "guile", "julia", "lua", "lisp" },
+  ft = {
+    "clojure",
+    "janet",
+    "fennel",
+    "racket",
+    "hy",
+    "scheme",
+    "guile",
+    "julia",
+    "lua",
+    "lisp",
+    "rust",
+    "sql",
+    "python",
+  },
 }


### PR DESCRIPTION
Attempting to match list here: https://github.com/Olical/conjure/blob/934687860a71d1d03e569ce11f880a4d404e69aa/fnl/conjure/config.fnl#L56

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This PR adds additional filetypes to activate the Conjure plugin