### PR TITLE
fix(tailwindcss): add mjs support for tailwind root dir detection

### DIFF
--- a/lua/astrocommunity/pack/tailwindcss/init.lua
+++ b/lua/astrocommunity/pack/tailwindcss/init.lua
@@ -16,6 +16,7 @@ return {
             tailwindcss = {
               root_dir = function(fname)
                 local root_pattern = require("lspconfig").util.root_pattern(
+                  "tailwind.config.mjs",
                   "tailwind.config.cjs",
                   "tailwind.config.js",
                   "tailwind.config.ts",


### PR DESCRIPTION
## 📑 Description
After updating to new version which included [this PR](https://github.com/AstroNvim/astrocommunity/pull/912) I noticed my tailwind intellisense stopped working and `:LspInfo:` shows that rootDir was not found.

I spotted that mentioned above PR didn't include .mjs extension which I use in my projects for tailwind config files.