### PR TITLE
docs(typst): Fix typo

### DIFF
--- a/lua/astrocommunity/pack/typst/README.md
+++ b/lua/astrocommunity/pack/typst/README.md
@@ -2,7 +2,7 @@
 
 This plugin pack does the following:
 
-- Add `typst,vim` for syntax
+- Add `typst.vim` for syntax
 - Add `typst_lsp` language server
 - Add `typst-preview.nvim` plugin
 


### PR DESCRIPTION
## 📑 Description

Fix the `typst.vim` name typo in pack/typst/README.md