### PR TITLE
fix(nvim-lsp-endhints): Fix issue with loading of plugin due to event

### DIFF
--- a/lua/astrocommunity/lsp/nvim-lsp-endhints/init.lua
+++ b/lua/astrocommunity/lsp/nvim-lsp-endhints/init.lua
@@ -1,5 +1,5 @@
 return {
   "chrisgrieser/nvim-lsp-endhints",
-  event = "User AstroLsp",
+  event = "LspAttach",
   opts = {},
 }


### PR DESCRIPTION
We tried AstroLsp, but seems that the event loading proposed by the plugin maintainer is the way to go. 