### PR TITLE
BREAKING CHANGE: remove scope.nvim

### DIFF
--- a/lua/astrocommunity/bars-and-lines/scope-nvim/README.md
+++ b/lua/astrocommunity/bars-and-lines/scope-nvim/README.md
@@ -1,7 +1,0 @@
-# scope.nvim
-
-Revolutionize Your Neovim Tab Workflow: Introducing Enhanced Tab Scoping!
-
-**Repository:** <https://github.com/tiagovla/scope.nvim>
-
-This plugin scopes buffers to tabs, cleaning up tabline plugins like `bufferline.nvim`.

--- a/lua/astrocommunity/bars-and-lines/scope-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/scope-nvim/init.lua
@@ -1,8 +1,0 @@
-return {
-  { "tiagovla/scope.nvim", event = "VeryLazy", opts = {} },
-  {
-    "nvim-telescope/telescope.nvim",
-    optional = true,
-    opts = function() require("telescope").load_extension "scope" end,
-  },
-}


### PR DESCRIPTION
## 📑 Description

Since AstroNvim manage it's own implementation of scoped tab buffer I think we can remove this plugin as it redundant and source of confuse.