### PR TITLE
feat(java)!: move to `nvim-java` for `jdtls` setup

### DIFF
--- a/lua/astrocommunity/pack/java/README.md
+++ b/lua/astrocommunity/pack/java/README.md
@@ -7,17 +7,8 @@ Requires:
 This plugin pack does the following:
 
 - Adds `java` treesitter parsers
-- Adds `html` treesitter parsers (XML)
 - Adds `jdtls` language server
-- Adds `lemminx` language server (XML)
-- Adds [nvim-jdtls](https://github.com/mfussenegger/nvim-jdtls) for language specific tooling
-- Enables [hot reloading](https://github.com/mfussenegger/nvim-jdtls/issues/80)
-- Adds `javadbg` and `javatest` debug adapters for nvim-dap
-
-## Note
-
-We require that the root folder of your projects include one of these files/folders([Reference](https://github.com/AstroNvim/astrocommunity/blob/49e9a3961bba079d7f413b8d5567382dd6f55392/lua/astrocommunity/pack/java/java.lua#LL37C96-L37C96)):  
-`.git`, `mvnw`, `gradlew`, `pom.xml`, `build.gradle` or `.project`
+- Adds [nvim-java](https://github.com/nvim-java/nvim-java) for language specific tooling
 
 ## Tips
 
@@ -25,30 +16,29 @@ We require that the root folder of your projects include one of these files/fold
 Here is a simple example:
 
 ```lua
+return {
   "AstroNvim/astrocommunity",
   { import = "astrocommunity.pack.java" },
   {
-    "mfussenegger/nvim-jdtls",
+    "AstroNvim/astrolsp",
     opts = {
-      settings = {
-        java = {
-          configuration = {
-            runtimes = {
-              {
-                name = "JavaSE-11",
-                path = "/usr/lib/jvm/java-11-openjdk/",
+      config = {
+        jdtls = {
+          settings = {
+            java = {
+              configuration = {
+                runtimes = {
+                  {
+                    name = "JavaSE-11",
+                    path = "/usr/lib/jvm/java-11-openjdk/",
+                  },
+                },
               },
             },
           },
         },
-        format = {
-          enabled = true,
-          settings = { -- you can use your preferred format style
-            url = "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml",
-            profile = "GoogleStyle",
-          },
-        },
       },
     },
-  }
+  },
+}
 ```

--- a/lua/astrocommunity/pack/java/init.lua
+++ b/lua/astrocommunity/pack/java/init.lua
@@ -1,10 +1,11 @@
 return {
+  { import = "astrocommunity.pack.xml" },
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "java", "html" })
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "java" })
       end
     end,
   },
@@ -12,148 +13,34 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "jdtls", "lemminx" })
-    end,
-  },
-  {
-    "jay-babu/mason-nvim-dap.nvim",
-    optional = true,
-    opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "javadbg", "javatest" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "jdtls" })
     end,
   },
   {
     "WhoIsSethDaniel/mason-tool-installer.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(
-        opts.ensure_installed,
-        { "jdtls", "lemminx", "java-debug-adapter", "java-test" }
-      )
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "jdtls" })
     end,
   },
   {
-    "mfussenegger/nvim-jdtls",
-    ft = { "java" },
+    "nvim-java/nvim-java",
+    lazy = true,
+    opts = {},
     dependencies = {
-      "williamboman/mason-lspconfig.nvim",
       {
         "AstroNvim/astrolsp",
         optional = true,
         ---@type AstroLSPOpts
         opts = {
-          ---@diagnostic disable: missing-fields
-          handlers = { jdtls = false },
+          handlers = {
+            jdtls = function(server, opts)
+              require("lazy").load { plugins = { "nvim-java" } }
+              require("lspconfig")[server].setup(opts)
+            end,
+          },
         },
       },
     },
-    opts = function(_, opts)
-      local utils = require "astrocore"
-      -- use this function notation to build some variables
-      local root_markers = { ".git", "mvnw", "gradlew", "pom.xml", "build.gradle", ".project" }
-      local root_dir = require("jdtls.setup").find_root(root_markers)
-      -- calculate workspace dir
-      local project_name = vim.fn.fnamemodify(vim.fn.getcwd(), ":p:h:t")
-      local workspace_dir = vim.fn.stdpath "data" .. "/site/java/workspace-root/" .. project_name
-      vim.fn.mkdir(workspace_dir, "p")
-
-      -- validate operating system
-      if not (vim.fn.has "mac" == 1 or vim.fn.has "unix" == 1 or vim.fn.has "win32" == 1) then
-        utils.notify("jdtls: Could not detect valid OS", vim.log.levels.ERROR)
-      end
-
-      return utils.extend_tbl({
-        cmd = {
-          "java",
-          "-Declipse.application=org.eclipse.jdt.ls.core.id1",
-          "-Dosgi.bundles.defaultStartLevel=4",
-          "-Declipse.product=org.eclipse.jdt.ls.core.product",
-          "-Dlog.protocol=true",
-          "-Dlog.level=ALL",
-          "-javaagent:" .. vim.fn.expand "$MASON/share/jdtls/lombok.jar",
-          "-Xms1g",
-          "--add-modules=ALL-SYSTEM",
-          "--add-opens",
-          "java.base/java.util=ALL-UNNAMED",
-          "--add-opens",
-          "java.base/java.lang=ALL-UNNAMED",
-          "-jar",
-          vim.fn.expand "$MASON/share/jdtls/plugins/org.eclipse.equinox.launcher.jar",
-          "-configuration",
-          vim.fn.expand "$MASON/share/jdtls/config",
-          "-data",
-          workspace_dir,
-        },
-        root_dir = root_dir,
-        settings = {
-          java = {
-            eclipse = { downloadSources = true },
-            configuration = { updateBuildConfiguration = "interactive" },
-            maven = { downloadSources = true },
-            implementationsCodeLens = { enabled = true },
-            referencesCodeLens = { enabled = true },
-            inlayHints = { parameterNames = { enabled = "all" } },
-            signatureHelp = { enabled = true },
-            completion = {
-              favoriteStaticMembers = {
-                "org.hamcrest.MatcherAssert.assertThat",
-                "org.hamcrest.Matchers.*",
-                "org.hamcrest.CoreMatchers.*",
-                "org.junit.jupiter.api.Assertions.*",
-                "java.util.Objects.requireNonNull",
-                "java.util.Objects.requireNonNullElse",
-                "org.mockito.Mockito.*",
-              },
-            },
-            sources = {
-              organizeImports = {
-                starThreshold = 9999,
-                staticStarThreshold = 9999,
-              },
-            },
-          },
-        },
-        init_options = {
-          bundles = {
-            vim.fn.expand "$MASON/share/java-debug-adapter/com.microsoft.java.debug.plugin.jar",
-            -- unpack remaining bundles
-            (table.unpack or unpack)(vim.split(vim.fn.glob "$MASON/share/java-test/*.jar", "\n", {})),
-          },
-        },
-        handlers = {
-          ["$/progress"] = function() end, -- disable progress updates.
-        },
-        filetypes = { "java" },
-        on_attach = function(...)
-          require("jdtls").setup_dap { hotcodereplace = "auto" }
-          local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
-          if astrolsp_avail then astrolsp.on_attach(...) end
-        end,
-      }, opts)
-    end,
-    config = function(_, opts)
-      -- setup autocmd on filetype detect java
-      vim.api.nvim_create_autocmd("Filetype", {
-        pattern = "java", -- autocmd to start jdtls
-        callback = function()
-          if opts.root_dir and opts.root_dir ~= "" then
-            require("jdtls").start_or_attach(opts)
-          else
-            require("astrocore").notify("jdtls: root_dir not found. Please specify a root marker", vim.log.levels.ERROR)
-          end
-        end,
-      })
-      -- create autocmd to load main class configs on LspAttach.
-      -- This ensures that the LSP is fully attached.
-      -- See https://github.com/mfussenegger/nvim-jdtls#nvim-dap-configuration
-      vim.api.nvim_create_autocmd("LspAttach", {
-        pattern = "*.java",
-        callback = function(args)
-          local client = vim.lsp.get_client_by_id(args.data.client_id)
-          -- ensure that only the jdtls client is activated
-          if client.name == "jdtls" then require("jdtls.dap").setup_dap_main_class_configs() end
-        end,
-      })
-    end,
   },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->
Closes #1062
Closes #1064 

## 📑 Description

This moves the Java pack to use [`nvim-java`](https://github.com/nvim-java/nvim-java) which greatly decreases the complexity of the pack as well as adds stuff like spring-boot support out of the box.

I did some testing and it spins up totally fine, the only downside I have found so far is that the debugger in my testing doesn't seem to get configured correctly. A debugging adapter is created but no DAP configurations are inserted. There seems to be an upstream issue regarding this: https://github.com/nvim-java/nvim-java/issues/169

Someone might want to run this down or verify if it's a me problem before we merge this in.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## TODO

- [ ] Confirm debugger and make sure that works to not introduce a big regression
