### PR TITLE
docs(blade): Add inn link for laravel-dev-generators

### DIFF
--- a/lua/astrocommunity/pack/blade/README.md
+++ b/lua/astrocommunity/pack/blade/README.md
@@ -2,7 +2,7 @@
 
 Requires:
 
-- `laravel-dev-generators` in your path
+- `laravel-dev-generators` in your path. See the releases section of <https://github.com/haringsrob/laravel-dev-tools>
 
 This plugin pack does the following:
 


### PR DESCRIPTION
Avoids cases like #1081  where people are too lazy to search themselves.  