### PR TITLE
refactor: migrate to using `specs` to make individual plugins disablable

### DIFF
--- a/.github/workflows/reviewchecklist.yml
+++ b/.github/workflows/reviewchecklist.yml
@@ -39,6 +39,8 @@ jobs:
 
             - [ ] Pull request title has the appropriate conventional commit type and **scope** where the scope is the name of the _pre-existing_ directory in the project as described above
             - [ ] \`README\` is properly formatted and uses fenced in links with \`<url>\` unless they are inside a \`[title](url)\`
+            - [ ] Entry returns a single plugin spec with the _new plugin_ as the only top level spec (not applicable for recipes or packs).
             - [ ] Proper usage of \`opts\` table rather than setting things up with the \`config\` function.
+            - [ ] Proper usage of \`specs\` table for all specs that are not dependencies of a given plugin (not applicable for recipes or packs).
             `,
             })

--- a/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/bufferline-nvim/init.lua
@@ -1,98 +1,98 @@
 return {
-  { import = "astrocommunity.recipes.disable-tabline" },
-  {
-    "akinsho/bufferline.nvim",
-    dependencies = {
-      {
-        "AstroNvim/astrocore",
-        opts = {
-          mappings = {
-            n = {
-              ["]b"] = { function() require("bufferline.commands").cycle(vim.v.count1) end, desc = "Next buffer" },
-              ["[b"] = { function() require("bufferline.commands").cycle(-vim.v.count1) end, desc = "Previous buffer" },
-              [">b"] = {
-                function() require("bufferline.commands").move(vim.v.count1) end,
-                desc = "Move buffer tab right",
-              },
-              ["<b"] = {
-                function() require("bufferline.commands").move(-vim.v.count1) end,
-                desc = "Move buffer tab left",
-              },
-              ["<leader>bb"] = {
-                function() require("bufferline.commands").pick() end,
-                desc = "Navigate to buffer tab with interactive picker",
-              },
-              ["<leader>bc"] = {
-                function() require("bufferline.commands").close_others() end,
-                desc = "Close all buffers except the current",
-              },
-              ["<leader>bd"] = {
-                function() require("bufferline.commands").close_with_pick() end,
-                desc = "Delete a buffer tab with interactive picker",
-              },
-              ["<leader>bl"] = {
-                function() require("bufferline.commands").close_in_direction "left" end,
-                desc = "Close all buffers to the left of the current",
-              },
-              ["<leader>br"] = {
-                function() require("bufferline.commands").close_in_direction "right" end,
-                desc = "Close all buffers to the right of the current",
-              },
-              ["<leader>bse"] = {
-                function() require("bufferline.commands").sort_by "extension" end,
-                desc = "Sort buffers by extension",
-              },
-              ["<leader>bsi"] = {
-                function() require("bufferline.commands").sort_by "id" end,
-                desc = "Sort buffers by buffer number",
-              },
-              ["<leader>bsm"] = {
-                function()
-                  require("bufferline.commands").sort_by(function(a, b) return a.modified and not b.modified end)
-                end,
-                desc = "Sort buffers by last modification",
-              },
-              ["<leader>bsp"] = {
-                function() require("bufferline.commands").sort_by "directory" end,
-                desc = "Sort buffers by directory",
-              },
-              ["<leader>bsr"] = {
-                function() require("bufferline.commands").sort_by "relative_directory" end,
-                desc = "Sort buffers by relative directory",
-              },
-              ["<leader>b\\"] = {
-                function()
-                  require("bufferline.pick").choose_then(function(id)
-                    vim.cmd "split"
-                    vim.cmd("buffer " .. id)
-                  end)
-                end,
-                desc = "Open a buffer tab in a new horizontal split with interactive picker",
-              },
-              ["<leader>b|"] = {
-                function()
-                  require("bufferline.pick").choose_then(function(id)
-                    vim.cmd "vsplit"
-                    vim.cmd("buffer " .. id)
-                  end)
-                end,
-                desc = "Open a buffer tab in a new vertical split with interactive picker",
-              },
+  "akinsho/bufferline.nvim",
+  specs = {
+    { import = "astrocommunity.recipes.disable-tabline" },
+  },
+  dependencies = {
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        mappings = {
+          n = {
+            ["]b"] = { function() require("bufferline.commands").cycle(vim.v.count1) end, desc = "Next buffer" },
+            ["[b"] = { function() require("bufferline.commands").cycle(-vim.v.count1) end, desc = "Previous buffer" },
+            [">b"] = {
+              function() require("bufferline.commands").move(vim.v.count1) end,
+              desc = "Move buffer tab right",
+            },
+            ["<b"] = {
+              function() require("bufferline.commands").move(-vim.v.count1) end,
+              desc = "Move buffer tab left",
+            },
+            ["<leader>bb"] = {
+              function() require("bufferline.commands").pick() end,
+              desc = "Navigate to buffer tab with interactive picker",
+            },
+            ["<leader>bc"] = {
+              function() require("bufferline.commands").close_others() end,
+              desc = "Close all buffers except the current",
+            },
+            ["<leader>bd"] = {
+              function() require("bufferline.commands").close_with_pick() end,
+              desc = "Delete a buffer tab with interactive picker",
+            },
+            ["<leader>bl"] = {
+              function() require("bufferline.commands").close_in_direction "left" end,
+              desc = "Close all buffers to the left of the current",
+            },
+            ["<leader>br"] = {
+              function() require("bufferline.commands").close_in_direction "right" end,
+              desc = "Close all buffers to the right of the current",
+            },
+            ["<leader>bse"] = {
+              function() require("bufferline.commands").sort_by "extension" end,
+              desc = "Sort buffers by extension",
+            },
+            ["<leader>bsi"] = {
+              function() require("bufferline.commands").sort_by "id" end,
+              desc = "Sort buffers by buffer number",
+            },
+            ["<leader>bsm"] = {
+              function()
+                require("bufferline.commands").sort_by(function(a, b) return a.modified and not b.modified end)
+              end,
+              desc = "Sort buffers by last modification",
+            },
+            ["<leader>bsp"] = {
+              function() require("bufferline.commands").sort_by "directory" end,
+              desc = "Sort buffers by directory",
+            },
+            ["<leader>bsr"] = {
+              function() require("bufferline.commands").sort_by "relative_directory" end,
+              desc = "Sort buffers by relative directory",
+            },
+            ["<leader>b\\"] = {
+              function()
+                require("bufferline.pick").choose_then(function(id)
+                  vim.cmd "split"
+                  vim.cmd("buffer " .. id)
+                end)
+              end,
+              desc = "Open a buffer tab in a new horizontal split with interactive picker",
+            },
+            ["<leader>b|"] = {
+              function()
+                require("bufferline.pick").choose_then(function(id)
+                  vim.cmd "vsplit"
+                  vim.cmd("buffer " .. id)
+                end)
+              end,
+              desc = "Open a buffer tab in a new vertical split with interactive picker",
             },
           },
         },
       },
     },
-    event = "VeryLazy",
-    opts = {
-      options = {
-        offsets = {
-          {
-            filetype = "neo-tree",
-            text = "Neo-tree",
-            highlight = "Directory",
-            text_align = "left",
-          },
+  },
+  event = "VeryLazy",
+  opts = {
+    options = {
+      offsets = {
+        {
+          filetype = "neo-tree",
+          text = "Neo-tree",
+          highlight = "Directory",
+          text_align = "left",
         },
       },
     },

--- a/lua/astrocommunity/bars-and-lines/dropbar-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/dropbar-nvim/init.lua
@@ -1,14 +1,18 @@
 return {
-  { "Bekaboo/dropbar.nvim", event = "UIEnter", opts = {} },
-  {
-    "rebelot/heirline.nvim",
-    optional = true,
-    opts = function(_, opts) opts.winbar = nil end,
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { dropbar = { enabled = true } } },
+  "Bekaboo/dropbar.nvim",
+  event = "UIEnter",
+  opts = {},
+  specs = {
+    {
+      "rebelot/heirline.nvim",
+      optional = true,
+      opts = function(_, opts) opts.winbar = nil end,
+    },
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { dropbar = { enabled = true } } },
+    },
   },
 }

--- a/lua/astrocommunity/bars-and-lines/feline-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/feline-nvim/init.lua
@@ -1,8 +1,12 @@
 return {
-  { "freddiehaddad/feline.nvim", event = "VeryLazy", opts = {} },
-  {
-    "rebelot/heirline.nvim",
-    optional = true,
-    opts = function(_, opts) opts.statusline = nil end,
+  "freddiehaddad/feline.nvim",
+  event = "VeryLazy",
+  opts = {},
+  specs = {
+    {
+      "rebelot/heirline.nvim",
+      optional = true,
+      opts = function(_, opts) opts.statusline = nil end,
+    },
   },
 }

--- a/lua/astrocommunity/bars-and-lines/lualine-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/lualine-nvim/init.lua
@@ -1,8 +1,12 @@
 return {
-  { "nvim-lualine/lualine.nvim", event = "VeryLazy", opts = {} },
-  {
-    "rebelot/heirline.nvim",
-    optional = true,
-    opts = function(_, opts) opts.statusline = nil end,
+  "nvim-lualine/lualine.nvim",
+  event = "VeryLazy",
+  opts = {},
+  specs = {
+    {
+      "rebelot/heirline.nvim",
+      optional = true,
+      opts = function(_, opts) opts.statusline = nil end,
+    },
   },
 }

--- a/lua/astrocommunity/bars-and-lines/scope-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/scope-nvim/init.lua
@@ -1,8 +1,12 @@
 return {
-  { "tiagovla/scope.nvim", event = "VeryLazy", opts = {} },
-  {
-    "nvim-telescope/telescope.nvim",
-    optional = true,
-    opts = function() require("telescope").load_extension "scope" end,
+  "tiagovla/scope.nvim",
+  event = "VeryLazy",
+  opts = {},
+  specs = {
+    {
+      "nvim-telescope/telescope.nvim",
+      optional = true,
+      opts = function() require("telescope").load_extension "scope" end,
+    },
   },
 }

--- a/lua/astrocommunity/bars-and-lines/statuscol-nvim/init.lua
+++ b/lua/astrocommunity/bars-and-lines/statuscol-nvim/init.lua
@@ -1,8 +1,12 @@
 return {
-  { "luukvbaal/statuscol.nvim", lazy = false, opts = {} },
-  {
-    "rebelot/heirline.nvim",
-    optional = true,
-    opts = function(_, opts) opts.statuscolumn = nil end,
+  "luukvbaal/statuscol.nvim",
+  lazy = false,
+  opts = {},
+  specs = {
+    {
+      "rebelot/heirline.nvim",
+      optional = true,
+      opts = function(_, opts) opts.statuscolumn = nil end,
+    },
   },
 }

--- a/lua/astrocommunity/bars-and-lines/vim-illuminate/init.lua
+++ b/lua/astrocommunity/bars-and-lines/vim-illuminate/init.lua
@@ -1,14 +1,14 @@
 return {
-  {
-    "RRethy/vim-illuminate",
-    event = "User AstroFile",
-    opts = {},
-    config = function(_, opts) require("illuminate").configure(opts) end,
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { illuminate = true } },
+  "RRethy/vim-illuminate",
+  event = "User AstroFile",
+  opts = {},
+  config = function(_, opts) require("illuminate").configure(opts) end,
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { illuminate = true } },
+    },
   },
 }

--- a/lua/astrocommunity/code-runner/overseer-nvim/init.lua
+++ b/lua/astrocommunity/code-runner/overseer-nvim/init.lua
@@ -1,63 +1,63 @@
 return {
-  {
-    "stevearc/overseer.nvim",
-    cmd = {
-      "OverseerOpen",
-      "OverseerClose",
-      "OverseerToggle",
-      "OverseerSaveBundle",
-      "OverseerLoadBundle",
-      "OverseerDeleteBundle",
-      "OverseerRunCmd",
-      "OverseerRun",
-      "OverseerInfo",
-      "OverseerBuild",
-      "OverseerQuickAction",
-      "OverseerTaskAction ",
-      "OverseerClearCache",
-    },
-    ---@param opts overseer.Config
-    opts = function(_, opts)
-      local astrocore = require "astrocore"
-      if astrocore.is_available "toggleterm.nvim" then opts.strategy = "toggleterm" end
-      opts.task_list = {
-        direction = "bottom",
-        bindings = {
-          ["<C-l>"] = false,
-          ["<C-h>"] = false,
-          ["<C-k>"] = false,
-          ["<C-j>"] = false,
-          q = "<Cmd>close<CR>",
-          K = "IncreaseDetail",
-          J = "DecreaseDetail",
-          ["<C-p>"] = "ScrollOutputUp",
-          ["<C-n>"] = "ScrollOutputDown",
-        },
-      }
-    end,
-    dependencies = {
-      { "AstroNvim/astroui", opts = { icons = { Overseer = "" } } },
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local maps = opts.mappings
-          local prefix = "<leader>M"
-          maps.n[prefix] = { desc = require("astroui").get_icon("Overseer", 1, true) .. "Overseer" }
-
-          maps.n[prefix .. "t"] = { "<Cmd>OverseerToggle<CR>", desc = "Toggle Overseer" }
-          maps.n[prefix .. "c"] = { "<Cmd>OverseerRunCmd<CR>", desc = "Run Command" }
-          maps.n[prefix .. "r"] = { "<Cmd>OverseerRun<CR>", desc = "Run Task" }
-          maps.n[prefix .. "q"] = { "<Cmd>OverseerQuickAction<CR>", desc = "Quick Action" }
-          maps.n[prefix .. "a"] = { "<Cmd>OverseerTaskAction<CR>", desc = "Task Action" }
-          maps.n[prefix .. "i"] = { "<Cmd>OverseerInfo<CR>", desc = "Overseer Info" }
-        end,
+  "stevearc/overseer.nvim",
+  cmd = {
+    "OverseerOpen",
+    "OverseerClose",
+    "OverseerToggle",
+    "OverseerSaveBundle",
+    "OverseerLoadBundle",
+    "OverseerDeleteBundle",
+    "OverseerRunCmd",
+    "OverseerRun",
+    "OverseerInfo",
+    "OverseerBuild",
+    "OverseerQuickAction",
+    "OverseerTaskAction ",
+    "OverseerClearCache",
+  },
+  ---@param opts overseer.Config
+  opts = function(_, opts)
+    local astrocore = require "astrocore"
+    if astrocore.is_available "toggleterm.nvim" then opts.strategy = "toggleterm" end
+    opts.task_list = {
+      direction = "bottom",
+      bindings = {
+        ["<C-l>"] = false,
+        ["<C-h>"] = false,
+        ["<C-k>"] = false,
+        ["<C-j>"] = false,
+        q = "<Cmd>close<CR>",
+        K = "IncreaseDetail",
+        J = "DecreaseDetail",
+        ["<C-p>"] = "ScrollOutputUp",
+        ["<C-n>"] = "ScrollOutputDown",
       },
+    }
+  end,
+  dependencies = {
+    { "AstroNvim/astroui", opts = { icons = { Overseer = "" } } },
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        local prefix = "<leader>M"
+        maps.n[prefix] = { desc = require("astroui").get_icon("Overseer", 1, true) .. "Overseer" }
+
+        maps.n[prefix .. "t"] = { "<Cmd>OverseerToggle<CR>", desc = "Toggle Overseer" }
+        maps.n[prefix .. "c"] = { "<Cmd>OverseerRunCmd<CR>", desc = "Run Command" }
+        maps.n[prefix .. "r"] = { "<Cmd>OverseerRun<CR>", desc = "Run Task" }
+        maps.n[prefix .. "q"] = { "<Cmd>OverseerQuickAction<CR>", desc = "Quick Action" }
+        maps.n[prefix .. "a"] = { "<Cmd>OverseerTaskAction<CR>", desc = "Task Action" }
+        maps.n[prefix .. "i"] = { "<Cmd>OverseerInfo<CR>", desc = "Overseer Info" }
+      end,
     },
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { overseer = true } },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { overseer = true } },
+    },
   },
 }

--- a/lua/astrocommunity/color/ccc-nvim/init.lua
+++ b/lua/astrocommunity/color/ccc-nvim/init.lua
@@ -1,32 +1,32 @@
 return {
-  { "NvChad/nvim-colorizer.lua", enabled = false },
-  {
-    "uga-rosa/ccc.nvim",
-    event = { "User AstroFile", "InsertEnter" },
-    cmd = { "CccPick", "CccConvert", "CccHighlighterEnable", "CccHighlighterDisable", "CccHighlighterToggle" },
-    dependencies = {
-      {
-        "AstroNvim/astrocore",
-        opts = {
-          mappings = {
-            n = {
-              ["<Leader>uC"] = { "<Cmd>CccHighlighterToggle<CR>", desc = "Toggle colorizer" },
-              ["<Leader>zc"] = { "<Cmd>CccConvert<CR>", desc = "Convert color" },
-              ["<Leader>zp"] = { "<Cmd>CccPick<CR>", desc = "Pick Color" },
-            },
+  "uga-rosa/ccc.nvim",
+  event = { "User AstroFile", "InsertEnter" },
+  cmd = { "CccPick", "CccConvert", "CccHighlighterEnable", "CccHighlighterDisable", "CccHighlighterToggle" },
+  specs = {
+    { "NvChad/nvim-colorizer.lua", optional = true, enabled = false },
+  },
+  dependencies = {
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        mappings = {
+          n = {
+            ["<Leader>uC"] = { "<Cmd>CccHighlighterToggle<CR>", desc = "Toggle colorizer" },
+            ["<Leader>zc"] = { "<Cmd>CccConvert<CR>", desc = "Convert color" },
+            ["<Leader>zp"] = { "<Cmd>CccPick<CR>", desc = "Pick Color" },
           },
         },
       },
     },
-    opts = {
-      highlighter = {
-        auto_enable = true,
-        lsp = true,
-      },
-    },
-    config = function(_, opts)
-      require("ccc").setup(opts)
-      if opts.highlighter and opts.highlighter.auto_enable then vim.cmd.CccHighlighterEnable() end
-    end,
   },
+  opts = {
+    highlighter = {
+      auto_enable = true,
+      lsp = true,
+    },
+  },
+  config = function(_, opts)
+    require("ccc").setup(opts)
+    if opts.highlighter and opts.highlighter.auto_enable then vim.cmd.CccHighlighterEnable() end
+  end,
 }

--- a/lua/astrocommunity/color/headlines-nvim/init.lua
+++ b/lua/astrocommunity/color/headlines-nvim/init.lua
@@ -1,14 +1,14 @@
 return {
-  {
-    "lukas-reineke/headlines.nvim",
-    dependencies = "nvim-treesitter/nvim-treesitter",
-    ft = { "markdown", "norg", "org", "rmd" },
-    opts = {},
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { headlines = true } },
+  "lukas-reineke/headlines.nvim",
+  dependencies = "nvim-treesitter/nvim-treesitter",
+  ft = { "markdown", "norg", "org", "rmd" },
+  opts = {},
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { headlines = true } },
+    },
   },
 }

--- a/lua/astrocommunity/color/mini-hipatterns/init.lua
+++ b/lua/astrocommunity/color/mini-hipatterns/init.lua
@@ -1,13 +1,13 @@
 return {
-  {
-    "echasnovski/mini.hipatterns",
-    event = "User AstroFile",
-    opts = {},
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  "echasnovski/mini.hipatterns",
+  event = "User AstroFile",
+  opts = {},
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/color/modes-nvim/init.lua
+++ b/lua/astrocommunity/color/modes-nvim/init.lua
@@ -1,9 +1,9 @@
 return {
-  { "folke/which-key.nvim", optional = true, opts = { plugins = { presets = { operators = false } } } },
-  {
-    "mvllow/modes.nvim",
-    version = "^0.2",
-    event = "VeryLazy",
-    opts = {},
+  "mvllow/modes.nvim",
+  version = "^0.2",
+  event = "VeryLazy",
+  opts = {},
+  specs = {
+    { "folke/which-key.nvim", optional = true, opts = { plugins = { presets = { operators = false } } } },
   },
 }

--- a/lua/astrocommunity/color/nvim-highlight-colors/init.lua
+++ b/lua/astrocommunity/color/nvim-highlight-colors/init.lua
@@ -1,39 +1,18 @@
 return {
-  { "NvChad/nvim-colorizer.lua", enabled = false },
-  {
-    "brenoprata10/nvim-highlight-colors",
-    event = "User AstroFile",
-    cmd = "HighlightColors",
-    dependencies = {
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local maps = opts.mappings
-          maps.n["<Leader>uz"] = { function() vim.cmd.HighlightColors "Toggle" end, desc = "Toggle color highlight" }
-        end,
-      },
+  "brenoprata10/nvim-highlight-colors",
+  event = "User AstroFile",
+  cmd = "HighlightColors",
+  dependencies = {
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        maps.n["<Leader>uz"] = { function() vim.cmd.HighlightColors "Toggle" end, desc = "Toggle color highlight" }
+      end,
     },
-    opts = { enabled_named_colors = false },
   },
-  {
-    "hrsh7th/nvim-cmp",
-    optional = true,
-    opts = function(_, opts)
-      if not opts.formatting then opts.formatting = {} end
-      local formatter = vim.tbl_get(opts, "formatting", "format")
-      opts.formatting.format = function(entry, item)
-        if formatter then
-          local color_item = require("nvim-highlight-colors").format(entry, { kind = item.kind })
-          item = formatter(entry, item)
-          if color_item.abbr_hl_group then
-            item.kind_hl_group = color_item.abbr_hl_group
-            item.kind = color_item.abbr
-          end
-        else
-          item = require("nvim-highlight-colors").format(entry, item)
-        end
-        return item
-      end
-    end,
+  opts = { enabled_named_colors = false },
+  specs = {
+    { "NvChad/nvim-colorizer.lua", optional = true, enabled = false },
   },
 }

--- a/lua/astrocommunity/colorscheme/catppuccin/init.lua
+++ b/lua/astrocommunity/colorscheme/catppuccin/init.lua
@@ -1,50 +1,50 @@
 return {
-  {
-    "catppuccin/nvim",
-    name = "catppuccin",
-    ---@type CatppuccinOptions
-    opts = {
-      integrations = {
-        aerial = true,
-        alpha = true,
-        cmp = true,
-        dap = true,
-        dap_ui = true,
-        gitsigns = true,
-        illuminate = true,
-        indent_blankline = true,
-        markdown = true,
-        mason = true,
-        native_lsp = { enabled = true },
-        neotree = true,
-        notify = true,
-        semantic_tokens = true,
-        symbols_outline = true,
-        telescope = true,
-        treesitter = true,
-        ts_rainbow = false,
-        ufo = true,
-        which_key = true,
-        window_picker = true,
-      },
+  "catppuccin/nvim",
+  name = "catppuccin",
+  ---@type CatppuccinOptions
+  opts = {
+    integrations = {
+      aerial = true,
+      alpha = true,
+      cmp = true,
+      dap = true,
+      dap_ui = true,
+      gitsigns = true,
+      illuminate = true,
+      indent_blankline = true,
+      markdown = true,
+      mason = true,
+      native_lsp = { enabled = true },
+      neotree = true,
+      notify = true,
+      semantic_tokens = true,
+      symbols_outline = true,
+      telescope = true,
+      treesitter = true,
+      ts_rainbow = false,
+      ufo = true,
+      which_key = true,
+      window_picker = true,
     },
   },
-  {
-    "akinsho/bufferline.nvim",
-    optional = true,
-    opts = function(_, opts)
-      return require("astrocore").extend_tbl(opts, {
-        highlights = require("catppuccin.groups.integrations.bufferline").get(),
-      })
-    end,
-  },
-  {
-    "nvim-telescope/telescope.nvim",
-    optional = true,
-    opts = {
-      highlight = {
-        enable = true,
-        additional_vim_regex_highlighting = false,
+  specs = {
+    {
+      "akinsho/bufferline.nvim",
+      optional = true,
+      opts = function(_, opts)
+        return require("astrocore").extend_tbl(opts, {
+          highlights = require("catppuccin.groups.integrations.bufferline").get(),
+        })
+      end,
+    },
+    {
+      "nvim-telescope/telescope.nvim",
+      optional = true,
+      opts = {
+        highlight = {
+          enable = true,
+          additional_vim_regex_highlighting = false,
+        },
       },
     },
   },

--- a/lua/astrocommunity/colorscheme/mini-base16/init.lua
+++ b/lua/astrocommunity/colorscheme/mini-base16/init.lua
@@ -1,9 +1,11 @@
 return {
   "echasnovski/mini.base16",
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/colorscheme/nord-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/nord-nvim/init.lua
@@ -1,46 +1,46 @@
 return {
-  {
-    "shaunsingh/nord.nvim",
-    dependencies = {
-      "AstroNvim/astrocore",
+  "shaunsingh/nord.nvim",
+  dependencies = {
+    "AstroNvim/astrocore",
+    opts = {
+      options = {
+        g = {
+          nord_contrast = true,
+          nord_borders = false,
+          nord_disable_background = false,
+          nord_italic = false,
+          nord_uniform_diff_background = true,
+          nord_bold = false,
+        },
+      },
+    },
+  },
+  specs = {
+    {
+      "lukas-reineke/headlines.nvim",
+      optional = true,
       opts = {
-        options = {
-          g = {
-            nord_contrast = true,
-            nord_borders = false,
-            nord_disable_background = false,
-            nord_italic = false,
-            nord_uniform_diff_background = true,
-            nord_bold = false,
+        markdown = {
+          headline_highlights = {
+            "Headline1",
+            "Headline2",
+            "Headline3",
+            "Headline4",
+            "Headline5",
+            "Headline6",
           },
         },
       },
     },
-  },
-  {
-    "lukas-reineke/headlines.nvim",
-    optional = true,
-    opts = {
-      markdown = {
-        headline_highlights = {
-          "Headline1",
-          "Headline2",
-          "Headline3",
-          "Headline4",
-          "Headline5",
-          "Headline6",
-        },
-      },
+    {
+      "akinsho/bufferline.nvim",
+      optional = true,
+      opts = function(_, opts)
+        return require("astrocore").extend_tbl(opts, {
+          highlights = require("nord").bufferline.highlights { italic = true, bold = true },
+          options = { separator_style = "thin" },
+        })
+      end,
     },
-  },
-  {
-    "akinsho/bufferline.nvim",
-    optional = true,
-    opts = function(_, opts)
-      return require("astrocore").extend_tbl(opts, {
-        highlights = require("nord").bufferline.highlights { italic = true, bold = true },
-        options = { separator_style = "thin" },
-      })
-    end,
   },
 }

--- a/lua/astrocommunity/comment/mini-comment/init.lua
+++ b/lua/astrocommunity/comment/mini-comment/init.lua
@@ -1,19 +1,19 @@
 return {
-  { "numToStr/Comment.nvim", enabled = false },
-  {
-    "echasnovski/mini.comment",
-    dependencies = { "JoosepAlviste/nvim-ts-context-commentstring", opts = { enable_autocmd = false } },
-    event = "User AstroFile",
-    opts = {
-      custom_commentstring = function()
-        return require("ts_context_commentstring").calculate_commentstring() or vim.bo.commentstring
-      end,
-    },
+  "echasnovski/mini.comment",
+  dependencies = { "JoosepAlviste/nvim-ts-context-commentstring", opts = { enable_autocmd = false } },
+  event = "User AstroFile",
+  opts = {
+    custom_commentstring = function()
+      return require("ts_context_commentstring").calculate_commentstring() or vim.bo.commentstring
+    end,
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  specs = {
+    { "numToStr/Comment.nvim", optional = true, enabled = false },
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/comment/ts-comments-nvim/init.lua
+++ b/lua/astrocommunity/comment/ts-comments-nvim/init.lua
@@ -1,10 +1,10 @@
 return {
-  { "numToStr/Comment.nvim", enabled = false },
-  { "JoosepAlviste/nvim-ts-context-commentstring", enabled = false },
-  {
-    "folke/ts-comments.nvim",
-    opts = {},
-    event = "VeryLazy",
-    enabled = vim.fn.has "nvim-0.10.0" == 1,
+  "folke/ts-comments.nvim",
+  opts = {},
+  event = "VeryLazy",
+  enabled = vim.fn.has "nvim-0.10.0" == 1,
+  specs = {
+    { "numToStr/Comment.nvim", optional = true, enabled = false },
+    { "JoosepAlviste/nvim-ts-context-commentstring", optional = true, enabled = false },
   },
 }

--- a/lua/astrocommunity/completion/copilot-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-cmp/init.lua
@@ -1,29 +1,36 @@
 ---@type LazySpec
 return {
-  {
-    "zbirenbaum/copilot.lua",
-    opts = {
-      suggestion = { enabled = false },
-      panel = { enabled = false },
+  "zbirenbaum/copilot-cmp",
+  opts = {},
+  dependencies = {
+    {
+      "zbirenbaum/copilot.lua",
+      opts = {
+        suggestion = { enabled = false },
+        panel = { enabled = false },
+      },
     },
   },
-  { "zbirenbaum/copilot-cmp", opts = {}, dependencies = { "zbirenbaum/copilot.lua" } },
-  {
-    "hrsh7th/nvim-cmp",
-    dependencies = { "zbirenbaum/copilot-cmp" },
-    opts = function(_, opts)
-      -- Inject copilot into cmp sources, with high priority
-      table.insert(opts.sources, 1, {
-        name = "copilot",
-        group_index = 1,
-        priority = 10000,
-      })
-    end,
-  },
-  {
-    "onsails/lspkind.nvim",
-    optional = true,
-    -- Adds icon for copilot using lspkind
-    opts = function(_, opts) opts.symbol_map.Copilot = "" end,
+  specs = {
+    { import = "astrocommunity.completion.copilot-lua" },
+    {
+      "hrsh7th/nvim-cmp",
+      optional = true,
+      dependencies = { "zbirenbaum/copilot-cmp" },
+      opts = function(_, opts)
+        -- Inject copilot into cmp sources, with high priority
+        table.insert(opts.sources, 1, {
+          name = "copilot",
+          group_index = 1,
+          priority = 10000,
+        })
+      end,
+    },
+    {
+      "onsails/lspkind.nvim",
+      optional = true,
+      -- Adds icon for copilot using lspkind
+      opts = function(_, opts) opts.symbol_map.Copilot = "" end,
+    },
   },
 }

--- a/lua/astrocommunity/completion/copilot-lua-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-lua-cmp/init.lua
@@ -1,60 +1,63 @@
 return {
-  { import = "astrocommunity.completion.copilot-lua" },
-  {
-    "hrsh7th/nvim-cmp",
-    dependencies = { "zbirenbaum/copilot.lua" },
-    opts = function(_, opts)
-      local cmp, copilot = require "cmp", require "copilot.suggestion"
-      local snip_status_ok, luasnip = pcall(require, "luasnip")
-      if not snip_status_ok then return end
-      local function has_words_before()
-        local line, col = unpack(vim.api.nvim_win_get_cursor(0))
-        return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match "%s" == nil
-      end
-      if not opts.mapping then opts.mapping = {} end
-      opts.mapping["<Tab>"] = cmp.mapping(function(fallback)
-        if copilot.is_visible() then
-          copilot.accept()
-        elseif cmp.visible() then
-          cmp.select_next_item()
-        elseif luasnip.expand_or_jumpable() then
-          luasnip.expand_or_jump()
-        elseif has_words_before() then
-          cmp.complete()
-        else
-          fallback()
+  "zbirenbaum/copilot.lua",
+  specs = {
+    { import = "astrocommunity.completion.copilot-lua" },
+    {
+      "hrsh7th/nvim-cmp",
+      dependencies = { "zbirenbaum/copilot.lua" },
+      opts = function(_, opts)
+        local cmp, copilot = require "cmp", require "copilot.suggestion"
+        local snip_status_ok, luasnip = pcall(require, "luasnip")
+        if not snip_status_ok then return end
+        local function has_words_before()
+          local line, col = unpack(vim.api.nvim_win_get_cursor(0))
+          return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match "%s" == nil
         end
-      end, { "i", "s" })
+        if not opts.mapping then opts.mapping = {} end
+        opts.mapping["<Tab>"] = cmp.mapping(function(fallback)
+          if copilot.is_visible() then
+            copilot.accept()
+          elseif cmp.visible() then
+            cmp.select_next_item()
+          elseif luasnip.expand_or_jumpable() then
+            luasnip.expand_or_jump()
+          elseif has_words_before() then
+            cmp.complete()
+          else
+            fallback()
+          end
+        end, { "i", "s" })
 
-      opts.mapping["<C-x>"] = cmp.mapping(function()
-        if copilot.is_visible() then copilot.next() end
-      end)
+        opts.mapping["<C-x>"] = cmp.mapping(function()
+          if copilot.is_visible() then copilot.next() end
+        end)
 
-      opts.mapping["<C-z>"] = cmp.mapping(function()
-        if copilot.is_visible() then copilot.prev() end
-      end)
+        opts.mapping["<C-z>"] = cmp.mapping(function()
+          if copilot.is_visible() then copilot.prev() end
+        end)
 
-      opts.mapping["<C-right>"] = cmp.mapping(function()
-        if copilot.is_visible() then copilot.accept_word() end
-      end)
+        opts.mapping["<C-right>"] = cmp.mapping(function()
+          if copilot.is_visible() then copilot.accept_word() end
+        end)
 
-      opts.mapping["<C-l>"] = cmp.mapping(function()
-        if copilot.is_visible() then copilot.accept_word() end
-      end)
+        opts.mapping["<C-l>"] = cmp.mapping(function()
+          if copilot.is_visible() then copilot.accept_word() end
+        end)
 
-      opts.mapping["<C-down>"] = cmp.mapping(function()
-        if copilot.is_visible() then copilot.accept_line() end
-      end)
+        opts.mapping["<C-down>"] = cmp.mapping(function()
+          if copilot.is_visible() then copilot.accept_line() end
+        end)
 
-      opts.mapping["<C-j>"] = cmp.mapping(function()
-        if copilot.is_visible() then copilot.accept_line() end
-      end)
+        opts.mapping["<C-j>"] = cmp.mapping(function()
+          if copilot.is_visible() then copilot.accept_line() end
+        end)
 
-      opts.mapping["<C-c>"] = cmp.mapping(function()
-        if copilot.is_visible() then copilot.dismiss() end
-      end)
+        opts.mapping["<C-c>"] = cmp.mapping(function()
+          if copilot.is_visible() then copilot.dismiss() end
+        end)
 
-      return opts
-    end,
+        return opts
+      end,
+    },
   },
 }

--- a/lua/astrocommunity/completion/coq_nvim/init.lua
+++ b/lua/astrocommunity/completion/coq_nvim/init.lua
@@ -1,49 +1,49 @@
 return {
-  { "hrsh7th/nvim-cmp", enabled = false },
-  { "hrsh7th/cmp-buffer", enabled = false },
-  { "hrsh7th/cmp-nvim-lsp", enabled = false },
-  { "hrsh7th/cmp-path", enabled = false },
-  { "L3MON4D3/LuaSnip", enabled = false },
-  { "saadparwaiz1/cmp_luasnip", enabled = false },
-  { "rcarriga/cmp-dap", enabled = false },
-  {
-    "ms-jpq/coq_nvim",
-    branch = "coq",
-    event = "InsertEnter",
-    build = ":COQdeps",
-    cmd = { "COQnow", "COQhelp", "COQstats", "COQdeps" },
-    dependencies = {
-      { "ms-jpq/coq.artifacts", branch = "artifacts" },
-      {
-        "AstroNvim/astrocore",
-        opts = {
-          options = {
-            g = {
-              coq_settings = {
-                auto_start = "shut-up",
-                keymap = { jump_to_mark = "<Tab>" },
-              },
+  "ms-jpq/coq_nvim",
+  branch = "coq",
+  event = "InsertEnter",
+  build = ":COQdeps",
+  cmd = { "COQnow", "COQhelp", "COQstats", "COQdeps" },
+  specs = {
+    { "hrsh7th/nvim-cmp", optional = true, enabled = false },
+    { "hrsh7th/cmp-buffer", optional = true, enabled = false },
+    { "hrsh7th/cmp-nvim-lsp", optional = true, enabled = false },
+    { "hrsh7th/cmp-path", optional = true, enabled = false },
+    { "L3MON4D3/LuaSnip", optional = true, enabled = false },
+    { "saadparwaiz1/cmp_luasnip", optional = true, enabled = false },
+    { "rcarriga/cmp-dap", optional = true, enabled = false },
+  },
+  dependencies = {
+    { "ms-jpq/coq.artifacts", branch = "artifacts" },
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        options = {
+          g = {
+            coq_settings = {
+              auto_start = "shut-up",
+              keymap = { jump_to_mark = "<Tab>" },
             },
           },
         },
       },
-      {
-        "AstroNvim/astrolsp",
-        optional = true,
-        opts = {
-          capabilities = {
-            textDocument = {
-              completion = {
-                completionItem = {
-                  deprecatedSupport = true,
-                  insertReplaceSupport = true,
-                  insertTextModeSupport = { valueSet = { 1, 2 } },
-                  labelDetailsSupport = true,
-                  preselectSupport = true,
-                  resolveSupport = { properties = {} },
-                  snippetSupport = true,
-                  tagSupport = { valueSet = { 1 } },
-                },
+    },
+    {
+      "AstroNvim/astrolsp",
+      optional = true,
+      opts = {
+        capabilities = {
+          textDocument = {
+            completion = {
+              completionItem = {
+                deprecatedSupport = true,
+                insertReplaceSupport = true,
+                insertTextModeSupport = { valueSet = { 1, 2 } },
+                labelDetailsSupport = true,
+                preselectSupport = true,
+                resolveSupport = { properties = {} },
+                snippetSupport = true,
+                tagSupport = { valueSet = { 1 } },
               },
             },
           },

--- a/lua/astrocommunity/completion/mini-completion/init.lua
+++ b/lua/astrocommunity/completion/mini-completion/init.lua
@@ -1,10 +1,14 @@
 return {
-  { "hrsh7th/nvim-cmp", enabled = false },
-  { "hrsh7th/cmp-buffer", enabled = false },
-  { "hrsh7th/cmp-nvim-lsp", enabled = false },
-  { "hrsh7th/cmp-path", enabled = false },
-  { "L3MON4D3/LuaSnip", enabled = false },
-  { "saadparwaiz1/cmp_luasnip", enabled = false },
-  { "rcarriga/cmp-dap", enabled = false },
-  { "echasnovski/mini.completion", lazy = false, opts = {} },
+  "echasnovski/mini.completion",
+  lazy = false,
+  opts = {},
+  specs = {
+    { "hrsh7th/nvim-cmp", optional = true, enabled = false },
+    { "hrsh7th/cmp-buffer", optional = true, enabled = false },
+    { "hrsh7th/cmp-nvim-lsp", optional = true, enabled = false },
+    { "hrsh7th/cmp-path", optional = true, enabled = false },
+    { "L3MON4D3/LuaSnip", optional = true, enabled = false },
+    { "saadparwaiz1/cmp_luasnip", optional = true, enabled = false },
+    { "rcarriga/cmp-dap", optional = true, enabled = false },
+  },
 }

--- a/lua/astrocommunity/completion/nvim-cmp-buffer-lines/init.lua
+++ b/lua/astrocommunity/completion/nvim-cmp-buffer-lines/init.lua
@@ -1,27 +1,31 @@
 ---@type LazySpec
 return {
-  "hrsh7th/nvim-cmp",
-  dependencies = {
-    { "amarakon/nvim-cmp-buffer-lines" },
-  },
-  opts = function(_, opts)
-    local cmp = require "cmp"
-    return require("astrocore").extend_tbl(opts, {
-      mapping = {
-        ["<C-x><C-l>"] = cmp.mapping.complete { -- this could've been a more ergonomic hotkey, but it would be a reach to try to make up one, that would fit everyone.
-          config = {
-            sources = {
-              {
-                name = "buffer-lines",
-                priority = 50,
-                option = {
-                  leading_whitespace = false,
+  "amarakon/nvim-cmp-buffer-lines",
+  lazy = true,
+  specs = {
+    {
+      "hrsh7th/nvim-cmp",
+      dependencies = { "amarakon/nvim-cmp-buffer-lines" },
+      opts = function(_, opts)
+        local cmp = require "cmp"
+        return require("astrocore").extend_tbl(opts, {
+          mapping = {
+            ["<C-x><C-l>"] = cmp.mapping.complete { -- this could've been a more ergonomic hotkey, but it would be a reach to try to make up one, that would fit everyone.
+              config = {
+                sources = {
+                  {
+                    name = "buffer-lines",
+                    priority = 50,
+                    option = {
+                      leading_whitespace = false,
+                    },
+                  },
                 },
               },
             },
           },
-        },
-      },
-    })
-  end,
+        })
+      end,
+    },
+  },
 }

--- a/lua/astrocommunity/debugging/nvim-dap-repl-highlights/init.lua
+++ b/lua/astrocommunity/debugging/nvim-dap-repl-highlights/init.lua
@@ -1,13 +1,19 @@
 return {
-  "nvim-treesitter/nvim-treesitter",
-  dependencies = {
-    "LiadOz/nvim-dap-repl-highlights",
-    dependencies = { "mfussenegger/nvim-dap" },
-    opts = {},
+  "LiadOz/nvim-dap-repl-highlights",
+  lazy = true,
+  specs = {
+    {
+      "nvim-treesitter/nvim-treesitter",
+      dependencies = {
+        "LiadOz/nvim-dap-repl-highlights",
+        dependencies = { "mfussenegger/nvim-dap" },
+        opts = {},
+      },
+      opts = function(_, opts)
+        if opts.ensure_installed ~= "all" then
+          opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "dap_repl" })
+        end
+      end,
+    },
   },
-  opts = function(_, opts)
-    if opts.ensure_installed ~= "all" then
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "dap_repl" })
-    end
-  end,
 }

--- a/lua/astrocommunity/debugging/telescope-dap-nvim/init.lua
+++ b/lua/astrocommunity/debugging/telescope-dap-nvim/init.lua
@@ -1,38 +1,44 @@
 local prefix = "<Leader>fd"
 
 return {
-  "nvim-telescope/telescope.nvim",
-  dependencies = {
-    "nvim-telescope/telescope-dap.nvim",
+  "nvim-telescope/telescope-dap.nvim",
+  lazy = true,
+  specs = {
     {
-      "AstroNvim/astrocore",
-      opts = {
-        mappings = {
-          n = {
-            [prefix .. "c"] = {
-              "<Cmd>lua require('telescope').extensions.dap.commands()<CR>",
-              desc = "Telescope DAP commands",
-            },
-            [prefix .. "f"] = {
-              "<Cmd>lua require('telescope').extensions.dap.frames()<CR>",
-              desc = "Telescope DAP frames",
-            },
-            [prefix .. "g"] = {
-              "<Cmd>lua require('telescope').extensions.dap.configurations()<CR>",
-              desc = "Telescope DAP configurations",
-            },
-            [prefix .. "l"] = {
-              "<Cmd>lua require('telescope').extensions.dap.list_breakpoints()<CR>",
-              desc = "Telescope DAP list breakpoints",
-            },
-            [prefix .. "v"] = {
-              "<Cmd>lua require('telescope').extensions.dap.variables()<CR>",
-              desc = "Telescope DAP variables",
+      "nvim-telescope/telescope.nvim",
+      dependencies = {
+        "nvim-telescope/telescope-dap.nvim",
+        {
+          "AstroNvim/astrocore",
+          opts = {
+            mappings = {
+              n = {
+                [prefix .. "c"] = {
+                  "<Cmd>lua require('telescope').extensions.dap.commands()<CR>",
+                  desc = "Telescope DAP commands",
+                },
+                [prefix .. "f"] = {
+                  "<Cmd>lua require('telescope').extensions.dap.frames()<CR>",
+                  desc = "Telescope DAP frames",
+                },
+                [prefix .. "g"] = {
+                  "<Cmd>lua require('telescope').extensions.dap.configurations()<CR>",
+                  desc = "Telescope DAP configurations",
+                },
+                [prefix .. "l"] = {
+                  "<Cmd>lua require('telescope').extensions.dap.list_breakpoints()<CR>",
+                  desc = "Telescope DAP list breakpoints",
+                },
+                [prefix .. "v"] = {
+                  "<Cmd>lua require('telescope').extensions.dap.variables()<CR>",
+                  desc = "Telescope DAP variables",
+                },
+              },
             },
           },
         },
       },
+      opts = function() require("telescope").load_extension "dap" end,
     },
   },
-  opts = function() require("telescope").load_extension "dap" end,
 }

--- a/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
@@ -1,67 +1,67 @@
 return {
-  {
-    "folke/trouble.nvim",
-    cmd = "Trouble",
-    dependencies = {
-      { "AstroNvim/astroui", opts = { icons = { Trouble = "󱍼" } } },
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local maps = opts.mappings
-          local prefix = "<Leader>x"
-          maps.n[prefix] = { desc = require("astroui").get_icon("Trouble", 1, true) .. "Trouble" }
-          maps.n[prefix .. "X"] = { "<Cmd>Trouble diagnostics toggle<CR>", desc = "Workspace Diagnostics (Trouble)" }
-          maps.n[prefix .. "x"] =
-            { "<Cmd>Trouble diagnostics toggle filter.buf=0<CR>", desc = "Document Diagnostics (Trouble)" }
-          maps.n[prefix .. "l"] = { "<Cmd>Trouble loclist toggle<CR>", desc = "Location List (Trouble)" }
-          maps.n[prefix .. "q"] = { "<Cmd>Trouble quickfix toggle<CR>", desc = "Quickfix List (Trouble)" }
-          if require("astrocore").is_available "todo-comments.nvim" then
-            maps.n[prefix .. "t"] = {
-              "<cmd>Trouble todo<cr>",
-              desc = "Todo (Trouble)",
-            }
-            maps.n[prefix .. "T"] = {
-              "<cmd>Trouble todo filter={tag={TODO,FIX,FIXME}}<cr>",
-              desc = "Todo/Fix/Fixme (Trouble)",
-            }
-          end
-        end,
-      },
+  "folke/trouble.nvim",
+  cmd = "Trouble",
+  dependencies = {
+    { "AstroNvim/astroui", opts = { icons = { Trouble = "󱍼" } } },
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        local prefix = "<Leader>x"
+        maps.n[prefix] = { desc = require("astroui").get_icon("Trouble", 1, true) .. "Trouble" }
+        maps.n[prefix .. "X"] = { "<Cmd>Trouble diagnostics toggle<CR>", desc = "Workspace Diagnostics (Trouble)" }
+        maps.n[prefix .. "x"] =
+          { "<Cmd>Trouble diagnostics toggle filter.buf=0<CR>", desc = "Document Diagnostics (Trouble)" }
+        maps.n[prefix .. "l"] = { "<Cmd>Trouble loclist toggle<CR>", desc = "Location List (Trouble)" }
+        maps.n[prefix .. "q"] = { "<Cmd>Trouble quickfix toggle<CR>", desc = "Quickfix List (Trouble)" }
+        if require("astrocore").is_available "todo-comments.nvim" then
+          maps.n[prefix .. "t"] = {
+            "<cmd>Trouble todo<cr>",
+            desc = "Todo (Trouble)",
+          }
+          maps.n[prefix .. "T"] = {
+            "<cmd>Trouble todo filter={tag={TODO,FIX,FIXME}}<cr>",
+            desc = "Todo/Fix/Fixme (Trouble)",
+          }
+        end
+      end,
     },
-    opts = function()
-      local get_icon = require("astroui").get_icon
-      local lspkind_avail, lspkind = pcall(require, "lspkind")
-      return {
-        keys = {
-          ["<ESC>"] = "close",
-          ["q"] = "close",
-          ["<C-E>"] = "close",
-        },
-        icons = {
-          indent = {
-            fold_open = get_icon "FoldOpened",
-            fold_closed = get_icon "FoldClosed",
-          },
-          folder_closed = get_icon "FolderClosed",
-          folder_open = get_icon "FolderOpen",
-          kinds = lspkind_avail and lspkind.symbol_map,
-        },
-      }
-    end,
   },
-  { "lewis6991/gitsigns.nvim", opts = { trouble = true } },
-  {
-    "folke/edgy.nvim",
-    optional = true,
-    opts = function(_, opts)
-      if not opts.bottom then opts.bottom = {} end
-      table.insert(opts.bottom, "Trouble")
-    end,
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { lsp_trouble = true } },
+  opts = function()
+    local get_icon = require("astroui").get_icon
+    local lspkind_avail, lspkind = pcall(require, "lspkind")
+    return {
+      keys = {
+        ["<ESC>"] = "close",
+        ["q"] = "close",
+        ["<C-E>"] = "close",
+      },
+      icons = {
+        indent = {
+          fold_open = get_icon "FoldOpened",
+          fold_closed = get_icon "FoldClosed",
+        },
+        folder_closed = get_icon "FolderClosed",
+        folder_open = get_icon "FolderOpen",
+        kinds = lspkind_avail and lspkind.symbol_map,
+      },
+    }
+  end,
+  specs = {
+    { "lewis6991/gitsigns.nvim", optional = true, opts = { trouble = true } },
+    {
+      "folke/edgy.nvim",
+      optional = true,
+      opts = function(_, opts)
+        if not opts.bottom then opts.bottom = {} end
+        table.insert(opts.bottom, "Trouble")
+      end,
+    },
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { lsp_trouble = true } },
+    },
   },
 }

--- a/lua/astrocommunity/editing-support/bigfile-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/bigfile-nvim/init.lua
@@ -1,11 +1,11 @@
 return {
-  {
-    "AstroNvim/astrocore",
-    opts = { features = { large_buf = false } } --[[@as AstroCoreOpts]],
-  },
-  {
-    "LunarVim/bigfile.nvim",
-    event = "BufReadPre",
-    opts = {},
+  "LunarVim/bigfile.nvim",
+  event = "BufReadPre",
+  opts = {},
+  specs = {
+    {
+      "AstroNvim/astrocore",
+      opts = { features = { large_buf = false } } --[[@as AstroCoreOpts]],
+    },
   },
 }

--- a/lua/astrocommunity/editing-support/conform-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/conform-nvim/init.lua
@@ -1,72 +1,72 @@
 return {
-  { "AstroNvim/astrolsp", optional = true, opts = { formatting = { disabled = true } } },
-  { "jay-babu/mason-null-ls.nvim", optional = true, opts = { methods = { formatting = false } } },
-  {
-    "stevearc/conform.nvim",
-    event = "User AstroFile",
-    cmd = "ConformInfo",
-    dependencies = {
-      { "williamboman/mason.nvim", optional = true },
-      {
-        "AstroNvim/astrocore",
-        opts = {
-          options = { opt = { formatexpr = "v:lua.require'conform'.formatexpr()" } },
-          commands = {
-            Format = {
-              function(args)
-                local range = nil
-                if args.count ~= -1 then
-                  local end_line = vim.api.nvim_buf_get_lines(0, args.line2 - 1, args.line2, true)[1]
-                  range = {
-                    start = { args.line1, 0 },
-                    ["end"] = { args.line2, end_line:len() },
-                  }
-                end
-                require("conform").format { async = true, lsp_format = "fallback", range = range }
-              end,
-              desc = "Format buffer",
-              range = true,
-            },
+  "stevearc/conform.nvim",
+  event = "User AstroFile",
+  cmd = "ConformInfo",
+  specs = {
+    { "AstroNvim/astrolsp", optional = true, opts = { formatting = { disabled = true } } },
+    { "jay-babu/mason-null-ls.nvim", optional = true, opts = { methods = { formatting = false } } },
+  },
+  dependencies = {
+    { "williamboman/mason.nvim", optional = true },
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        options = { opt = { formatexpr = "v:lua.require'conform'.formatexpr()" } },
+        commands = {
+          Format = {
+            function(args)
+              local range = nil
+              if args.count ~= -1 then
+                local end_line = vim.api.nvim_buf_get_lines(0, args.line2 - 1, args.line2, true)[1]
+                range = {
+                  start = { args.line1, 0 },
+                  ["end"] = { args.line2, end_line:len() },
+                }
+              end
+              require("conform").format { async = true, lsp_format = "fallback", range = range }
+            end,
+            desc = "Format buffer",
+            range = true,
           },
-          mappings = {
-            n = {
-              ["<Leader>lf"] = { function() vim.cmd.Format() end, desc = "Format buffer" },
-              ["<Leader>uf"] = {
-                function()
-                  if vim.b.autoformat == nil then
-                    if vim.g.autoformat == nil then vim.g.autoformat = true end
-                    vim.b.autoformat = vim.g.autoformat
-                  end
-                  vim.b.autoformat = not vim.b.autoformat
-                  require("astrocore").notify(
-                    string.format("Buffer autoformatting %s", vim.b.autoformat and "on" or "off")
-                  )
-                end,
-                desc = "Toggle autoformatting (buffer)",
-              },
-              ["<Leader>uF"] = {
-                function()
+        },
+        mappings = {
+          n = {
+            ["<Leader>lf"] = { function() vim.cmd.Format() end, desc = "Format buffer" },
+            ["<Leader>uf"] = {
+              function()
+                if vim.b.autoformat == nil then
                   if vim.g.autoformat == nil then vim.g.autoformat = true end
-                  vim.g.autoformat = not vim.g.autoformat
-                  vim.b.autoformat = nil
-                  require("astrocore").notify(
-                    string.format("Global autoformatting %s", vim.g.autoformat and "on" or "off")
-                  )
-                end,
-                desc = "Toggle autoformatting (global)",
-              },
+                  vim.b.autoformat = vim.g.autoformat
+                end
+                vim.b.autoformat = not vim.b.autoformat
+                require("astrocore").notify(
+                  string.format("Buffer autoformatting %s", vim.b.autoformat and "on" or "off")
+                )
+              end,
+              desc = "Toggle autoformatting (buffer)",
+            },
+            ["<Leader>uF"] = {
+              function()
+                if vim.g.autoformat == nil then vim.g.autoformat = true end
+                vim.g.autoformat = not vim.g.autoformat
+                vim.b.autoformat = nil
+                require("astrocore").notify(
+                  string.format("Global autoformatting %s", vim.g.autoformat and "on" or "off")
+                )
+              end,
+              desc = "Toggle autoformatting (global)",
             },
           },
         },
       },
     },
-    opts = {
-      format_on_save = function(bufnr)
-        if vim.g.autoformat == nil then vim.g.autoformat = true end
-        local autoformat = vim.b[bufnr].autoformat
-        if autoformat == nil then autoformat = vim.g.autoformat end
-        if autoformat then return { timeout_ms = 500, lsp_format = "fallback" } end
-      end,
-    },
+  },
+  opts = {
+    format_on_save = function(bufnr)
+      if vim.g.autoformat == nil then vim.g.autoformat = true end
+      local autoformat = vim.b[bufnr].autoformat
+      if autoformat == nil then autoformat = vim.g.autoformat end
+      if autoformat then return { timeout_ms = 500, lsp_format = "fallback" } end
+    end,
   },
 }

--- a/lua/astrocommunity/editing-support/mini-splitjoin/init.lua
+++ b/lua/astrocommunity/editing-support/mini-splitjoin/init.lua
@@ -1,13 +1,13 @@
 return {
-  {
-    "echasnovski/mini.splitjoin",
-    event = "User AstroFile",
-    opts = {},
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  "echasnovski/mini.splitjoin",
+  event = "User AstroFile",
+  opts = {},
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/editing-support/nvim-devdocs/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-devdocs/init.lua
@@ -1,47 +1,45 @@
 local prefix = "<Leader>f"
 
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "html" })
-      end
-    end,
-  },
-  {
-    "luckasRanarison/nvim-devdocs",
-    dependencies = {
-      "nvim-lua/plenary.nvim",
-      "nvim-telescope/telescope.nvim",
+  "luckasRanarison/nvim-devdocs",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "nvim-telescope/telescope.nvim",
+    {
       "nvim-treesitter/nvim-treesitter",
-    },
-    cmd = {
-      "DevdocsFetch",
-      "DevdocsInstall",
-      "DevdocsUninstall",
-      "DevdocsOpen",
-      "DevdocsOpenFloat",
-      "DevdocsUpdate",
-      "DevdocsUpdateAll",
-      "DevdocsToggle",
-    },
-    keys = {
-      { prefix .. "dd", "<Cmd>DevdocsOpenCurrentFloat<CR>", desc = "Find Devdocs for current file", mode = { "n" } },
-      { prefix .. "dt", "<Cmd>DevdocsToggle<CR>", desc = "Toggle last Devdocs item", mode = { "n" } },
-      { prefix .. "D", "<Cmd>DevdocsOpenFloat<CR>", desc = "Find Devdocs", mode = { "n" } },
-    },
-    opts = {
-      previewer_cmd = vim.fn.executable "glow" == 1 and "glow" or nil,
-      cmd_args = { "-s", "dark", "-w", "80" },
-      picker_cmd = true,
-      picker_cmd_args = { "-p" },
-      filetypes = {
-        typescript = { "node", "javascript", "typescript" },
-      },
-      after_open = function()
-        vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<C-\\><C-n>", true, false, true), "n", true)
+      opts = function(_, opts)
+        if opts.ensure_installed ~= "all" then
+          opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "html" })
+        end
       end,
     },
+  },
+  specs = {},
+  cmd = {
+    "DevdocsFetch",
+    "DevdocsInstall",
+    "DevdocsUninstall",
+    "DevdocsOpen",
+    "DevdocsOpenFloat",
+    "DevdocsUpdate",
+    "DevdocsUpdateAll",
+    "DevdocsToggle",
+  },
+  keys = {
+    { prefix .. "dd", "<Cmd>DevdocsOpenCurrentFloat<CR>", desc = "Find Devdocs for current file", mode = { "n" } },
+    { prefix .. "dt", "<Cmd>DevdocsToggle<CR>", desc = "Toggle last Devdocs item", mode = { "n" } },
+    { prefix .. "D", "<Cmd>DevdocsOpenFloat<CR>", desc = "Find Devdocs", mode = { "n" } },
+  },
+  opts = {
+    previewer_cmd = vim.fn.executable "glow" == 1 and "glow" or nil,
+    cmd_args = { "-s", "dark", "-w", "80" },
+    picker_cmd = true,
+    picker_cmd_args = { "-p" },
+    filetypes = {
+      typescript = { "node", "javascript", "typescript" },
+    },
+    after_open = function()
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<C-\\><C-n>", true, false, true), "n", true)
+    end,
   },
 }

--- a/lua/astrocommunity/editing-support/nvim-regexplainer/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-regexplainer/init.lua
@@ -1,17 +1,16 @@
 return {
-  {
-    "bennypowers/nvim-regexplainer",
-    opts = {},
-    ft = { "html", "javascript", "javascriptreact", "typescript", "typescriptreact" },
-  },
-  -- Regex support
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      -- add regex to treesitters
-      if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "regex" })
-      end
-    end,
+  "bennypowers/nvim-regexplainer",
+  opts = {},
+  ft = { "html", "javascript", "javascriptreact", "typescript", "typescriptreact" },
+  specs = {
+    {
+      "nvim-treesitter/nvim-treesitter",
+      opts = function(_, opts)
+        -- add regex to treesitters
+        if opts.ensure_installed ~= "all" then
+          opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "regex" })
+        end
+      end,
+    },
   },
 }

--- a/lua/astrocommunity/editing-support/nvim-treesitter-endwise/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-treesitter-endwise/init.lua
@@ -1,7 +1,13 @@
 return {
-  "nvim-treesitter/nvim-treesitter",
-  dependencies = { "RRethy/nvim-treesitter-endwise" },
-  opts = {
-    endwise = { enable = true },
+  "RRethy/nvim-treesitter-endwise",
+  lazy = true,
+  specs = {
+    {
+      "nvim-treesitter/nvim-treesitter",
+      dependencies = { "RRethy/nvim-treesitter-endwise" },
+      opts = {
+        endwise = { enable = true },
+      },
+    },
   },
 }

--- a/lua/astrocommunity/editing-support/nvim-ts-rainbow/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-ts-rainbow/init.lua
@@ -1,30 +1,34 @@
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    dependencies = {
-      "mrjones2014/nvim-ts-rainbow",
-      init = function()
-        require("astrocore").notify(
-          "`nvim-ts-rainbow` is deprecated!\nPlease use `rainbow-delimiters`",
-          vim.log.levels.WARN
-        )
-      end,
-      config = function()
-        -- HACK: https://github.com/p00f/nvim-ts-rainbow/issues/112#issuecomment-1310835936
-        vim.api.nvim_create_autocmd({ "BufWritePost", "FocusGained" }, {
-          callback = function()
-            vim.cmd "TSDisable rainbow"
-            vim.cmd "TSEnable rainbow"
-          end,
-        })
-      end,
+  "mrjones2014/nvim-ts-rainbow",
+  lazy = true,
+  specs = {
+    {
+      "nvim-treesitter/nvim-treesitter",
+      dependencies = {
+        "mrjones2014/nvim-ts-rainbow",
+        init = function()
+          require("astrocore").notify(
+            "`nvim-ts-rainbow` is deprecated!\nPlease use `rainbow-delimiters`",
+            vim.log.levels.WARN
+          )
+        end,
+        config = function()
+          -- HACK: https://github.com/p00f/nvim-ts-rainbow/issues/112#issuecomment-1310835936
+          vim.api.nvim_create_autocmd({ "BufWritePost", "FocusGained" }, {
+            callback = function()
+              vim.cmd "TSDisable rainbow"
+              vim.cmd "TSEnable rainbow"
+            end,
+          })
+        end,
+      },
+      opts = { rainbow = { enable = true } },
     },
-    opts = { rainbow = { enable = true } },
-  },
-  {
-    "catppuccin/nvim",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { ts_rainbow = true } },
+    {
+      "catppuccin/nvim",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { ts_rainbow = true } },
+    },
   },
 }

--- a/lua/astrocommunity/editing-support/nvim-ts-rainbow2/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-ts-rainbow2/init.lua
@@ -1,21 +1,25 @@
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    dependencies = {
-      "HiPhish/nvim-ts-rainbow2",
-      init = function()
-        require("astrocore").notify(
-          "`nvim-ts-rainbow2` is deprecated!\nPlease use `rainbow-delimiters`",
-          vim.log.levels.WARN
-        )
-      end,
+  "HiPhish/nvim-ts-rainbow2",
+  lazy = true,
+  specs = {
+    {
+      "nvim-treesitter/nvim-treesitter",
+      dependencies = {
+        "HiPhish/nvim-ts-rainbow2",
+        init = function()
+          require("astrocore").notify(
+            "`nvim-ts-rainbow2` is deprecated!\nPlease use `rainbow-delimiters`",
+            vim.log.levels.WARN
+          )
+        end,
+      },
+      opts = { rainbow = { enable = true } },
     },
-    opts = { rainbow = { enable = true } },
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { ts_rainbow2 = true } },
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { ts_rainbow2 = true } },
+    },
   },
 }

--- a/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/rainbow-delimiters-nvim/init.lua
@@ -26,14 +26,16 @@ return {
         },
       },
     },
+    specs = {
+      {
+        "catppuccin",
+        optional = true,
+        ---@type CatppuccinOptions
+        opts = { integrations = { rainbow_delimiters = true } },
+      },
+    },
     event = "User AstroFile",
     main = "rainbow-delimiters.setup",
     opts = {},
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { rainbow_delimiters = true } },
   },
 }

--- a/lua/astrocommunity/editing-support/telescope-undo-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/telescope-undo-nvim/init.lua
@@ -1,17 +1,23 @@
 return {
-  "nvim-telescope/telescope.nvim",
-  dependencies = {
-    "debugloop/telescope-undo.nvim",
+  "debugloop/telescope-undo.nvim",
+  lazy = true,
+  specs = {
     {
-      "AstroNvim/astrocore",
-      opts = {
-        mappings = {
-          n = {
-            ["<Leader>fu"] = { "<Cmd>Telescope undo<CR>", desc = "Find undos" },
+      "nvim-telescope/telescope.nvim",
+      dependencies = {
+        "debugloop/telescope-undo.nvim",
+        {
+          "AstroNvim/astrocore",
+          opts = {
+            mappings = {
+              n = {
+                ["<Leader>fu"] = { "<Cmd>Telescope undo<CR>", desc = "Find undos" },
+              },
+            },
           },
         },
       },
+      opts = function() require("telescope").load_extension "undo" end,
     },
   },
-  opts = function() require("telescope").load_extension "undo" end,
 }

--- a/lua/astrocommunity/editing-support/todo-comments-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/todo-comments-nvim/init.lua
@@ -1,8 +1,6 @@
 return {
-  {
-    "folke/todo-comments.nvim",
-    opts = {},
-    event = "User AstroFile",
-    cmd = { "TodoTrouble", "TodoTelescope", "TodoLocList", "TodoQuickFix" },
-  },
+  "folke/todo-comments.nvim",
+  opts = {},
+  event = "User AstroFile",
+  cmd = { "TodoTrouble", "TodoTelescope", "TodoLocList", "TodoQuickFix" },
 }

--- a/lua/astrocommunity/editing-support/ultimate-autopair-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/ultimate-autopair-nvim/init.lua
@@ -1,33 +1,27 @@
 return {
-  {
-    "windwp/nvim-autopairs",
-    enabled = false,
-  },
-  {
-    "altermo/ultimate-autopair.nvim",
-    event = "InsertEnter",
-    branch = "v0.6", --recommended as each new version will have breaking changes
-    opts = {
-      -- disable autopair in the command line: https://github.com/altermo/ultimate-autopair.nvim/issues/8
-      cmap = false,
-      extensions = {
+  "altermo/ultimate-autopair.nvim",
+  event = "InsertEnter",
+  branch = "v0.6", --recommended as each new version will have breaking changes
+  opts = {
+    -- disable autopair in the command line: https://github.com/altermo/ultimate-autopair.nvim/issues/8
+    cmap = false,
+    extensions = {
+      cond = {
+        -- disable in comments
+        -- https://github.com/altermo/ultimate-autopair.nvim/blob/6fd0d6aa976a97dd6f1bed4d46be1b437613a52f/Q%26A.md?plain=1#L26
         cond = {
-          -- disable in comments
-          -- https://github.com/altermo/ultimate-autopair.nvim/blob/6fd0d6aa976a97dd6f1bed4d46be1b437613a52f/Q%26A.md?plain=1#L26
-          cond = {
-            function(fn) return not fn.in_node "comment" end,
-          },
-        },
-        -- get fly mode working on strings:
-        -- https://github.com/altermo/ultimate-autopair.nvim/issues/33
-        fly = {
-          nofilter = true,
+          function(fn) return not fn.in_node "comment" end,
         },
       },
-      config_internal_pairs = {
-        { '"', '"', fly = true },
-        { "'", "'", fly = true },
+      -- get fly mode working on strings:
+      -- https://github.com/altermo/ultimate-autopair.nvim/issues/33
+      fly = {
+        nofilter = true,
       },
+    },
+    config_internal_pairs = {
+      { '"', '"', fly = true },
+      { "'", "'", fly = true },
     },
   },
   dependencies = {
@@ -54,6 +48,13 @@ return {
           },
         },
       },
+    },
+  },
+  specs = {
+    {
+      "windwp/nvim-autopairs",
+      optional = true,
+      enabled = false,
     },
   },
 }

--- a/lua/astrocommunity/file-explorer/mini-files/init.lua
+++ b/lua/astrocommunity/file-explorer/mini-files/init.lua
@@ -1,31 +1,31 @@
 return {
-  { "neo-tree.nvim", enabled = false },
-  {
-    "echasnovski/mini.files",
-    dependencies = {
-      "nvim-tree/nvim-web-devicons",
-      {
-        "AstroNvim/astrocore",
-        opts = {
-          mappings = {
-            n = {
-              ["<Leader>e"] = {
-                function()
-                  if not require("mini.files").close() then require("mini.files").open() end
-                end,
-                desc = "Explorer",
-              },
+  "echasnovski/mini.files",
+  dependencies = {
+    "nvim-tree/nvim-web-devicons",
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        mappings = {
+          n = {
+            ["<Leader>e"] = {
+              function()
+                if not require("mini.files").close() then require("mini.files").open() end
+              end,
+              desc = "Explorer",
             },
           },
         },
       },
     },
-    opts = {},
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  specs = {
+    { "neo-tree.nvim", optional = true, enabled = false },
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
+  opts = {},
 }

--- a/lua/astrocommunity/fuzzy-finder/fzf-lua/init.lua
+++ b/lua/astrocommunity/fuzzy-finder/fzf-lua/init.lua
@@ -1,67 +1,67 @@
 return {
-  { "nvim-telescope/telescope.nvim", enabled = false },
-  { "nvim-telescope/telescope-fzf-native.nvim", enabled = false },
-  { "stevearc/dressing.nvim", optional = true, opts = { select = { backend = { "fzf_lua" } } } },
-  {
-    "ibhagwan/fzf-lua",
-    cmd = "FzfLua",
-    dependencies = {
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
+  "ibhagwan/fzf-lua",
+  cmd = "FzfLua",
+  specs = {
+    { "nvim-telescope/telescope.nvim", optional = true, enabled = false },
+    { "nvim-telescope/telescope-fzf-native.nvim", optional = true, enabled = false },
+    { "stevearc/dressing.nvim", optional = true, opts = { select = { backend = { "fzf_lua" } } } },
+    {
+      "AstroNvim/astrolsp",
+      optional = true,
+      opts = function(_, opts)
+        if require("astrocore").is_available "fzf-lua" then
           local maps = opts.mappings
-          maps.n["<Leader>f"] = vim.tbl_get(opts, "_map_sections", "f")
-          if vim.fn.executable "git" == 1 then
-            maps.n["<Leader>g"] = vim.tbl_get(opts, "_map_sections", "g")
-            maps.n["<Leader>gb"] = { function() require("fzf-lua").git_branches() end, desc = "Git branches" }
-            maps.n["<Leader>gc"] =
-              { function() require("fzf-lua").git_commits() end, desc = "Git commits (repository)" }
-            maps.n["<Leader>gC"] =
-              { function() require("fzf-lua").git_bcommits() end, desc = "Git commits (current file)" }
-            maps.n["<Leader>gt"] = { function() require("fzf-lua").git_status() end, desc = "Git status" }
+          maps.n["<Leader>lD"] =
+            { function() require("fzf-lua").diagnostics_document() end, desc = "Search diagnostics" }
+          if maps.n.gd then maps.n.gd[1] = function() require("fzf-lua").lsp_definitions() end end
+          if maps.n.gI then maps.n.gI[1] = function() require("fzf-lua").lsp_implementations() end end
+          if maps.n["<Leader>lR"] then maps.n["<Leader>lR"][1] = function() require("fzf-lua").lsp_references() end end
+          if maps.n.gy then maps.n.gy[1] = function() require("fzf-lua").lsp_typedefs() end end
+          if maps.n["<Leader>lG"] then
+            maps.n["<Leader>lG"][1] = function() require("fzf-lua").lsp_workspace_symbols() end
           end
-          maps.n["<Leader>f<CR>"] = { function() require("fzf-lua").resume() end, desc = "Resume previous search" }
-          maps.n["<Leader>f'"] = { function() require("fzf-lua").marks() end, desc = "Find marks" }
-          maps.n["<Leader>f/"] =
-            { function() require("fzf-lua").lgrep_curbuf() end, desc = "Find words in current buffer" }
-          maps.n["<Leader>fa"] = {
-            function() require("fzf-lua").files { prompt = "Config> ", cwd = vim.fn.stdpath "config" } end,
-            desc = "Find AstroNvim config files",
-          }
-          maps.n["<Leader>fb"] = { function() require("fzf-lua").buffers() end, desc = "Find buffers" }
-          maps.n["<Leader>fc"] = { function() require("fzf-lua").grep_cword() end, desc = "Find word under cursor" }
-          maps.n["<Leader>fC"] = { function() require("fzf-lua").commands() end, desc = "Find commands" }
-          maps.n["<Leader>ff"] = { function() require("fzf-lua").files() end, desc = "Find files" }
-          maps.n["<Leader>fh"] = { function() require("fzf-lua").helptags() end, desc = "Find help" }
-          maps.n["<Leader>fk"] = { function() require("fzf-lua").keymaps() end, desc = "Find keymaps" }
-          maps.n["<Leader>fm"] = { function() require("fzf-lua").manpages() end, desc = "Find man" }
-          maps.n["<Leader>fo"] = { function() require("fzf-lua").oldfiles() end, desc = "Find history" }
-          maps.n["<Leader>fr"] = { function() require("fzf-lua").registers() end, desc = "Find registers" }
-          maps.n["<Leader>ft"] = { function() require("fzf-lua").colorschemes() end, desc = "Find themes" }
-          if vim.fn.executable "rg" == 1 or vim.fn.executable "grep" == 1 then
-            maps.n["<Leader>fw"] = { function() require("fzf-lua").live_grep_native() end, desc = "Find words" }
-          end
-          maps.n["<Leader>ls"] = { function() require("fzf-lua").lsp_document_symbols() end, desc = "Search symbols" }
-        end,
-      },
-    },
-    opts = { "default-title" },
-  },
-  {
-    "AstroNvim/astrolsp",
-    optional = true,
-    opts = function(_, opts)
-      if require("astrocore").is_available "fzf-lua" then
-        local maps = opts.mappings
-        maps.n["<Leader>lD"] = { function() require("fzf-lua").diagnostics_document() end, desc = "Search diagnostics" }
-        if maps.n.gd then maps.n.gd[1] = function() require("fzf-lua").lsp_definitions() end end
-        if maps.n.gI then maps.n.gI[1] = function() require("fzf-lua").lsp_implementations() end end
-        if maps.n["<Leader>lR"] then maps.n["<Leader>lR"][1] = function() require("fzf-lua").lsp_references() end end
-        if maps.n.gy then maps.n.gy[1] = function() require("fzf-lua").lsp_typedefs() end end
-        if maps.n["<Leader>lG"] then
-          maps.n["<Leader>lG"][1] = function() require("fzf-lua").lsp_workspace_symbols() end
         end
-      end
-    end,
+      end,
+    },
   },
+  dependencies = {
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        maps.n["<Leader>f"] = vim.tbl_get(opts, "_map_sections", "f")
+        if vim.fn.executable "git" == 1 then
+          maps.n["<Leader>g"] = vim.tbl_get(opts, "_map_sections", "g")
+          maps.n["<Leader>gb"] = { function() require("fzf-lua").git_branches() end, desc = "Git branches" }
+          maps.n["<Leader>gc"] = { function() require("fzf-lua").git_commits() end, desc = "Git commits (repository)" }
+          maps.n["<Leader>gC"] =
+            { function() require("fzf-lua").git_bcommits() end, desc = "Git commits (current file)" }
+          maps.n["<Leader>gt"] = { function() require("fzf-lua").git_status() end, desc = "Git status" }
+        end
+        maps.n["<Leader>f<CR>"] = { function() require("fzf-lua").resume() end, desc = "Resume previous search" }
+        maps.n["<Leader>f'"] = { function() require("fzf-lua").marks() end, desc = "Find marks" }
+        maps.n["<Leader>f/"] =
+          { function() require("fzf-lua").lgrep_curbuf() end, desc = "Find words in current buffer" }
+        maps.n["<Leader>fa"] = {
+          function() require("fzf-lua").files { prompt = "Config> ", cwd = vim.fn.stdpath "config" } end,
+          desc = "Find AstroNvim config files",
+        }
+        maps.n["<Leader>fb"] = { function() require("fzf-lua").buffers() end, desc = "Find buffers" }
+        maps.n["<Leader>fc"] = { function() require("fzf-lua").grep_cword() end, desc = "Find word under cursor" }
+        maps.n["<Leader>fC"] = { function() require("fzf-lua").commands() end, desc = "Find commands" }
+        maps.n["<Leader>ff"] = { function() require("fzf-lua").files() end, desc = "Find files" }
+        maps.n["<Leader>fh"] = { function() require("fzf-lua").helptags() end, desc = "Find help" }
+        maps.n["<Leader>fk"] = { function() require("fzf-lua").keymaps() end, desc = "Find keymaps" }
+        maps.n["<Leader>fm"] = { function() require("fzf-lua").manpages() end, desc = "Find man" }
+        maps.n["<Leader>fo"] = { function() require("fzf-lua").oldfiles() end, desc = "Find history" }
+        maps.n["<Leader>fr"] = { function() require("fzf-lua").registers() end, desc = "Find registers" }
+        maps.n["<Leader>ft"] = { function() require("fzf-lua").colorschemes() end, desc = "Find themes" }
+        if vim.fn.executable "rg" == 1 or vim.fn.executable "grep" == 1 then
+          maps.n["<Leader>fw"] = { function() require("fzf-lua").live_grep_native() end, desc = "Find words" }
+        end
+        maps.n["<Leader>ls"] = { function() require("fzf-lua").lsp_document_symbols() end, desc = "Search symbols" }
+      end,
+    },
+  },
+  opts = { "default-title" },
 }

--- a/lua/astrocommunity/fuzzy-finder/telescope-zoxide/init.lua
+++ b/lua/astrocommunity/fuzzy-finder/telescope-zoxide/init.lua
@@ -1,17 +1,23 @@
 return {
-  "nvim-telescope/telescope.nvim",
-  dependencies = {
-    "jvgrootveld/telescope-zoxide",
+  "jvgrootveld/telescope-zoxide",
+  lazy = true,
+  specs = {
     {
-      "AstroNvim/astrocore",
-      opts = {
-        mappings = {
-          n = {
-            ["<Leader>fz"] = { "<Cmd>Telescope zoxide list<CR>", desc = "Find directories" },
+      "nvim-telescope/telescope.nvim",
+      dependencies = {
+        "jvgrootveld/telescope-zoxide",
+        {
+          "AstroNvim/astrocore",
+          opts = {
+            mappings = {
+              n = {
+                ["<Leader>fz"] = { "<Cmd>Telescope zoxide list<CR>", desc = "Find directories" },
+              },
+            },
           },
         },
       },
+      opts = function() require("telescope").load_extension "zoxide" end,
     },
   },
-  opts = function() require("telescope").load_extension "zoxide" end,
 }

--- a/lua/astrocommunity/git/diffview-nvim/init.lua
+++ b/lua/astrocommunity/git/diffview-nvim/init.lua
@@ -1,20 +1,20 @@
 return {
-  {
-    "sindrets/diffview.nvim",
-    event = "User AstroGitFile",
-    cmd = { "DiffviewOpen" },
-    opts = {
-      enhanced_diff_hl = true,
-      view = {
-        default = { winbar_info = true },
-        file_history = { winbar_info = true },
-      },
-      hooks = { diff_buf_read = function(bufnr) vim.b[bufnr].view_activated = false end },
+  "sindrets/diffview.nvim",
+  event = "User AstroGitFile",
+  cmd = { "DiffviewOpen" },
+  opts = {
+    enhanced_diff_hl = true,
+    view = {
+      default = { winbar_info = true },
+      file_history = { winbar_info = true },
     },
+    hooks = { diff_buf_read = function(bufnr) vim.b[bufnr].view_activated = false end },
   },
-  {
-    "NeogitOrg/neogit",
-    optional = true,
-    opts = { integrations = { diffview = true } },
+  specs = {
+    {
+      "NeogitOrg/neogit",
+      optional = true,
+      opts = { integrations = { diffview = true } },
+    },
   },
 }

--- a/lua/astrocommunity/git/fugit2-nvim/init.lua
+++ b/lua/astrocommunity/git/fugit2-nvim/init.lua
@@ -1,20 +1,20 @@
 return {
-  { import = "astrocommunity.git.diffview-nvim" }, -- optional dependency
-  { import = "astrocommunity.git.nvim-tinygit" }, -- optional dependency
-  {
-    "SuperBo/fugit2.nvim",
-    cmd = { "Fugit2", "Fugit2Graph" },
-    dependencies = {
-      "MunifTanjim/nui.nvim",
-      "nvim-tree/nvim-web-devicons",
-      "nvim-lua/plenary.nvim",
-      {
-        "AstroNvim/astrocore",
-        opts = { mappings = { n = {
-          ["<Leader>gF"] = { "<Cmd>Fugit2<CR>", desc = "Fugit2" },
-        } } },
-      },
-    },
-    opts = {},
+  "SuperBo/fugit2.nvim",
+  cmd = { "Fugit2", "Fugit2Graph" },
+  specs = {
+    { import = "astrocommunity.git.diffview-nvim" }, -- optional dependency
+    { import = "astrocommunity.git.nvim-tinygit" }, -- optional dependency
   },
+  dependencies = {
+    "MunifTanjim/nui.nvim",
+    "nvim-tree/nvim-web-devicons",
+    "nvim-lua/plenary.nvim",
+    {
+      "AstroNvim/astrocore",
+      opts = { mappings = { n = {
+        ["<Leader>gF"] = { "<Cmd>Fugit2<CR>", desc = "Fugit2" },
+      } } },
+    },
+  },
+  opts = {},
 }

--- a/lua/astrocommunity/git/gitlinker-nvim/init.lua
+++ b/lua/astrocommunity/git/gitlinker-nvim/init.lua
@@ -1,17 +1,15 @@
 return {
-  {
-    "linrongbin16/gitlinker.nvim",
-    event = "BufRead",
-    dependencies = {
-      "AstroNvim/astrocore",
-      opts = function(_, opts)
-        local prefix = "<Leader>g"
-        opts.mappings.n[prefix .. "y"] = { "<Cmd>GitLink<CR>", desc = "Git link copy" }
-        opts.mappings.n[prefix .. "z"] = { "<Cmd>GitLink!<CR>", desc = "Git link open" }
-        opts.mappings.v[prefix .. "y"] = { "<Cmd>GitLink<CR>", desc = "Git link copy" }
-        opts.mappings.v[prefix .. "z"] = { "<Cmd>GitLink!<CR>", desc = "Git link open" }
-      end,
-    },
-    opts = {},
+  "linrongbin16/gitlinker.nvim",
+  event = "BufRead",
+  dependencies = {
+    "AstroNvim/astrocore",
+    opts = function(_, opts)
+      local prefix = "<Leader>g"
+      opts.mappings.n[prefix .. "y"] = { "<Cmd>GitLink<CR>", desc = "Git link copy" }
+      opts.mappings.n[prefix .. "z"] = { "<Cmd>GitLink!<CR>", desc = "Git link open" }
+      opts.mappings.v[prefix .. "y"] = { "<Cmd>GitLink<CR>", desc = "Git link copy" }
+      opts.mappings.v[prefix .. "z"] = { "<Cmd>GitLink!<CR>", desc = "Git link open" }
+    end,
   },
+  opts = {},
 }

--- a/lua/astrocommunity/git/neogit/init.lua
+++ b/lua/astrocommunity/git/neogit/init.lua
@@ -1,44 +1,44 @@
 return {
-  {
-    "NeogitOrg/neogit",
-    cmd = "Neogit",
-    dependencies = {
-      "nvim-lua/plenary.nvim",
-      { "AstroNvim/astroui", opts = { icons = { Neogit = "󰰔" } } },
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local maps = opts.mappings
-          local prefix = "<Leader>g"
-          maps.n[prefix .. "n"] = { desc = require("astroui").get_icon("Neogit", 1, true) .. "Neogit" }
-          maps.n[prefix .. "nt"] = { "<Cmd>Neogit<CR>", desc = "Open Neogit Tab Page" }
-          maps.n[prefix .. "nc"] = { "<Cmd>Neogit commit<CR>", desc = "Open Neogit Commit Page" }
-          maps.n[prefix .. "nd"] = { ":Neogit cwd=", desc = "Open Neogit Override CWD" }
-          maps.n[prefix .. "nk"] = { ":Neogit kind=", desc = "Open Neogit Override Kind" }
-        end,
-      },
+  "NeogitOrg/neogit",
+  cmd = "Neogit",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    { "AstroNvim/astroui", opts = { icons = { Neogit = "󰰔" } } },
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        local prefix = "<Leader>g"
+        maps.n[prefix .. "n"] = { desc = require("astroui").get_icon("Neogit", 1, true) .. "Neogit" }
+        maps.n[prefix .. "nt"] = { "<Cmd>Neogit<CR>", desc = "Open Neogit Tab Page" }
+        maps.n[prefix .. "nc"] = { "<Cmd>Neogit commit<CR>", desc = "Open Neogit Commit Page" }
+        maps.n[prefix .. "nd"] = { ":Neogit cwd=", desc = "Open Neogit Override CWD" }
+        maps.n[prefix .. "nk"] = { ":Neogit kind=", desc = "Open Neogit Override Kind" }
+      end,
     },
-    event = "User AstroGitFile",
-    opts = function(_, opts)
-      local utils = require "astrocore"
-      local disable_builtin_notifications = utils.is_available "nvim-notify" or utils.is_available "noice.nvim"
+  },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { neogit = true } },
+    },
+  },
+  event = "User AstroGitFile",
+  opts = function(_, opts)
+    local utils = require "astrocore"
+    local disable_builtin_notifications = utils.is_available "nvim-notify" or utils.is_available "noice.nvim"
 
-      return utils.extend_tbl(opts, {
-        disable_builtin_notifications = disable_builtin_notifications,
-        disable_signs = true,
-        telescope_sorter = function()
-          if utils.is_available "telescope-fzf-native.nvim" then
-            return require("telescope").extensions.fzf.native_fzf_sorter()
-          end
-        end,
-        integrations = { telescope = utils.is_available "telescope.nvim" },
-      })
-    end,
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { neogit = true } },
-  },
+    return utils.extend_tbl(opts, {
+      disable_builtin_notifications = disable_builtin_notifications,
+      disable_signs = true,
+      telescope_sorter = function()
+        if utils.is_available "telescope-fzf-native.nvim" then
+          return require("telescope").extensions.fzf.native_fzf_sorter()
+        end
+      end,
+      integrations = { telescope = utils.is_available "telescope.nvim" },
+    })
+  end,
 }

--- a/lua/astrocommunity/git/octo-nvim/init.lua
+++ b/lua/astrocommunity/git/octo-nvim/init.lua
@@ -1,89 +1,89 @@
 return {
-  {
-    "pwntester/octo.nvim",
-    dependencies = {
-      "nvim-lua/plenary.nvim",
-      "nvim-telescope/telescope.nvim",
-      "nvim-tree/nvim-web-devicons",
-      { "AstroNvim/astroui", opts = { icons = { Octo = "" } } },
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local maps = opts.mappings
-          local prefix = "<Leader>O"
-          maps.n[prefix] = { desc = require("astroui").get_icon("Octo", 1, true) .. "Octo" }
-          maps.n[prefix .. "a"] = { desc = "Assignee/Reviewer" }
-          maps.n[prefix .. "aa"] = { "<Cmd>Octo assignee add<CR>", desc = "Assign a user" }
-          maps.n[prefix .. "ap"] = { "<Cmd>Octo reviewer add<CR>", desc = "Assign a PR reviewer" }
-          maps.n[prefix .. "ar"] = { "<Cmd>Octo assignee remove<CR>", desc = "Remove a user" }
-          maps.n[prefix .. "c"] = { desc = "Comments" }
-          maps.n[prefix .. "ca"] = { "<Cmd>Octo comment add<CR>", desc = "Add a new comment" }
-          maps.n[prefix .. "cd"] = { "<Cmd>Octo comment delete<CR>", desc = "Delete a comment" }
-          maps.n[prefix .. "e"] = { desc = "Reaction" }
-          maps.n[prefix .. "e1"] = { "<Cmd>Octo reaction thumbs_up<CR>", desc = "Add 👍 reaction" }
-          maps.n[prefix .. "e2"] = { "<Cmd>Octo reaction thumbs_down<CR>", desc = "Add 👎 reaction" }
-          maps.n[prefix .. "e3"] = { "<Cmd>Octo reaction eyes<CR>", desc = "Add 👀 reaction" }
-          maps.n[prefix .. "e4"] = { "<Cmd>Octo reaction laugh<CR>", desc = "Add 😄 reaction" }
-          maps.n[prefix .. "e5"] = { "<Cmd>Octo reaction confused<CR>", desc = "Add 😕 reaction" }
-          maps.n[prefix .. "e6"] = { "<Cmd>Octo reaction rocket<CR>", desc = "Add 🚀 reaction" }
-          maps.n[prefix .. "e7"] = { "<Cmd>Octo reaction heart<CR>", desc = "Add ❤️ reaction" }
-          maps.n[prefix .. "e8"] = { "<Cmd>Octo reaction party<CR>", desc = "Add 🎉 reaction" }
-          maps.n[prefix .. "i"] = { desc = "Issues" }
-          maps.n[prefix .. "ic"] = { "<Cmd>Octo issue close<CR>", desc = "Close current issue" }
-          maps.n[prefix .. "il"] = { "<Cmd>Octo issue list<CR>", desc = "List open issues" }
-          maps.n[prefix .. "io"] = { "<Cmd>Octo issue browser<CR>", desc = "Open current issue in browser" }
-          maps.n[prefix .. "ir"] = { "<Cmd>Octo issue reopen<CR>", desc = "Reopen current issue" }
-          maps.n[prefix .. "iu"] = { "<Cmd>Octo issue url<CR>", desc = "Copies URL of current issue" }
-          maps.n[prefix .. "l"] = { desc = "Label" }
-          maps.n[prefix .. "la"] = { "<Cmd>Octo label add<CR>", desc = "Assign a label" }
-          maps.n[prefix .. "lc"] = { "<Cmd>Octo label create<CR>", desc = "Create a label" }
-          maps.n[prefix .. "lr"] = { "<Cmd>Octo label remove<CR>", desc = "Remove a label" }
-          maps.n[prefix .. "p"] = { desc = "Pull requests" }
-          maps.n[prefix .. "pc"] = { "<Cmd>Octo pr close<CR>", desc = "Close current PR" }
-          maps.n[prefix .. "pd"] = { "<Cmd>Octo pr diff<CR>", desc = "Show PR diff" }
-          maps.n[prefix .. "pl"] = { "<Cmd>Octo pr commits<CR>", desc = "List changed files in PR" }
-          maps.n[prefix .. "pm"] = { desc = "Merge current PR" }
-          maps.n[prefix .. "pmd"] = { "<Cmd>Octo pr merge delete<CR>", desc = "Delete merge PR" }
-          maps.n[prefix .. "pmm"] = { "<Cmd>Octo pr merge commit<CR>", desc = "Merge commit PR" }
-          maps.n[prefix .. "pmr"] = { "<Cmd>Octo pr merge rebase<CR>", desc = "Rebase merge PR" }
-          maps.n[prefix .. "pms"] = { "<Cmd>Octo pr merge squash<CR>", desc = "Squash merge PR" }
-          maps.n[prefix .. "pn"] = { "<Cmd>Octo pr create<CR>", desc = "Create PR for current branch" }
-          maps.n[prefix .. "po"] = { "<Cmd>Octo pr browser<CR>", desc = "Open current PR in browser" }
-          maps.n[prefix .. "pp"] = { "<Cmd>Octo pr checkout<CR>", desc = "Checkout PR" }
-          maps.n[prefix .. "pr"] = { "<Cmd>Octo pr ready<CR>", desc = "Mark draft as ready for review" }
-          maps.n[prefix .. "ps"] = { "<Cmd>Octo pr list<CR>", desc = "List open PRs" }
-          maps.n[prefix .. "pt"] = { "<Cmd>Octo pr commits<CR>", desc = "List PR commits" }
-          maps.n[prefix .. "pu"] = { "<Cmd>Octo pr url<CR>", desc = "Copies URL of current PR" }
-          maps.n[prefix .. "r"] = { desc = "Repo" }
-          maps.n[prefix .. "rf"] = { "<Cmd>Octo repo fork<CR>", desc = "Fork repo" }
-          maps.n[prefix .. "rl"] = { "<Cmd>Octo repo list<CR>", desc = "List repo user stats" }
-          maps.n[prefix .. "ro"] = { "<Cmd>Octo repo open<CR>", desc = "Open current repo in browser" }
-          maps.n[prefix .. "ru"] = { "<Cmd>Octo repo url<CR>", desc = "Copies URL of current repo" }
-          maps.n[prefix .. "s"] = { desc = "Review" }
-          maps.n[prefix .. "sc"] = { "<Cmd>Octo review close<CR>", desc = "Return to PR" }
-          maps.n[prefix .. "sc"] = { "<Cmd>Octo review comments<CR>", desc = "View pending comments" }
-          maps.n[prefix .. "sd"] = { "<Cmd>Octo review discard<CR>", desc = "Delete pending review" }
-          maps.n[prefix .. "sf"] = { "<Cmd>Octo review submit<CR>", desc = "Submit review" }
-          maps.n[prefix .. "sp"] = { "<Cmd>Octo review commit<CR>", desc = "Select commit to review" }
-          maps.n[prefix .. "sr"] = { "<Cmd>Octo review resume<CR>", desc = "Resume review" }
-          maps.n[prefix .. "ss"] = { "<Cmd>Octo review start<CR>", desc = "Start review" }
-          maps.n[prefix .. "t"] = { desc = "Threads" }
-          maps.n[prefix .. "ta"] = { "<Cmd>Octo thread resolve<CR>", desc = "Mark thread as resolved" }
-          maps.n[prefix .. "td"] = { "<Cmd>Octo thread unresolve<CR>", desc = "Mark thread as unresolved" }
-          maps.n[prefix .. "x"] = { "<Cmd>Octo actions<CR>", desc = "Run an action" }
-        end,
-      },
-    },
-    cmd = { "Octo" },
-    opts = {
-      use_diagnostic_signs = true,
-      mappings = {},
+  "pwntester/octo.nvim",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "nvim-telescope/telescope.nvim",
+    "nvim-tree/nvim-web-devicons",
+    { "AstroNvim/astroui", opts = { icons = { Octo = "" } } },
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        local prefix = "<Leader>O"
+        maps.n[prefix] = { desc = require("astroui").get_icon("Octo", 1, true) .. "Octo" }
+        maps.n[prefix .. "a"] = { desc = "Assignee/Reviewer" }
+        maps.n[prefix .. "aa"] = { "<Cmd>Octo assignee add<CR>", desc = "Assign a user" }
+        maps.n[prefix .. "ap"] = { "<Cmd>Octo reviewer add<CR>", desc = "Assign a PR reviewer" }
+        maps.n[prefix .. "ar"] = { "<Cmd>Octo assignee remove<CR>", desc = "Remove a user" }
+        maps.n[prefix .. "c"] = { desc = "Comments" }
+        maps.n[prefix .. "ca"] = { "<Cmd>Octo comment add<CR>", desc = "Add a new comment" }
+        maps.n[prefix .. "cd"] = { "<Cmd>Octo comment delete<CR>", desc = "Delete a comment" }
+        maps.n[prefix .. "e"] = { desc = "Reaction" }
+        maps.n[prefix .. "e1"] = { "<Cmd>Octo reaction thumbs_up<CR>", desc = "Add 👍 reaction" }
+        maps.n[prefix .. "e2"] = { "<Cmd>Octo reaction thumbs_down<CR>", desc = "Add 👎 reaction" }
+        maps.n[prefix .. "e3"] = { "<Cmd>Octo reaction eyes<CR>", desc = "Add 👀 reaction" }
+        maps.n[prefix .. "e4"] = { "<Cmd>Octo reaction laugh<CR>", desc = "Add 😄 reaction" }
+        maps.n[prefix .. "e5"] = { "<Cmd>Octo reaction confused<CR>", desc = "Add 😕 reaction" }
+        maps.n[prefix .. "e6"] = { "<Cmd>Octo reaction rocket<CR>", desc = "Add 🚀 reaction" }
+        maps.n[prefix .. "e7"] = { "<Cmd>Octo reaction heart<CR>", desc = "Add ❤️ reaction" }
+        maps.n[prefix .. "e8"] = { "<Cmd>Octo reaction party<CR>", desc = "Add 🎉 reaction" }
+        maps.n[prefix .. "i"] = { desc = "Issues" }
+        maps.n[prefix .. "ic"] = { "<Cmd>Octo issue close<CR>", desc = "Close current issue" }
+        maps.n[prefix .. "il"] = { "<Cmd>Octo issue list<CR>", desc = "List open issues" }
+        maps.n[prefix .. "io"] = { "<Cmd>Octo issue browser<CR>", desc = "Open current issue in browser" }
+        maps.n[prefix .. "ir"] = { "<Cmd>Octo issue reopen<CR>", desc = "Reopen current issue" }
+        maps.n[prefix .. "iu"] = { "<Cmd>Octo issue url<CR>", desc = "Copies URL of current issue" }
+        maps.n[prefix .. "l"] = { desc = "Label" }
+        maps.n[prefix .. "la"] = { "<Cmd>Octo label add<CR>", desc = "Assign a label" }
+        maps.n[prefix .. "lc"] = { "<Cmd>Octo label create<CR>", desc = "Create a label" }
+        maps.n[prefix .. "lr"] = { "<Cmd>Octo label remove<CR>", desc = "Remove a label" }
+        maps.n[prefix .. "p"] = { desc = "Pull requests" }
+        maps.n[prefix .. "pc"] = { "<Cmd>Octo pr close<CR>", desc = "Close current PR" }
+        maps.n[prefix .. "pd"] = { "<Cmd>Octo pr diff<CR>", desc = "Show PR diff" }
+        maps.n[prefix .. "pl"] = { "<Cmd>Octo pr commits<CR>", desc = "List changed files in PR" }
+        maps.n[prefix .. "pm"] = { desc = "Merge current PR" }
+        maps.n[prefix .. "pmd"] = { "<Cmd>Octo pr merge delete<CR>", desc = "Delete merge PR" }
+        maps.n[prefix .. "pmm"] = { "<Cmd>Octo pr merge commit<CR>", desc = "Merge commit PR" }
+        maps.n[prefix .. "pmr"] = { "<Cmd>Octo pr merge rebase<CR>", desc = "Rebase merge PR" }
+        maps.n[prefix .. "pms"] = { "<Cmd>Octo pr merge squash<CR>", desc = "Squash merge PR" }
+        maps.n[prefix .. "pn"] = { "<Cmd>Octo pr create<CR>", desc = "Create PR for current branch" }
+        maps.n[prefix .. "po"] = { "<Cmd>Octo pr browser<CR>", desc = "Open current PR in browser" }
+        maps.n[prefix .. "pp"] = { "<Cmd>Octo pr checkout<CR>", desc = "Checkout PR" }
+        maps.n[prefix .. "pr"] = { "<Cmd>Octo pr ready<CR>", desc = "Mark draft as ready for review" }
+        maps.n[prefix .. "ps"] = { "<Cmd>Octo pr list<CR>", desc = "List open PRs" }
+        maps.n[prefix .. "pt"] = { "<Cmd>Octo pr commits<CR>", desc = "List PR commits" }
+        maps.n[prefix .. "pu"] = { "<Cmd>Octo pr url<CR>", desc = "Copies URL of current PR" }
+        maps.n[prefix .. "r"] = { desc = "Repo" }
+        maps.n[prefix .. "rf"] = { "<Cmd>Octo repo fork<CR>", desc = "Fork repo" }
+        maps.n[prefix .. "rl"] = { "<Cmd>Octo repo list<CR>", desc = "List repo user stats" }
+        maps.n[prefix .. "ro"] = { "<Cmd>Octo repo open<CR>", desc = "Open current repo in browser" }
+        maps.n[prefix .. "ru"] = { "<Cmd>Octo repo url<CR>", desc = "Copies URL of current repo" }
+        maps.n[prefix .. "s"] = { desc = "Review" }
+        maps.n[prefix .. "sc"] = { "<Cmd>Octo review close<CR>", desc = "Return to PR" }
+        maps.n[prefix .. "sc"] = { "<Cmd>Octo review comments<CR>", desc = "View pending comments" }
+        maps.n[prefix .. "sd"] = { "<Cmd>Octo review discard<CR>", desc = "Delete pending review" }
+        maps.n[prefix .. "sf"] = { "<Cmd>Octo review submit<CR>", desc = "Submit review" }
+        maps.n[prefix .. "sp"] = { "<Cmd>Octo review commit<CR>", desc = "Select commit to review" }
+        maps.n[prefix .. "sr"] = { "<Cmd>Octo review resume<CR>", desc = "Resume review" }
+        maps.n[prefix .. "ss"] = { "<Cmd>Octo review start<CR>", desc = "Start review" }
+        maps.n[prefix .. "t"] = { desc = "Threads" }
+        maps.n[prefix .. "ta"] = { "<Cmd>Octo thread resolve<CR>", desc = "Mark thread as resolved" }
+        maps.n[prefix .. "td"] = { "<Cmd>Octo thread unresolve<CR>", desc = "Mark thread as unresolved" }
+        maps.n[prefix .. "x"] = { "<Cmd>Octo actions<CR>", desc = "Run an action" }
+      end,
     },
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { octo = true } },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { octo = true } },
+    },
+  },
+  cmd = { "Octo" },
+  opts = {
+    use_diagnostic_signs = true,
+    mappings = {},
   },
 }

--- a/lua/astrocommunity/indent/mini-indentscope/init.lua
+++ b/lua/astrocommunity/indent/mini-indentscope/init.lua
@@ -22,67 +22,67 @@ local ignore_buftypes = {
 local char = "▏"
 
 return {
-  {
-    "echasnovski/mini.indentscope",
-    event = "User AstroFile",
-    opts = function()
-      return {
-        options = { try_as_border = true },
-        symbol = require("astrocore").plugin_opts("indent-blankline.nvim").context_char or char,
-      }
-    end,
-    dependencies = {
-      { "lukas-reineke/indent-blankline.nvim", optional = true, opts = { scope = { enabled = false } } },
-      {
-        "AstroNvim/astrocore",
-        opts = {
-          autocmds = {
-            mini_indentscope = {
-              {
-                event = "FileType",
-                desc = "Disable indentscope for certain filetypes",
-                callback = function(event)
-                  if vim.b[event.buf].miniindentscope_disable == nil then
-                    local filetype = vim.bo[event.buf].filetype
-                    local blankline_opts = require("astrocore").plugin_opts "indent-blankline.nvim"
-                    if vim.tbl_contains(blankline_opts.filetype_exclude or ignore_filetypes, filetype) then
-                      vim.b[event.buf].miniindentscope_disable = true
-                    end
-                  end
-                end,
-              },
-              {
-                event = "BufWinEnter",
-                desc = "Disable indentscope for certain buftypes",
-                callback = function(event)
-                  if vim.b[event.buf].miniindentscope_disable == nil then
-                    local buftype = vim.bo[event.buf].buftype
-                    local blankline_opts = require("astrocore").plugin_opts "indent-blankline.nvim"
-                    if vim.tbl_contains(blankline_opts.buftype_exclude or ignore_buftypes, buftype) then
-                      vim.b[event.buf].miniindentscope_disable = true
-                    end
-                  end
-                end,
-              },
-              {
-                event = "TermOpen",
-                desc = "Disable indentscope for terminals",
-                callback = function(event)
-                  if vim.b[event.buf].miniindentscope_disable == nil then
+  "echasnovski/mini.indentscope",
+  event = "User AstroFile",
+  opts = function()
+    return {
+      options = { try_as_border = true },
+      symbol = require("astrocore").plugin_opts("indent-blankline.nvim").context_char or char,
+    }
+  end,
+  dependencies = {
+    { "lukas-reineke/indent-blankline.nvim", optional = true, opts = { scope = { enabled = false } } },
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        autocmds = {
+          mini_indentscope = {
+            {
+              event = "FileType",
+              desc = "Disable indentscope for certain filetypes",
+              callback = function(event)
+                if vim.b[event.buf].miniindentscope_disable == nil then
+                  local filetype = vim.bo[event.buf].filetype
+                  local blankline_opts = require("astrocore").plugin_opts "indent-blankline.nvim"
+                  if vim.tbl_contains(blankline_opts.filetype_exclude or ignore_filetypes, filetype) then
                     vim.b[event.buf].miniindentscope_disable = true
                   end
-                end,
-              },
+                end
+              end,
+            },
+            {
+              event = "BufWinEnter",
+              desc = "Disable indentscope for certain buftypes",
+              callback = function(event)
+                if vim.b[event.buf].miniindentscope_disable == nil then
+                  local buftype = vim.bo[event.buf].buftype
+                  local blankline_opts = require("astrocore").plugin_opts "indent-blankline.nvim"
+                  if vim.tbl_contains(blankline_opts.buftype_exclude or ignore_buftypes, buftype) then
+                    vim.b[event.buf].miniindentscope_disable = true
+                  end
+                end
+              end,
+            },
+            {
+              event = "TermOpen",
+              desc = "Disable indentscope for terminals",
+              callback = function(event)
+                if vim.b[event.buf].miniindentscope_disable == nil then
+                  vim.b[event.buf].miniindentscope_disable = true
+                end
+              end,
             },
           },
         },
       },
     },
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/keybinding/mini-clue/init.lua
+++ b/lua/astrocommunity/keybinding/mini-clue/init.lua
@@ -1,72 +1,72 @@
 return {
-  { "folke/which-key.nvim", enabled = false },
-  {
-    "echasnovski/mini.clue",
-    dependencies = { "AstroNvim/astrocore" },
-    keys = function()
-      require("lazy").load { plugins = { "astrocore" } } -- load astrocore before loading opts
-      local plugin = require("lazy.core.config").spec.plugins["mini.clue"]
-      local opts = require("lazy.core.plugin").values(plugin, "opts", false) -- resolve mini.clue options
-      return vim.tbl_map(function(trigger) return { trigger.keys, mode = trigger.mode } end, opts.triggers or {})
-    end,
-    opts = function()
-      local miniclue = require "mini.clue"
-      local astrocore_clues = {}
-      for mode, maps in pairs(require("astrocore").which_key_queue or {}) do
-        for keys, map in pairs(maps) do
-          if type(map) == "table" then
-            local desc = map.name or map.desc
-            if desc then table.insert(astrocore_clues, { mode = mode, keys = keys, desc = desc }) end
-          end
+  "echasnovski/mini.clue",
+  dependencies = { "AstroNvim/astrocore" },
+  specs = {
+    { "folke/which-key.nvim", optional = true, enabled = false },
+  },
+  keys = function()
+    require("lazy").load { plugins = { "astrocore" } } -- load astrocore before loading opts
+    local plugin = require("lazy.core.config").spec.plugins["mini.clue"]
+    local opts = require("lazy.core.plugin").values(plugin, "opts", false) -- resolve mini.clue options
+    return vim.tbl_map(function(trigger) return { trigger.keys, mode = trigger.mode } end, opts.triggers or {})
+  end,
+  opts = function()
+    local miniclue = require "mini.clue"
+    local astrocore_clues = {}
+    for mode, maps in pairs(require("astrocore").which_key_queue or {}) do
+      for keys, map in pairs(maps) do
+        if type(map) == "table" then
+          local desc = map.name or map.desc
+          if desc then table.insert(astrocore_clues, { mode = mode, keys = keys, desc = desc }) end
         end
       end
-      return {
-        window = { config = { row = "auto", col = "auto" } },
-        triggers = {
-          -- Leader triggers
-          { mode = "n", keys = "<Leader>" },
-          { mode = "x", keys = "<Leader>" },
+    end
+    return {
+      window = { config = { row = "auto", col = "auto" } },
+      triggers = {
+        -- Leader triggers
+        { mode = "n", keys = "<Leader>" },
+        { mode = "x", keys = "<Leader>" },
 
-          -- Built-in completion
-          { mode = "i", keys = "<C-x>" },
+        -- Built-in completion
+        { mode = "i", keys = "<C-x>" },
 
-          -- `g` key
-          { mode = "n", keys = "g" },
-          { mode = "x", keys = "g" },
+        -- `g` key
+        { mode = "n", keys = "g" },
+        { mode = "x", keys = "g" },
 
-          -- Marks
-          { mode = "n", keys = "'" },
-          { mode = "n", keys = "`" },
-          { mode = "x", keys = "'" },
-          { mode = "x", keys = "`" },
+        -- Marks
+        { mode = "n", keys = "'" },
+        { mode = "n", keys = "`" },
+        { mode = "x", keys = "'" },
+        { mode = "x", keys = "`" },
 
-          -- Registers
-          { mode = "n", keys = '"' },
-          { mode = "x", keys = '"' },
-          { mode = "i", keys = "<C-r>" },
-          { mode = "c", keys = "<C-r>" },
+        -- Registers
+        { mode = "n", keys = '"' },
+        { mode = "x", keys = '"' },
+        { mode = "i", keys = "<C-r>" },
+        { mode = "c", keys = "<C-r>" },
 
-          -- Window commands
-          { mode = "n", keys = "<C-w>" },
+        -- Window commands
+        { mode = "n", keys = "<C-w>" },
 
-          -- `z` key
-          { mode = "n", keys = "z" },
-          { mode = "x", keys = "z" },
+        -- `z` key
+        { mode = "n", keys = "z" },
+        { mode = "x", keys = "z" },
+      },
+      clues = {
+        astrocore_clues,
+        miniclue.gen_clues.builtin_completion(),
+        miniclue.gen_clues.g(),
+        miniclue.gen_clues.marks(),
+        miniclue.gen_clues.registers(),
+        miniclue.gen_clues.windows {
+          submode_move = true,
+          submode_navigate = true,
+          submode_resize = true,
         },
-        clues = {
-          astrocore_clues,
-          miniclue.gen_clues.builtin_completion(),
-          miniclue.gen_clues.g(),
-          miniclue.gen_clues.marks(),
-          miniclue.gen_clues.registers(),
-          miniclue.gen_clues.windows {
-            submode_move = true,
-            submode_navigate = true,
-            submode_resize = true,
-          },
-          miniclue.gen_clues.z(),
-        },
-      }
-    end,
-  },
+        miniclue.gen_clues.z(),
+      },
+    }
+  end,
 }

--- a/lua/astrocommunity/lsp/coc-nvim/init.lua
+++ b/lua/astrocommunity/lsp/coc-nvim/init.lua
@@ -1,165 +1,166 @@
 return {
-  {
-    "neoclide/coc.nvim",
-    branch = "release",
-    cmd = {
-      "CocCommand",
-      "CocConfig",
-      "CocDiagnostics",
-      "CocDisable",
-      "CocEnable",
-      "CocInfo",
-      "CocInstall",
-      "CocList",
-      "CocLocalConfig",
-      "CocOpenLog",
-      "CocOutline",
-      "CocPrintErrors",
-      "CocRestart",
-      "CocSearch",
-      "CocStart",
-      "CocUninstall",
-      "CocUpdate",
-      "CocUpdateSync",
-      "CocWatch",
-    },
-    event = { "User AstroFile", "InsertEnter" },
-    dependencies = {
-      "AstroNvim/astrocore",
-      ---@param opts AstroCoreOpts
-      opts = function(_, opts)
-        if not opts.options then opts.options = {} end
-        if not opts.options.g then opts.options.g = {} end
-        if not opts.options.opt then opts.options.opt = {} end
-        opts.options.opt.cmdheight = 1
-        opts.options.g.coc_global_extensions = {
-          "coc-json",
-          "coc-marketplace",
-        }
-
-        if not opts.commands then opts.commands = {} end
-        opts.commands.Format = { function() vim.fn.CocAction "format" end, desc = "Format file with LSP" }
-        if not opts.mappings then opts.mappings = require("astrocore").empty_map_table() end
-        local maps = assert(opts.mappings)
-        maps.n["[d"] = { "<Plug>(coc-diagnostic-prev)", desc = "Previous diagnostic" }
-        maps.n["]d"] = { "<Plug>(coc-diagnostic-next)", desc = "Next diagnostic" }
-        maps.n["gD"] = { "<Plug>(coc-declaration)", desc = "Show the declaration of current symbol" }
-        maps.n["gI"] = { "<Plug>(coc-implementation)", desc = "Show the implementation of current symbol" }
-        maps.n["gT"] = { "<Plug>(coc-type-definition)", desc = "Show the definition of current type" }
-        maps.n["gd"] = { "<Plug>(coc-definition)", desc = "Show the definition of current symbol" }
-        maps.n["gr"] = { "<Plug>(coc-references)", desc = "Show the references of current symbol" }
-        maps.n["<Leader>lR"] = maps.n.gr
-        maps.n["<Leader>la"] = { "<Plug>(coc-codeaction-cursor)", desc = "LSP code action" }
-        maps.n["<Leader>lc"] = { "<Cmd>CocConfig<CR>", desc = "Configuration" }
-        maps.n["<Leader>lf"] = { function() vim.cmd.Format() end, desc = "Format buffer" }
-        maps.n["<Leader>lm"] = { "<Cmd>CocList marketplace<CR>", desc = "Marketplace" }
-        maps.n["<Leader>lr"] = { "<Plug>(coc-rename)", desc = "Rename current symbol" }
-        maps.n["<Leader>ls"] = { "<Cmd>CocList symbols<CR>", desc = "Search symbols" }
-        maps.n["<Leader>lS"] = { "<Cmd>CocOutline<CR>", desc = "Symbols outline" }
-        maps.n["<Leader>lL"] = { "<Plug>(coc-codelens-action)", desc = "LSP CodeLens run" }
-        maps.n["<Leader>uL"] = { "<Cmd>CocCommand document.toggleCodeLens<CR>", desc = "Toggle CodeLens" }
-        maps.n["<Leader>uh"] = { "<Cmd>CocCommand document.toggleInlayHint<CR>", desc = "Toggle LSP inlay hints" }
-        maps.x["<Leader>lF"] = { "<Plug>(coc-format-selected)", desc = "Format selection" }
-        maps.n["K"] = {
-          function()
-            local cw = vim.fn.expand "<cword>"
-            if vim.fn.index({ "vim", "help" }, vim.bo.filetype) >= 0 then
-              vim.api.nvim_command("h " .. cw)
-            elseif vim.api.nvim_eval "coc#rpc#ready()" then
-              vim.fn.CocActionAsync "doHover"
-            else
-              vim.api.nvim_command("!" .. vim.o.keywordprg .. " " .. cw)
-            end
-          end,
-          desc = "Hover symbol details",
-        }
-      end,
-    },
+  "neoclide/coc.nvim",
+  branch = "release",
+  cmd = {
+    "CocCommand",
+    "CocConfig",
+    "CocDiagnostics",
+    "CocDisable",
+    "CocEnable",
+    "CocInfo",
+    "CocInstall",
+    "CocList",
+    "CocLocalConfig",
+    "CocOpenLog",
+    "CocOutline",
+    "CocPrintErrors",
+    "CocRestart",
+    "CocSearch",
+    "CocStart",
+    "CocUninstall",
+    "CocUpdate",
+    "CocUpdateSync",
+    "CocWatch",
   },
-  {
-    "rebelot/heirline.nvim",
+  event = { "User AstroFile", "InsertEnter" },
+  dependencies = {
+    "AstroNvim/astrocore",
+    ---@param opts AstroCoreOpts
     opts = function(_, opts)
-      local statusline, status = opts.statusline, require "astroui.status"
-      local function coc_diagnostic(coc_type, diagnostic_type)
-        return {
-          provider = function(self)
-            local count = vim.b[self.bufnr or 0].coc_diagnostic_info[coc_type]
-            return status.utils.stylize(
-              count ~= 0 and tostring(count) or "",
-              { icon = { kind = "Diagnostic" .. diagnostic_type, padding = { left = 1, right = 1 } } }
-            )
-          end,
-          hl = { fg = "diag_" .. diagnostic_type:upper() },
-        }
-      end
-      statusline[5] = status.component.builder { -- diagnostics
-        coc_diagnostic("error", "Error"),
-        coc_diagnostic("warning", "Warn"),
-        coc_diagnostic("information", "Info"),
-        coc_diagnostic("hint", "Hint"),
-        update = { "User", pattern = "CocDiagnosticChange" },
-        init = status.init.update_events { "BufEnter" },
-        surround = {
-          separator = "right",
-          condition = function()
-            for _, count in pairs(vim.b.coc_diagnostic_info or {}) do
-              if type(count) == "number" and count > 0 then return true end
-            end
-            return false
-          end,
-        },
-        on_click = { name = "coc_diagnostic", callback = function() vim.schedule(vim.cmd.CocDiagnostic) end },
+      if not opts.options then opts.options = {} end
+      if not opts.options.g then opts.options.g = {} end
+      if not opts.options.opt then opts.options.opt = {} end
+      opts.options.opt.cmdheight = 1
+      opts.options.g.coc_global_extensions = {
+        "coc-json",
+        "coc-marketplace",
       }
-      -- FIXME: This update on every keypress, introducing delay for nearly all coc-extensions.
-      --
-      -- statusline[9] = status.component.builder { -- status
-      --   {
-      --     provider = function() return vim.g.coc_status end,
-      --     on_click = { name = "coc_status", callback = function() vim.schedule(vim.cmd.CocInfo) end },
-      --   },
-      --   {
-      --     provider = function()
-      --       if vim.g.coc_status then
-      --         return status.utils.stylize(" ", { icon = { kind = "ActiveLSP", padding = { left = 1 } } })
-      --       end
-      --     end,
-      --     on_click = {
-      --       name = "coc_services",
-      --       callback = vim.schedule_wrap(function() vim.cmd.CocList "services" end),
-      --     },
-      --   },
-      --   update = {
-      --     "User",
-      --     pattern = "CocStatusChange",
-      --     callback = function() vim.schedule(vim.cmd.redrawstatus) end,
-      --   },
-      --   surround = { separator = "right", condition = function() return vim.g.coc_status ~= nil end },
-      -- }
+
+      if not opts.commands then opts.commands = {} end
+      opts.commands.Format = { function() vim.fn.CocAction "format" end, desc = "Format file with LSP" }
+      if not opts.mappings then opts.mappings = require("astrocore").empty_map_table() end
+      local maps = assert(opts.mappings)
+      maps.n["[d"] = { "<Plug>(coc-diagnostic-prev)", desc = "Previous diagnostic" }
+      maps.n["]d"] = { "<Plug>(coc-diagnostic-next)", desc = "Next diagnostic" }
+      maps.n["gD"] = { "<Plug>(coc-declaration)", desc = "Show the declaration of current symbol" }
+      maps.n["gI"] = { "<Plug>(coc-implementation)", desc = "Show the implementation of current symbol" }
+      maps.n["gT"] = { "<Plug>(coc-type-definition)", desc = "Show the definition of current type" }
+      maps.n["gd"] = { "<Plug>(coc-definition)", desc = "Show the definition of current symbol" }
+      maps.n["gr"] = { "<Plug>(coc-references)", desc = "Show the references of current symbol" }
+      maps.n["<Leader>lR"] = maps.n.gr
+      maps.n["<Leader>la"] = { "<Plug>(coc-codeaction-cursor)", desc = "LSP code action" }
+      maps.n["<Leader>lc"] = { "<Cmd>CocConfig<CR>", desc = "Configuration" }
+      maps.n["<Leader>lf"] = { function() vim.cmd.Format() end, desc = "Format buffer" }
+      maps.n["<Leader>lm"] = { "<Cmd>CocList marketplace<CR>", desc = "Marketplace" }
+      maps.n["<Leader>lr"] = { "<Plug>(coc-rename)", desc = "Rename current symbol" }
+      maps.n["<Leader>ls"] = { "<Cmd>CocList symbols<CR>", desc = "Search symbols" }
+      maps.n["<Leader>lS"] = { "<Cmd>CocOutline<CR>", desc = "Symbols outline" }
+      maps.n["<Leader>lL"] = { "<Plug>(coc-codelens-action)", desc = "LSP CodeLens run" }
+      maps.n["<Leader>uL"] = { "<Cmd>CocCommand document.toggleCodeLens<CR>", desc = "Toggle CodeLens" }
+      maps.n["<Leader>uh"] = { "<Cmd>CocCommand document.toggleInlayHint<CR>", desc = "Toggle LSP inlay hints" }
+      maps.x["<Leader>lF"] = { "<Plug>(coc-format-selected)", desc = "Format selection" }
+      maps.n["K"] = {
+        function()
+          local cw = vim.fn.expand "<cword>"
+          if vim.fn.index({ "vim", "help" }, vim.bo.filetype) >= 0 then
+            vim.api.nvim_command("h " .. cw)
+          elseif vim.api.nvim_eval "coc#rpc#ready()" then
+            vim.fn.CocActionAsync "doHover"
+          else
+            vim.api.nvim_command("!" .. vim.o.keywordprg .. " " .. cw)
+          end
+        end,
+        desc = "Hover symbol details",
+      }
     end,
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { coc_nvim = true } },
+  specs = {
+    {
+      "rebelot/heirline.nvim",
+      optional = true,
+      opts = function(_, opts)
+        local statusline, status = opts.statusline, require "astroui.status"
+        local function coc_diagnostic(coc_type, diagnostic_type)
+          return {
+            provider = function(self)
+              local count = vim.b[self.bufnr or 0].coc_diagnostic_info[coc_type]
+              return status.utils.stylize(
+                count ~= 0 and tostring(count) or "",
+                { icon = { kind = "Diagnostic" .. diagnostic_type, padding = { left = 1, right = 1 } } }
+              )
+            end,
+            hl = { fg = "diag_" .. diagnostic_type:upper() },
+          }
+        end
+        statusline[5] = status.component.builder { -- diagnostics
+          coc_diagnostic("error", "Error"),
+          coc_diagnostic("warning", "Warn"),
+          coc_diagnostic("information", "Info"),
+          coc_diagnostic("hint", "Hint"),
+          update = { "User", pattern = "CocDiagnosticChange" },
+          init = status.init.update_events { "BufEnter" },
+          surround = {
+            separator = "right",
+            condition = function()
+              for _, count in pairs(vim.b.coc_diagnostic_info or {}) do
+                if type(count) == "number" and count > 0 then return true end
+              end
+              return false
+            end,
+          },
+          on_click = { name = "coc_diagnostic", callback = function() vim.schedule(vim.cmd.CocDiagnostic) end },
+        }
+        -- FIXME: This update on every keypress, introducing delay for nearly all coc-extensions.
+        --
+        -- statusline[9] = status.component.builder { -- status
+        --   {
+        --     provider = function() return vim.g.coc_status end,
+        --     on_click = { name = "coc_status", callback = function() vim.schedule(vim.cmd.CocInfo) end },
+        --   },
+        --   {
+        --     provider = function()
+        --       if vim.g.coc_status then
+        --         return status.utils.stylize(" ", { icon = { kind = "ActiveLSP", padding = { left = 1 } } })
+        --       end
+        --     end,
+        --     on_click = {
+        --       name = "coc_services",
+        --       callback = vim.schedule_wrap(function() vim.cmd.CocList "services" end),
+        --     },
+        --   },
+        --   update = {
+        --     "User",
+        --     pattern = "CocStatusChange",
+        --     callback = function() vim.schedule(vim.cmd.redrawstatus) end,
+        --   },
+        --   surround = { separator = "right", condition = function() return vim.g.coc_status ~= nil end },
+        -- }
+      end,
+    },
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { coc_nvim = true } },
+    },
+    -- disable core lsp plugins
+    { "AstroNvim/astrolsp", optional = true, enabled = false },
+    { "folke/neoconf.nvim", optional = true, enabled = false },
+    { "folke/neodev.nvim", optional = true, enabled = false },
+    { "jay-babu/mason-null-ls.nvim", optional = true, enabled = false },
+    { "neovim/nvim-lspconfig", optional = true, enabled = false },
+    { "nvimtools/none-ls.nvim", optional = true, enabled = false },
+    { "stevearc/aerial.nvim", optional = true, enabled = false },
+    { "williamboman/mason-lspconfig.nvim", optional = true, enabled = false },
+    -- cmp
+    { "hrsh7th/cmp-buffer", optional = true, enabled = false },
+    { "hrsh7th/cmp-nvim-lsp", optional = true, enabled = false },
+    { "hrsh7th/cmp-path", optional = true, enabled = false },
+    { "hrsh7th/nvim-cmp", optional = true, enabled = false },
+    { "rcarriga/cmp-dap", optional = true, enabled = false },
+    { "saadparwaiz1/cmp_luasnip", optional = true, enabled = false },
+    -- luaship
+    { "L3MON4D3/LuaSnip", optional = true, enabled = false },
+    { "rafamadriz/friendly-snippets", optional = true, enabled = false },
   },
-  -- disable core lsp plugins
-  { "AstroNvim/astrolsp", enabled = false },
-  { "folke/neoconf.nvim", enabled = false },
-  { "folke/neodev.nvim", enabled = false },
-  { "jay-babu/mason-null-ls.nvim", enabled = false },
-  { "neovim/nvim-lspconfig", enabled = false },
-  { "nvimtools/none-ls.nvim", enabled = false },
-  { "stevearc/aerial.nvim", enabled = false },
-  { "williamboman/mason-lspconfig.nvim", enabled = false },
-  -- cmp
-  { "hrsh7th/cmp-buffer", enabled = false },
-  { "hrsh7th/cmp-nvim-lsp", enabled = false },
-  { "hrsh7th/cmp-path", enabled = false },
-  { "hrsh7th/nvim-cmp", enabled = false },
-  { "rcarriga/cmp-dap", enabled = false },
-  { "saadparwaiz1/cmp_luasnip", enabled = false },
-  -- luaship
-  { "L3MON4D3/LuaSnip", enabled = false },
-  { "rafamadriz/friendly-snippets", enabled = false },
 }

--- a/lua/astrocommunity/lsp/lsp-inlayhints-nvim/init.lua
+++ b/lua/astrocommunity/lsp/lsp-inlayhints-nvim/init.lua
@@ -1,45 +1,45 @@
 return {
-  {
-    "lvimuser/lsp-inlayhints.nvim",
-    lazy = true,
-    dependencies = {
-      "AstroNvim/astrocore",
-      opts = {
-        autocmds = {
-          LspAttach_inlayhints = {
-            {
-              event = "LspAttach",
-              callback = function(args)
-                if not (args.data and args.data.client_id) then return end
-                local client = vim.lsp.get_client_by_id(args.data.client_id)
-                if client and client.server_capabilities.inlayHintProvider then
-                  local inlayhints = require "lsp-inlayhints"
-                  inlayhints.on_attach(client, args.buf)
-                  require("astrocore").set_mappings({
-                    n = {
-                      ["<Leader>uh"] = { inlayhints.toggle, desc = "Toggle inlay hints" },
-                    },
-                  }, { buffer = args.buf })
-                end
-              end,
-            },
+  "lvimuser/lsp-inlayhints.nvim",
+  lazy = true,
+  dependencies = {
+    "AstroNvim/astrocore",
+    opts = {
+      autocmds = {
+        LspAttach_inlayhints = {
+          {
+            event = "LspAttach",
+            callback = function(args)
+              if not (args.data and args.data.client_id) then return end
+              local client = vim.lsp.get_client_by_id(args.data.client_id)
+              if client and client.server_capabilities.inlayHintProvider then
+                local inlayhints = require "lsp-inlayhints"
+                inlayhints.on_attach(client, args.buf)
+                require("astrocore").set_mappings({
+                  n = {
+                    ["<Leader>uh"] = { inlayhints.toggle, desc = "Toggle inlay hints" },
+                  },
+                }, { buffer = args.buf })
+              end
+            end,
           },
         },
       },
     },
-    init = function()
-      require("astrocore").notify("`lsp-inlayhints.nvim` has been archived and is now read only!", vim.log.levels.WARN)
-    end,
-    opts = {},
   },
-  {
-    "p00f/clangd_extensions.nvim",
-    optional = true,
-    opts = { extensions = { autoSetHints = false } },
+  specs = {
+    {
+      "p00f/clangd_extensions.nvim",
+      optional = true,
+      opts = { extensions = { autoSetHints = false } },
+    },
+    {
+      "simrat39/rust-tools.nvim",
+      optional = true,
+      opts = { tools = { inlay_hints = { auto = false } } },
+    },
   },
-  {
-    "simrat39/rust-tools.nvim",
-    optional = true,
-    opts = { tools = { inlay_hints = { auto = false } } },
-  },
+  init = function()
+    require("astrocore").notify("`lsp-inlayhints.nvim` has been archived and is now read only!", vim.log.levels.WARN)
+  end,
+  opts = {},
 }

--- a/lua/astrocommunity/lsp/lsp-signature-nvim/init.lua
+++ b/lua/astrocommunity/lsp/lsp-signature-nvim/init.lua
@@ -1,21 +1,21 @@
 ---@type LazySpec
 return {
-  {
-    "ray-x/lsp_signature.nvim",
-    event = "User AstroFile",
-    main = "lsp_signature",
-    opts = {
-      hint_enable = false, -- disable hints as it will crash in some terminal
-    },
+  "ray-x/lsp_signature.nvim",
+  event = "User AstroFile",
+  main = "lsp_signature",
+  opts = {
+    hint_enable = false, -- disable hints as it will crash in some terminal
   },
-  {
-    "folke/noice.nvim",
-    optional = true,
-    ---@type NoiceConfig
-    opts = {
-      lsp = {
-        signature = { enabled = false },
-        hover = { enabled = false },
+  specs = {
+    {
+      "folke/noice.nvim",
+      optional = true,
+      ---@type NoiceConfig
+      opts = {
+        lsp = {
+          signature = { enabled = false },
+          hover = { enabled = false },
+        },
       },
     },
   },

--- a/lua/astrocommunity/lsp/nvim-lint/init.lua
+++ b/lua/astrocommunity/lsp/nvim-lint/init.lua
@@ -1,56 +1,56 @@
 ---@type LazySpec
 return {
-  { "jay-babu/mason-null-ls.nvim", optional = true, opts = { methods = { diagnostics = false } } },
-  {
-    "mfussenegger/nvim-lint",
-    event = "User AstroFile",
-    dependencies = { "williamboman/mason.nvim" },
-    opts = {},
-    config = function(_, opts)
-      local lint = require "lint"
-
-      lint.linters_by_ft = opts.linters_by_ft or {}
-      for name, linter in pairs(opts.linters or {}) do
-        local base = lint.linters[name]
-        lint.linters[name] = (type(linter) == "table" and type(base) == "table")
-            and vim.tbl_deep_extend("force", base, linter)
-          or linter
-      end
-
-      local valid_linters = function(ctx, linters)
-        if not linters then return {} end
-        return vim.tbl_filter(function(name)
-          local linter = lint.linters[name]
-          return linter
-            and vim.fn.executable(linter.cmd) == 1
-            and not (type(linter) == "table" and linter.condition and not linter.condition(ctx))
-        end, linters)
-      end
-
-      local orig_resolve_linter_by_ft = lint._resolve_linter_by_ft
-      lint._resolve_linter_by_ft = function(...)
-        local ctx = { filename = vim.api.nvim_buf_get_name(0) }
-        ctx.dirname = vim.fn.fnamemodify(ctx.filename, ":h")
-
-        local linters = valid_linters(ctx, orig_resolve_linter_by_ft(...))
-        if not linters[1] then linters = valid_linters(ctx, lint.linters_by_ft["_"]) end -- fallback
-        require("astrocore").list_insert_unique(linters, valid_linters(ctx, lint.linters_by_ft["*"])) -- global
-
-        return linters
-      end
-
-      lint.try_lint() -- start linter immediately
-      local timer = vim.loop.new_timer()
-      vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave", "TextChanged" }, {
-        group = vim.api.nvim_create_augroup("auto_lint", { clear = true }),
-        desc = "Automatically try linting",
-        callback = function()
-          timer:start(100, 0, function()
-            timer:stop()
-            vim.schedule(lint.try_lint)
-          end)
-        end,
-      })
-    end,
+  "mfussenegger/nvim-lint",
+  event = "User AstroFile",
+  dependencies = { "williamboman/mason.nvim" },
+  specs = {
+    { "jay-babu/mason-null-ls.nvim", optional = true, opts = { methods = { diagnostics = false } } },
   },
+  opts = {},
+  config = function(_, opts)
+    local lint = require "lint"
+
+    lint.linters_by_ft = opts.linters_by_ft or {}
+    for name, linter in pairs(opts.linters or {}) do
+      local base = lint.linters[name]
+      lint.linters[name] = (type(linter) == "table" and type(base) == "table")
+          and vim.tbl_deep_extend("force", base, linter)
+        or linter
+    end
+
+    local valid_linters = function(ctx, linters)
+      if not linters then return {} end
+      return vim.tbl_filter(function(name)
+        local linter = lint.linters[name]
+        return linter
+          and vim.fn.executable(linter.cmd) == 1
+          and not (type(linter) == "table" and linter.condition and not linter.condition(ctx))
+      end, linters)
+    end
+
+    local orig_resolve_linter_by_ft = lint._resolve_linter_by_ft
+    lint._resolve_linter_by_ft = function(...)
+      local ctx = { filename = vim.api.nvim_buf_get_name(0) }
+      ctx.dirname = vim.fn.fnamemodify(ctx.filename, ":h")
+
+      local linters = valid_linters(ctx, orig_resolve_linter_by_ft(...))
+      if not linters[1] then linters = valid_linters(ctx, lint.linters_by_ft["_"]) end -- fallback
+      require("astrocore").list_insert_unique(linters, valid_linters(ctx, lint.linters_by_ft["*"])) -- global
+
+      return linters
+    end
+
+    lint.try_lint() -- start linter immediately
+    local timer = vim.loop.new_timer()
+    vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave", "TextChanged" }, {
+      group = vim.api.nvim_create_augroup("auto_lint", { clear = true }),
+      desc = "Automatically try linting",
+      callback = function()
+        timer:start(100, 0, function()
+          timer:stop()
+          vim.schedule(lint.try_lint)
+        end)
+      end,
+    })
+  end,
 }

--- a/lua/astrocommunity/markdown-and-latex/markmap-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/markmap-nvim/init.lua
@@ -1,19 +1,19 @@
 --  [markdown markmap]
 --  https://github.com/Zeioth/markmap.nvim
 return {
-  {
-    "Zeioth/markmap.nvim",
-    cmd = { "MarkmapOpen", "MarkmapSave", "MarkmapWatch", "MarkmapWatchStop" },
-    ft = "markdown",
-    opts = {
-      hide_toolbar = "false",
-    },
+  "Zeioth/markmap.nvim",
+  cmd = { "MarkmapOpen", "MarkmapSave", "MarkmapWatch", "MarkmapWatchStop" },
+  ft = "markdown",
+  opts = {
+    hide_toolbar = "false",
   },
-  {
-    "jay-babu/mason-null-ls.nvim",
-    optional = true,
-    opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "markmap-cli" })
-    end,
+  specs = {
+    {
+      "jay-babu/mason-null-ls.nvim",
+      optional = true,
+      opts = function(_, opts)
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "markmap-cli" })
+      end,
+    },
   },
 }

--- a/lua/astrocommunity/motion/harp-nvim/harp-nvim.lua
+++ b/lua/astrocommunity/motion/harp-nvim/harp-nvim.lua
@@ -1,32 +1,30 @@
 return {
-  {
-    "Axlefublr/harp-nvim",
-    lazy = true,
-    dependencies = {
-      "AstroNvim/astrocore",
-      opts = {
-        mappings = {
-          n = {
-            ["<Leader>i"] = { function() require("harp").default_get() end, desc = ":edit file in given register" },
-            ["<Leader>I"] = {
-              function() require("harp").default_set() end,
-              desc = "Store current buffer path in given register",
-            },
-            ["<Leader>x"] = {
-              function() require("harp").percwd_get() end,
-              desc = ":edit file in given register, specific to this project",
-            },
-            ["<Leader>X"] = {
-              function() require("harp").percwd_set() end,
-              desc = "Store current buffer path in given register, specific to this project",
-            },
-            ["'"] = { function() require("harp").perbuffer_mark_get() end, desc = "Show local marks" },
-            ["m"] = { function() require("harp").perbuffer_mark_set() end, desc = "Set local mark" },
-            ["<Leader>'"] = { function() require("harp").global_mark_get() end, desc = "Show global marks" },
-            ["<Leader>m"] = { function() require("harp").global_mark_set() end, desc = "Set global mark" },
-            ["<Leader>z"] = { function() require("harp").cd_get() end, desc = "CD to path stored in register" },
-            ["<Leader>Z"] = { function() require("harp").cd_set() end, desc = "Set CWD in register" },
+  "Axlefublr/harp-nvim",
+  lazy = true,
+  dependencies = {
+    "AstroNvim/astrocore",
+    opts = {
+      mappings = {
+        n = {
+          ["<Leader>i"] = { function() require("harp").default_get() end, desc = ":edit file in given register" },
+          ["<Leader>I"] = {
+            function() require("harp").default_set() end,
+            desc = "Store current buffer path in given register",
           },
+          ["<Leader>x"] = {
+            function() require("harp").percwd_get() end,
+            desc = ":edit file in given register, specific to this project",
+          },
+          ["<Leader>X"] = {
+            function() require("harp").percwd_set() end,
+            desc = "Store current buffer path in given register, specific to this project",
+          },
+          ["'"] = { function() require("harp").perbuffer_mark_get() end, desc = "Show local marks" },
+          ["m"] = { function() require("harp").perbuffer_mark_set() end, desc = "Set local mark" },
+          ["<Leader>'"] = { function() require("harp").global_mark_get() end, desc = "Show global marks" },
+          ["<Leader>m"] = { function() require("harp").global_mark_set() end, desc = "Set global mark" },
+          ["<Leader>z"] = { function() require("harp").cd_get() end, desc = "CD to path stored in register" },
+          ["<Leader>Z"] = { function() require("harp").cd_set() end, desc = "Set CWD in register" },
         },
       },
     },

--- a/lua/astrocommunity/motion/harpoon/init.lua
+++ b/lua/astrocommunity/motion/harpoon/init.lua
@@ -1,53 +1,53 @@
 return {
-  {
-    "ThePrimeagen/harpoon",
-    branch = "harpoon2",
-    dependencies = {
-      "nvim-lua/plenary.nvim",
-      "nvim-telescope/telescope.nvim",
-      { "AstroNvim/astroui", opts = { icons = { Harpoon = "󱡀" } } },
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local maps = opts.mappings
-          local term_string = vim.fn.exists "$TMUX" == 1 and "tmux" or "term"
-          local prefix = "<Leader><Leader>"
-          maps.n[prefix] = { desc = require("astroui").get_icon("Harpoon", 1, true) .. "Harpoon" }
+  "ThePrimeagen/harpoon",
+  branch = "harpoon2",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "nvim-telescope/telescope.nvim",
+    { "AstroNvim/astroui", opts = { icons = { Harpoon = "󱡀" } } },
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        local term_string = vim.fn.exists "$TMUX" == 1 and "tmux" or "term"
+        local prefix = "<Leader><Leader>"
+        maps.n[prefix] = { desc = require("astroui").get_icon("Harpoon", 1, true) .. "Harpoon" }
 
-          maps.n[prefix .. "a"] = { function() require("harpoon"):list():add() end, desc = "Add file" }
-          maps.n[prefix .. "e"] = {
-            function() require("harpoon").ui:toggle_quick_menu(require("harpoon"):list()) end,
-            desc = "Toggle quick menu",
-          }
-          maps.n["<C-x>"] = {
-            function()
-              vim.ui.input({ prompt = "Harpoon mark index: " }, function(input)
-                local num = tonumber(input)
-                if num then require("harpoon"):list():select(num) end
-              end)
-            end,
-            desc = "Goto index of mark",
-          }
-          maps.n["<C-p>"] = { function() require("harpoon"):list():prev() end, desc = "Goto previous mark" }
-          maps.n["<C-n>"] = { function() require("harpoon"):list():next() end, desc = "Goto next mark" }
-          maps.n[prefix .. "m"] = { "<Cmd>Telescope harpoon marks<CR>", desc = "Show marks in Telescope" }
-          maps.n[prefix .. "t"] = {
-            function()
-              vim.ui.input({ prompt = term_string .. " window number: " }, function(input)
-                local num = tonumber(input)
-                if num then require("harpoon").term.gotoTerminal(num) end
-              end)
-            end,
-            desc = "Go to " .. term_string .. " window",
-          }
-        end,
-      },
+        maps.n[prefix .. "a"] = { function() require("harpoon"):list():add() end, desc = "Add file" }
+        maps.n[prefix .. "e"] = {
+          function() require("harpoon").ui:toggle_quick_menu(require("harpoon"):list()) end,
+          desc = "Toggle quick menu",
+        }
+        maps.n["<C-x>"] = {
+          function()
+            vim.ui.input({ prompt = "Harpoon mark index: " }, function(input)
+              local num = tonumber(input)
+              if num then require("harpoon"):list():select(num) end
+            end)
+          end,
+          desc = "Goto index of mark",
+        }
+        maps.n["<C-p>"] = { function() require("harpoon"):list():prev() end, desc = "Goto previous mark" }
+        maps.n["<C-n>"] = { function() require("harpoon"):list():next() end, desc = "Goto next mark" }
+        maps.n[prefix .. "m"] = { "<Cmd>Telescope harpoon marks<CR>", desc = "Show marks in Telescope" }
+        maps.n[prefix .. "t"] = {
+          function()
+            vim.ui.input({ prompt = term_string .. " window number: " }, function(input)
+              local num = tonumber(input)
+              if num then require("harpoon").term.gotoTerminal(num) end
+            end)
+          end,
+          desc = "Go to " .. term_string .. " window",
+        }
+      end,
     },
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { harpoon = true } },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { harpoon = true } },
+    },
   },
 }

--- a/lua/astrocommunity/motion/hop-nvim/init.lua
+++ b/lua/astrocommunity/motion/hop-nvim/init.lua
@@ -1,30 +1,30 @@
 return {
-  {
-    "smoka7/hop.nvim",
-    opts = {},
-    dependencies = {
-      "AstroNvim/astrocore",
-      opts = {
-        mappings = {
-          n = {
-            ["s"] = { function() require("hop").hint_words() end, desc = "Hop hint words" },
-            ["<S-s>"] = { function() require("hop").hint_lines() end, desc = "Hop hint lines" },
-          },
-          v = {
-            ["s"] = { function() require("hop").hint_words { extend_visual = true } end, desc = "Hop hint words" },
-            ["<S-s>"] = {
-              function() require("hop").hint_lines { extend_visual = true } end,
-              desc = "Hop hint lines",
-            },
+  "smoka7/hop.nvim",
+  opts = {},
+  dependencies = {
+    "AstroNvim/astrocore",
+    opts = {
+      mappings = {
+        n = {
+          ["s"] = { function() require("hop").hint_words() end, desc = "Hop hint words" },
+          ["<S-s>"] = { function() require("hop").hint_lines() end, desc = "Hop hint lines" },
+        },
+        v = {
+          ["s"] = { function() require("hop").hint_words { extend_visual = true } end, desc = "Hop hint words" },
+          ["<S-s>"] = {
+            function() require("hop").hint_lines { extend_visual = true } end,
+            desc = "Hop hint lines",
           },
         },
       },
     },
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { hop = true } },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { hop = true } },
+    },
   },
 }

--- a/lua/astrocommunity/motion/leap-nvim/init.lua
+++ b/lua/astrocommunity/motion/leap-nvim/init.lua
@@ -1,57 +1,57 @@
 return {
-  {
-    "ggandor/leap.nvim",
-    dependencies = {
-      "tpope/vim-repeat",
-      {
-        "AstroNvim/astrocore",
-        opts = {
-          autocmds = {
-            leap_cursor = { -- https://github.com/ggandor/leap.nvim/issues/70#issuecomment-1521177534
-              {
-                event = "User",
-                pattern = "LeapEnter",
-                callback = function()
-                  vim.cmd.hi("Cursor", "blend=100")
-                  vim.opt.guicursor:append { "a:Cursor/lCursor" }
-                end,
-              },
-              {
-                event = "User",
-                pattern = "LeapLeave",
-                callback = function()
-                  vim.cmd.hi("Cursor", "blend=0")
-                  vim.opt.guicursor:remove { "a:Cursor/lCursor" }
-                end,
-              },
+  "ggandor/leap.nvim",
+  dependencies = {
+    "tpope/vim-repeat",
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        autocmds = {
+          leap_cursor = { -- https://github.com/ggandor/leap.nvim/issues/70#issuecomment-1521177534
+            {
+              event = "User",
+              pattern = "LeapEnter",
+              callback = function()
+                vim.cmd.hi("Cursor", "blend=100")
+                vim.opt.guicursor:append { "a:Cursor/lCursor" }
+              end,
+            },
+            {
+              event = "User",
+              pattern = "LeapLeave",
+              callback = function()
+                vim.cmd.hi("Cursor", "blend=0")
+                vim.opt.guicursor:remove { "a:Cursor/lCursor" }
+              end,
             },
           },
-          mappings = {
-            n = {
-              ["s"] = { "<Plug>(leap-forward)", desc = "Leap forward" },
-              ["S"] = { "<Plug>(leap-backward)", desc = "Leap backward" },
-              ["gs"] = { "<Plug>(leap-from-window)", desc = "Leap from window" },
-            },
-            x = {
-              ["s"] = { "<Plug>(leap-forward)", desc = "Leap forward" },
-              ["S"] = { "<Plug>(leap-backward)", desc = "Leap backward" },
-              ["gs"] = { "<Plug>(leap-from-window)", desc = "Leap from window" },
-            },
-            o = {
-              ["s"] = { "<Plug>(leap-forward)", desc = "Leap forward" },
-              ["S"] = { "<Plug>(leap-backward)", desc = "Leap backward" },
-              ["gs"] = { "<Plug>(leap-from-window)", desc = "Leap from window" },
-            },
+        },
+        mappings = {
+          n = {
+            ["s"] = { "<Plug>(leap-forward)", desc = "Leap forward" },
+            ["S"] = { "<Plug>(leap-backward)", desc = "Leap backward" },
+            ["gs"] = { "<Plug>(leap-from-window)", desc = "Leap from window" },
+          },
+          x = {
+            ["s"] = { "<Plug>(leap-forward)", desc = "Leap forward" },
+            ["S"] = { "<Plug>(leap-backward)", desc = "Leap backward" },
+            ["gs"] = { "<Plug>(leap-from-window)", desc = "Leap from window" },
+          },
+          o = {
+            ["s"] = { "<Plug>(leap-forward)", desc = "Leap forward" },
+            ["S"] = { "<Plug>(leap-backward)", desc = "Leap backward" },
+            ["gs"] = { "<Plug>(leap-from-window)", desc = "Leap from window" },
           },
         },
       },
     },
-    opts = {},
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { leap = true } },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { leap = true } },
+    },
   },
+  opts = {},
 }

--- a/lua/astrocommunity/motion/mini-ai/init.lua
+++ b/lua/astrocommunity/motion/mini-ai/init.lua
@@ -1,13 +1,13 @@
 return {
-  {
-    "echasnovski/mini.ai",
-    event = "User AstroFile",
-    opts = {},
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  "echasnovski/mini.ai",
+  event = "User AstroFile",
+  opts = {},
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/motion/mini-basics/init.lua
+++ b/lua/astrocommunity/motion/mini-basics/init.lua
@@ -1,19 +1,19 @@
 return {
-  {
-    "echasnovski/mini.basics",
-    version = false,
-    event = "User AstroFile",
-    opts = {
-      mappings = {
-        windows = true,
-        move_with_alt = true,
-      },
+  "echasnovski/mini.basics",
+  version = false,
+  event = "User AstroFile",
+  opts = {
+    mappings = {
+      windows = true,
+      move_with_alt = true,
     },
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/motion/mini-bracketed/init.lua
+++ b/lua/astrocommunity/motion/mini-bracketed/init.lua
@@ -1,13 +1,13 @@
 return {
-  {
-    "echasnovski/mini.bracketed",
-    event = "User AstroFile",
-    opts = {},
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  "echasnovski/mini.bracketed",
+  event = "User AstroFile",
+  opts = {},
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/motion/mini-move/init.lua
+++ b/lua/astrocommunity/motion/mini-move/init.lua
@@ -1,40 +1,40 @@
 return {
-  {
-    "echasnovski/mini.move",
-    keys = function(_, keys)
-      local plugin = require("lazy.core.config").spec.plugins["mini.move"]
-      local opts = require("lazy.core.plugin").values(plugin, "opts", false) -- resolve mini.clue options
-      -- Populate the keys based on the user's options
-      local mappings = {
-        { opts.mappings.line_left, desc = "Move line left" },
-        { opts.mappings.line_right, desc = "Move line right" },
-        { opts.mappings.line_down, desc = "Move line down" },
-        { opts.mappings.line_up, desc = "Move line up" },
-        { opts.mappings.left, desc = "Move selection left", mode = "v" },
-        { opts.mappings.right, desc = "Move selection right", mode = "v" },
-        { opts.mappings.down, desc = "Move selection down", mode = "v" },
-        { opts.mappings.up, desc = "Move selection up", mode = "v" },
-      }
-      mappings = vim.tbl_filter(function(m) return m[1] and #m[1] > 0 end, mappings)
-      return vim.list_extend(mappings, keys)
-    end,
-    opts = {
-      mappings = {
-        left = "<A-h>",
-        right = "<A-l>",
-        down = "<A-j>",
-        up = "<A-k>",
-        line_left = "<A-h>",
-        line_right = "<A-l>",
-        line_down = "<A-j>",
-        line_up = "<A-k>",
-      },
+  "echasnovski/mini.move",
+  keys = function(_, keys)
+    local plugin = require("lazy.core.config").spec.plugins["mini.move"]
+    local opts = require("lazy.core.plugin").values(plugin, "opts", false) -- resolve mini.clue options
+    -- Populate the keys based on the user's options
+    local mappings = {
+      { opts.mappings.line_left, desc = "Move line left" },
+      { opts.mappings.line_right, desc = "Move line right" },
+      { opts.mappings.line_down, desc = "Move line down" },
+      { opts.mappings.line_up, desc = "Move line up" },
+      { opts.mappings.left, desc = "Move selection left", mode = "v" },
+      { opts.mappings.right, desc = "Move selection right", mode = "v" },
+      { opts.mappings.down, desc = "Move selection down", mode = "v" },
+      { opts.mappings.up, desc = "Move selection up", mode = "v" },
+    }
+    mappings = vim.tbl_filter(function(m) return m[1] and #m[1] > 0 end, mappings)
+    return vim.list_extend(mappings, keys)
+  end,
+  opts = {
+    mappings = {
+      left = "<A-h>",
+      right = "<A-l>",
+      down = "<A-j>",
+      up = "<A-k>",
+      line_left = "<A-h>",
+      line_right = "<A-l>",
+      line_down = "<A-j>",
+      line_up = "<A-k>",
     },
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/motion/mini-surround/init.lua
+++ b/lua/astrocommunity/motion/mini-surround/init.lua
@@ -1,49 +1,49 @@
 local prefix = "gz"
 return {
-  {
-    "echasnovski/mini.surround",
-    dependencies = {
-      { "AstroNvim/astroui", opts = { icons = { Surround = "󰑤" } } },
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local maps = opts.mappings
-          maps.n[prefix] = { desc = require("astroui").get_icon("Surround", 1, true) .. "Surround" }
-        end,
-      },
-    },
-    keys = function(_, keys)
-      local plugin = require("lazy.core.config").spec.plugins["mini.surround"]
-      local opts = require("lazy.core.plugin").values(plugin, "opts", false) -- resolve mini.clue options
-      -- Populate the keys based on the user's options
-      local mappings = {
-        { opts.mappings.add, desc = "Add surrounding", mode = { "n", "v" } },
-        { opts.mappings.delete, desc = "Delete surrounding" },
-        { opts.mappings.find, desc = "Find right surrounding" },
-        { opts.mappings.find_left, desc = "Find left surrounding" },
-        { opts.mappings.highlight, desc = "Highlight surrounding" },
-        { opts.mappings.replace, desc = "Replace surrounding" },
-        { opts.mappings.update_n_lines, desc = "Update `MiniSurround.config.n_lines`" },
-      }
-      mappings = vim.tbl_filter(function(m) return m[1] and #m[1] > 0 end, mappings)
-      return vim.list_extend(mappings, keys)
-    end,
-    opts = {
-      mappings = {
-        add = prefix .. "a", -- Add surrounding in Normal and Visual modes
-        delete = prefix .. "d", -- Delete surrounding
-        find = prefix .. "f", -- Find surrounding (to the right)
-        find_left = prefix .. "F", -- Find surrounding (to the left)
-        highlight = prefix .. "h", -- Highlight surrounding
-        replace = prefix .. "r", -- Replace surrounding
-        update_n_lines = prefix .. "n", -- Update `n_lines`
-      },
+  "echasnovski/mini.surround",
+  dependencies = {
+    { "AstroNvim/astroui", opts = { icons = { Surround = "󰑤" } } },
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        maps.n[prefix] = { desc = require("astroui").get_icon("Surround", 1, true) .. "Surround" }
+      end,
     },
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  keys = function(_, keys)
+    local plugin = require("lazy.core.config").spec.plugins["mini.surround"]
+    local opts = require("lazy.core.plugin").values(plugin, "opts", false) -- resolve mini.clue options
+    -- Populate the keys based on the user's options
+    local mappings = {
+      { opts.mappings.add, desc = "Add surrounding", mode = { "n", "v" } },
+      { opts.mappings.delete, desc = "Delete surrounding" },
+      { opts.mappings.find, desc = "Find right surrounding" },
+      { opts.mappings.find_left, desc = "Find left surrounding" },
+      { opts.mappings.highlight, desc = "Highlight surrounding" },
+      { opts.mappings.replace, desc = "Replace surrounding" },
+      { opts.mappings.update_n_lines, desc = "Update `MiniSurround.config.n_lines`" },
+    }
+    mappings = vim.tbl_filter(function(m) return m[1] and #m[1] > 0 end, mappings)
+    return vim.list_extend(mappings, keys)
+  end,
+  opts = {
+    mappings = {
+      add = prefix .. "a", -- Add surrounding in Normal and Visual modes
+      delete = prefix .. "d", -- Delete surrounding
+      find = prefix .. "f", -- Find surrounding (to the right)
+      find_left = prefix .. "F", -- Find surrounding (to the left)
+      highlight = prefix .. "h", -- Highlight surrounding
+      replace = prefix .. "r", -- Replace surrounding
+      update_n_lines = prefix .. "n", -- Update `n_lines`
+    },
+  },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/motion/nvim-surround/init.lua
+++ b/lua/astrocommunity/motion/nvim-surround/init.lua
@@ -1,8 +1,6 @@
 return {
-  {
-    "kylechui/nvim-surround",
-    version = "*", -- Use for stability; omit to use `main` branch for the latest features
-    event = "VeryLazy",
-    opts = {},
-  },
+  "kylechui/nvim-surround",
+  version = "*", -- Use for stability; omit to use `main` branch for the latest features
+  event = "VeryLazy",
+  opts = {},
 }

--- a/lua/astrocommunity/motion/vim-matchup/init.lua
+++ b/lua/astrocommunity/motion/vim-matchup/init.lua
@@ -1,19 +1,30 @@
 return {
-  "nvim-treesitter/nvim-treesitter",
-  dependencies = {
+  "andymass/vim-matchup",
+  lazy = true,
+  specs = {
     {
-      "andymass/vim-matchup",
+      "nvim-treesitter/nvim-treesitter",
       dependencies = {
-        "AstroNvim/astrocore",
-        opts = {
-          options = {
-            g = {
-              matchup_matchparen_offscreen = { method = "popup", fullwidth = 1, highlight = "Normal", syntax_hl = 1 },
+        {
+          "andymass/vim-matchup",
+          dependencies = {
+            "AstroNvim/astrocore",
+            opts = {
+              options = {
+                g = {
+                  matchup_matchparen_offscreen = {
+                    method = "popup",
+                    fullwidth = 1,
+                    highlight = "Normal",
+                    syntax_hl = 1,
+                  },
+                },
+              },
             },
           },
         },
       },
+      opts = { matchup = { enable = true } },
     },
   },
-  opts = { matchup = { enable = true } },
 }

--- a/lua/astrocommunity/neovim-lua-development/lazydev-nvim/init.lua
+++ b/lua/astrocommunity/neovim-lua-development/lazydev-nvim/init.lua
@@ -1,23 +1,24 @@
 return {
-  { "folke/neodev.nvim", enabled = false },
-  { "Bilal2453/luvit-meta", lazy = true },
-  {
-    "folke/lazydev.nvim",
-    ft = "lua",
-    cmd = "LazyDev",
-    opts = {
-      library = {
-        { path = "luvit-meta/library", words = { "vim%.uv" } },
-        { path = "astrocore", words = { "AstroCore" } },
-        { path = "astrolsp", words = { "AstroLSP" } },
-        { path = "astroui", words = { "AstroUI" } },
-        { path = "astrotheme", words = { "AstroTheme" } },
-        { path = "lazy.nvim", words = { "Lazy" } },
-      },
+  "folke/lazydev.nvim",
+  ft = "lua",
+  cmd = "LazyDev",
+  opts = {
+    library = {
+      { path = "luvit-meta/library", words = { "vim%.uv" } },
+      { path = "astrocore", words = { "AstroCore" } },
+      { path = "astrolsp", words = { "AstroLSP" } },
+      { path = "astroui", words = { "AstroUI" } },
+      { path = "astrotheme", words = { "AstroTheme" } },
+      { path = "lazy.nvim", words = { "Lazy" } },
     },
   },
-  {
-    "hrsh7th/nvim-cmp",
-    opts = function(_, opts) table.insert(opts.sources, { name = "lazydev", group_index = 0 }) end,
+  specs = {
+    { "folke/neodev.nvim", optional = true, enabled = false },
+    { "Bilal2453/luvit-meta", lazy = true },
+    {
+      "hrsh7th/nvim-cmp",
+      optional = true,
+      opts = function(_, opts) table.insert(opts.sources, { name = "lazydev", group_index = 0 }) end,
+    },
   },
 }

--- a/lua/astrocommunity/note-taking/venn-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/venn-nvim/init.lua
@@ -6,93 +6,93 @@ local hint = [[
 ]]
 
 return {
-  {
-    "jbyuki/venn.nvim",
-    cmd = "VBox",
-    dependencies = {
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local astrocore = require "astrocore"
-          if astrocore.is_available "hydra.nvim" then
-            if not opts.commands then opts.comands = {} end
-            opts.commands.ToggleVenn = {
-              function()
-                local hydra = vim.tbl_get(astrocore.plugin_opts "hydra.nvim", "Draw Diagram", "hydra")
-                if hydra then
-                  if hydra.layer.active then
-                    hydra:exit()
-                  else
-                    hydra:activate()
-                  end
+  "jbyuki/venn.nvim",
+  cmd = "VBox",
+  dependencies = {
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local astrocore = require "astrocore"
+        if astrocore.is_available "hydra.nvim" then
+          if not opts.commands then opts.comands = {} end
+          opts.commands.ToggleVenn = {
+            function()
+              local hydra = vim.tbl_get(astrocore.plugin_opts "hydra.nvim", "Draw Diagram", "hydra")
+              if hydra then
+                if hydra.layer.active then
+                  hydra:exit()
+                else
+                  hydra:activate()
                 end
-              end,
-              desc = "Toggle venn diagramming mode",
-            }
-          else
-            return astrocore.extend_tbl(opts, {
-              commands = {
-                ToggleVenn = {
-                  function()
-                    local mappings = {
-                      n = { -- draw a line on HJKL keystokes
-                        H = "<C-v>h:VBox<CR>",
-                        J = "<C-v>j:VBox<CR>",
-                        K = "<C-v>k:VBox<CR>",
-                        L = "<C-v>l:VBox<CR>",
-                      },
-                      v = { -- draw a box by pressing "f" with visual selection
-                        f = ":VBox<CR>",
-                      },
-                    }
-                    if vim.b.venn_enabled then
-                      vim.opt_local.virtualedit = ""
-                      for mode, map in pairs(mappings) do
-                        for lhs, _ in pairs(map) do
-                          vim.keymap.del(mode, lhs, { buffer = true })
-                        end
+              end
+            end,
+            desc = "Toggle venn diagramming mode",
+          }
+        else
+          return astrocore.extend_tbl(opts, {
+            commands = {
+              ToggleVenn = {
+                function()
+                  local mappings = {
+                    n = { -- draw a line on HJKL keystokes
+                      H = "<C-v>h:VBox<CR>",
+                      J = "<C-v>j:VBox<CR>",
+                      K = "<C-v>k:VBox<CR>",
+                      L = "<C-v>l:VBox<CR>",
+                    },
+                    v = { -- draw a box by pressing "f" with visual selection
+                      f = ":VBox<CR>",
+                    },
+                  }
+                  if vim.b.venn_enabled then
+                    vim.opt_local.virtualedit = ""
+                    for mode, map in pairs(mappings) do
+                      for lhs, _ in pairs(map) do
+                        vim.keymap.del(mode, lhs, { buffer = true })
                       end
-                      vim.b.venn_enabled = nil
-                    else
-                      vim.b.venn_enabled = true
-                      vim.opt_local.virtualedit = "all"
-                      require("astrocore").set_mappings(mappings, { buffer = true })
                     end
-                    vim.notify(("Venn Diagramming Mode: %s"):format(vim.b.venn_enabled and "Enabled" or "Disabled"))
-                  end,
-                  desc = "Toggle venn diagramming mode",
-                },
+                    vim.b.venn_enabled = nil
+                  else
+                    vim.b.venn_enabled = true
+                    vim.opt_local.virtualedit = "all"
+                    require("astrocore").set_mappings(mappings, { buffer = true })
+                  end
+                  vim.notify(("Venn Diagramming Mode: %s"):format(vim.b.venn_enabled and "Enabled" or "Disabled"))
+                end,
+                desc = "Toggle venn diagramming mode",
               },
-              mappings = {
-                n = { ["<Leader>v"] = { function() vim.cmd.ToggleVenn() end, desc = "Toggle venn diagramming" } },
-              },
-            })
-          end
-        end,
-      },
+            },
+            mappings = {
+              n = { ["<Leader>v"] = { function() vim.cmd.ToggleVenn() end, desc = "Toggle venn diagramming" } },
+            },
+          })
+        end
+      end,
     },
   },
-  {
-    "anuvyklack/hydra.nvim",
-    optional = true,
-    opts = {
-      ["Draw Diagram"] = {
-        hint = hint,
-        config = {
-          color = "pink",
-          invoke_on_body = true,
-          hint = { border = "rounded" },
-          on_enter = function() vim.o.virtualedit = "all" end,
-        },
-        mode = "n",
-        body = "<leader>v",
-        heads = {
-          { "H", "<C-v>h:VBox<CR>" },
-          { "J", "<C-v>j:VBox<CR>" },
-          { "K", "<C-v>k:VBox<CR>" },
-          { "L", "<C-v>l:VBox<CR>" },
-          { "f", ":VBox<CR>", { mode = "v" } },
-          { "<Esc>", nil, { exit = true } },
+  specs = {
+    {
+      "anuvyklack/hydra.nvim",
+      optional = true,
+      opts = {
+        ["Draw Diagram"] = {
+          hint = hint,
+          config = {
+            color = "pink",
+            invoke_on_body = true,
+            hint = { border = "rounded" },
+            on_enter = function() vim.o.virtualedit = "all" end,
+          },
+          mode = "n",
+          body = "<leader>v",
+          heads = {
+            { "H", "<C-v>h:VBox<CR>" },
+            { "J", "<C-v>j:VBox<CR>" },
+            { "K", "<C-v>k:VBox<CR>" },
+            { "L", "<C-v>l:VBox<CR>" },
+            { "f", ":VBox<CR>", { mode = "v" } },
+            { "<Esc>", nil, { exit = true } },
+          },
         },
       },
     },

--- a/lua/astrocommunity/note-taking/zk-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/zk-nvim/init.lua
@@ -1,37 +1,45 @@
 return {
-  {
-    "zk-org/zk-nvim",
-    main = "zk",
-    event = "User AstroFile",
-    cmd = {
-      "ZkIndex",
-      "ZkNew",
-      "ZkNewFromTitleSelection",
-      "ZkNewFromContentSelection",
-      "ZkCd",
-      "ZkNotes",
-      "ZkBacklinks",
-      "ZkLinks",
-      "ZkInsertLinkAtSelection",
-      "ZkInsertLink",
-      "ZkMatch",
-      "ZkTags",
+  "zk-org/zk-nvim",
+  main = "zk",
+  event = "User AstroFile",
+  cmd = {
+    "ZkIndex",
+    "ZkNew",
+    "ZkNewFromTitleSelection",
+    "ZkNewFromContentSelection",
+    "ZkCd",
+    "ZkNotes",
+    "ZkBacklinks",
+    "ZkLinks",
+    "ZkInsertLinkAtSelection",
+    "ZkInsertLink",
+    "ZkMatch",
+    "ZkTags",
+  },
+  dependencies = { "AstroNvim/astrolsp", opts = { handlers = { zk = function() end } } },
+  specs = {
+    {
+      "williamboman/mason-lspconfig.nvim",
+      optional = true,
+      opts = function(_, opts)
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "zk" })
+      end,
     },
-    dependencies = { "AstroNvim/astrolsp", opts = { handlers = { zk = function() end } } },
-    opts = function()
-      local lsp_config = require("astrolsp").lsp_opts "zk"
-      return {
-        lsp = {
-          config = lsp_config,
-          auto_attach = { filetypes = lsp_config.filetypes },
-        },
-      }
-    end,
+    {
+      "WhoIsSethDaniel/mason-tool-installer.nvim",
+      optional = true,
+      opts = function(_, opts)
+        opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "zk" })
+      end,
+    },
   },
-  {
-    "williamboman/mason-lspconfig.nvim",
-    opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "zk" })
-    end,
-  },
+  opts = function()
+    local lsp_config = require("astrolsp").lsp_opts "zk"
+    return {
+      lsp = {
+        config = lsp_config,
+        auto_attach = { filetypes = lsp_config.filetypes },
+      },
+    }
+  end,
 }

--- a/lua/astrocommunity/programming-language-support/dooku-nvim/init.lua
+++ b/lua/astrocommunity/programming-language-support/dooku-nvim/init.lua
@@ -1,7 +1,5 @@
 return {
-  {
-    "Zeioth/dooku.nvim",
-    cmd = { "DookuGenerate", "DookuOpen", "DookuAutoSetup" },
-    opts = {},
-  },
+  "Zeioth/dooku.nvim",
+  cmd = { "DookuGenerate", "DookuOpen", "DookuAutoSetup" },
+  opts = {},
 }

--- a/lua/astrocommunity/programming-language-support/rest-nvim/init.lua
+++ b/lua/astrocommunity/programming-language-support/rest-nvim/init.lua
@@ -1,30 +1,30 @@
 return {
-  {
-    "rest-nvim/rest.nvim",
-    ft = "http",
-    cmd = "Rest",
-    dependencies = {
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local maps = opts.mappings
-          local prefix = "<Leader>r"
-          maps.n[prefix] = { desc = "RestNvim" }
-          maps.n[prefix .. "r"] = { "<cmd>Rest run<cr>", desc = "Run request under the cursor" }
-          maps.n[prefix .. "l"] = { "<cmd>Rest run last<cr>", desc = "Re-run latest request" }
-        end,
-      },
+  "rest-nvim/rest.nvim",
+  ft = "http",
+  cmd = "Rest",
+  dependencies = {
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        local prefix = "<Leader>r"
+        maps.n[prefix] = { desc = "RestNvim" }
+        maps.n[prefix .. "r"] = { "<cmd>Rest run<cr>", desc = "Run request under the cursor" }
+        maps.n[prefix .. "l"] = { "<cmd>Rest run last<cr>", desc = "Re-run latest request" }
+      end,
     },
-    main = "rest-nvim",
-    opts = {},
   },
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      if opts.ensure_installed ~= "all" then
-        opts.ensure_installed =
-          require("astrocore").list_insert_unique(opts.ensure_installed, { "lua", "xml", "http", "json", "graphql" })
-      end
-    end,
+  specs = {
+    {
+      "nvim-treesitter/nvim-treesitter",
+      opts = function(_, opts)
+        if opts.ensure_installed ~= "all" then
+          opts.ensure_installed =
+            require("astrocore").list_insert_unique(opts.ensure_installed, { "lua", "xml", "http", "json", "graphql" })
+        end
+      end,
+    },
   },
+  main = "rest-nvim",
+  opts = {},
 }

--- a/lua/astrocommunity/programming-language-support/xbase/init.lua
+++ b/lua/astrocommunity/programming-language-support/xbase/init.lua
@@ -1,12 +1,10 @@
 return {
-  {
-    "xbase-lab/xbase",
-    ft = { "swift", "objcpp", "objc" },
-    run = "make install",
-    dependencies = {
-      { "nvim-telescope/telescope.nvim", optional = true },
-      { "nvim-lua/plenary.nvim", optional = true },
-      { "stevearc/dressing.nvim", optional = true }, -- (in case you don't use telescope but something else)
-    },
+  "xbase-lab/xbase",
+  ft = { "swift", "objcpp", "objc" },
+  run = "make install",
+  dependencies = {
+    { "nvim-telescope/telescope.nvim", optional = true },
+    { "nvim-lua/plenary.nvim", optional = true },
+    { "stevearc/dressing.nvim", optional = true }, -- (in case you don't use telescope but something else)
   },
 }

--- a/lua/astrocommunity/project/neoconf-nvim/init.lua
+++ b/lua/astrocommunity/project/neoconf-nvim/init.lua
@@ -1,16 +1,14 @@
 return {
-  "neovim/nvim-lspconfig",
-  dependencies = {
-    {
-      "folke/neoconf.nvim",
-      cmd = "Neoconf",
-      init = function()
-        require("astrocore").notify(
-          "`Neoconf.nvim` has been included upstream!\nPlease remove from your community plugins.",
-          vim.log.levels.WARN
-        )
-      end,
-      opts = {},
-    },
+  "folke/neoconf.nvim",
+  cmd = "Neoconf",
+  init = function()
+    require("astrocore").notify(
+      "`Neoconf.nvim` has been included upstream!\nPlease remove from your community plugins.",
+      vim.log.levels.WARN
+    )
+  end,
+  opts = {},
+  specs = {
+    { "neovim/nvim-lspconfig", dependencies = { "folke/neoconf.nvim" } },
   },
 }

--- a/lua/astrocommunity/project/nvim-spectre/init.lua
+++ b/lua/astrocommunity/project/nvim-spectre/init.lua
@@ -1,47 +1,47 @@
 return {
-  {
-    "nvim-pack/nvim-spectre",
-    cmd = "Spectre",
-    dependencies = {
-      { "AstroNvim/astroui", opts = { icons = { Spectre = "󰛔" } } },
-      {
-        "AstroNvim/astrocore",
-        opts = function(_, opts)
-          local maps = opts.mappings
-          local prefix = "<Leader>s"
-          maps.n[prefix] = { desc = require("astroui").get_icon("Spectre", 1, true) .. "Search / Replace" }
-          maps.n[prefix .. "s"] = { function() require("spectre").open() end, desc = "Spectre" }
-          maps.n[prefix .. "f"] =
-            { function() require("spectre").open_file_search() end, desc = "Spectre (current file)" }
+  "nvim-pack/nvim-spectre",
+  cmd = "Spectre",
+  dependencies = {
+    { "AstroNvim/astroui", opts = { icons = { Spectre = "󰛔" } } },
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        local prefix = "<Leader>s"
+        maps.n[prefix] = { desc = require("astroui").get_icon("Spectre", 1, true) .. "Search / Replace" }
+        maps.n[prefix .. "s"] = { function() require("spectre").open() end, desc = "Spectre" }
+        maps.n[prefix .. "f"] =
+          { function() require("spectre").open_file_search() end, desc = "Spectre (current file)" }
 
-          maps.x[prefix] = maps.n[prefix]
-          maps.x[prefix .. "w"] = {
-            function() require("spectre").open_visual { select_word = true } end,
-            desc = "Spectre (current word)",
-          }
-        end,
-      },
+        maps.x[prefix] = maps.n[prefix]
+        maps.x[prefix .. "w"] = {
+          function() require("spectre").open_visual { select_word = true } end,
+          desc = "Spectre (current word)",
+        }
+      end,
     },
-    opts = function()
-      return {
-        mapping = {
-          send_to_qf = { map = "q" },
-          replace_cmd = { map = "c" },
-          show_option_menu = { map = "o" },
-          run_current_replace = { map = "C" },
-          run_replace = { map = "R" },
-          change_view_mode = { map = "v" },
-          resume_last_search = { map = "l" },
-        },
-      }
-    end,
   },
-  {
-    "folke/edgy.nvim",
-    optional = true,
-    opts = function(_, opts)
-      if not opts.bottom then opts.bottom = {} end
-      table.insert(opts.bottom, { ft = "spectre_panel", title = "Search/Replace", size = { height = 0.4 } })
-    end,
+  specs = {
+    {
+      "folke/edgy.nvim",
+      optional = true,
+      opts = function(_, opts)
+        if not opts.bottom then opts.bottom = {} end
+        table.insert(opts.bottom, { ft = "spectre_panel", title = "Search/Replace", size = { height = 0.4 } })
+      end,
+    },
   },
+  opts = function()
+    return {
+      mapping = {
+        send_to_qf = { map = "q" },
+        replace_cmd = { map = "c" },
+        show_option_menu = { map = "o" },
+        run_current_replace = { map = "C" },
+        run_replace = { map = "R" },
+        change_view_mode = { map = "v" },
+        resume_last_search = { map = "l" },
+      },
+    }
+  end,
 }

--- a/lua/astrocommunity/project/project-nvim/init.lua
+++ b/lua/astrocommunity/project/project-nvim/init.lua
@@ -1,15 +1,15 @@
 return {
-  { "AstroNvim/astrocore", opts = { rooter = { enabled = false } } },
-  {
-    "jay-babu/project.nvim",
-    main = "project_nvim",
-    event = "VeryLazy",
-    opts = { ignore_lsp = { "lua_ls" } },
-  },
-  {
-    "nvim-telescope/telescope.nvim",
-    optional = true,
-    dependencies = { "jay-babu/project.nvim" },
-    opts = function() require("telescope").load_extension "projects" end,
+  "jay-babu/project.nvim",
+  main = "project_nvim",
+  event = "VeryLazy",
+  opts = { ignore_lsp = { "lua_ls" } },
+  specs = {
+    { "AstroNvim/astrocore", opts = { rooter = { enabled = false } } },
+    {
+      "nvim-telescope/telescope.nvim",
+      optional = true,
+      dependencies = { "jay-babu/project.nvim" },
+      opts = function() require("telescope").load_extension "projects" end,
+    },
   },
 }

--- a/lua/astrocommunity/project/projectmgr-nvim/init.lua
+++ b/lua/astrocommunity/project/projectmgr-nvim/init.lua
@@ -1,15 +1,13 @@
 return {
-  {
-    "charludo/projectmgr.nvim",
-    lazy = false, -- important!
-    dependencies = {
-      {
-        "AstroNvim/astrocore",
-        opts = {
-          mappings = {
-            n = {
-              ["<Leader>P"] = { "<Cmd>ProjectMgr<CR>", desc = "Open ProjectMgr panel" },
-            },
+  "charludo/projectmgr.nvim",
+  lazy = false, -- important!
+  dependencies = {
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        mappings = {
+          n = {
+            ["<Leader>P"] = { "<Cmd>ProjectMgr<CR>", desc = "Open ProjectMgr panel" },
           },
         },
       },

--- a/lua/astrocommunity/remote-development/netman-nvim/init.lua
+++ b/lua/astrocommunity/remote-development/netman-nvim/init.lua
@@ -1,21 +1,21 @@
 return {
-  {
-    "miversen33/netman.nvim",
-    cmd = {
-      "NmloadProvider",
-      "Nmlogs",
-      "Nmdelete",
-      "Nmread",
-      "Nmwrite",
-    },
-    opts = {},
+  "miversen33/netman.nvim",
+  cmd = {
+    "NmloadProvider",
+    "Nmlogs",
+    "Nmdelete",
+    "Nmread",
+    "Nmwrite",
   },
-  {
-    "nvim-neo-tree/neo-tree.nvim",
-    dependencies = { "netman.nvim" },
-    optional = true,
-    opts = function(_, opts)
-      opts.sources = require("astrocore").list_insert_unique(opts.sources, { "netman.ui.neo-tree" })
-    end,
+  opts = {},
+  specs = {
+    {
+      "nvim-neo-tree/neo-tree.nvim",
+      dependencies = { "netman.nvim" },
+      optional = true,
+      opts = function(_, opts)
+        opts.sources = require("astrocore").list_insert_unique(opts.sources, { "netman.ui.neo-tree" })
+      end,
+    },
   },
 }

--- a/lua/astrocommunity/scrolling/mini-animate/init.lua
+++ b/lua/astrocommunity/scrolling/mini-animate/init.lua
@@ -1,47 +1,47 @@
 return {
-  {
-    "echasnovski/mini.animate",
-    event = "VeryLazy",
-    cond = not (vim.g.neovide or vim.g.vscode),
-    -- enabled = false,
-    opts = function()
-      -- don't use animate when scrolling with the mouse
-      local mouse_scrolled = false
-      for _, scroll in ipairs { "Up", "Down" } do
-        local key = "<ScrollWheel" .. scroll .. ">"
-        vim.keymap.set({ "", "i" }, key, function()
-          mouse_scrolled = true
-          return key
-        end, { expr = true })
-      end
+  "echasnovski/mini.animate",
+  event = "VeryLazy",
+  cond = not (vim.g.neovide or vim.g.vscode),
+  -- enabled = false,
+  opts = function()
+    -- don't use animate when scrolling with the mouse
+    local mouse_scrolled = false
+    for _, scroll in ipairs { "Up", "Down" } do
+      local key = "<ScrollWheel" .. scroll .. ">"
+      vim.keymap.set({ "", "i" }, key, function()
+        mouse_scrolled = true
+        return key
+      end, { expr = true })
+    end
 
-      local animate = require "mini.animate"
-      return {
-        resize = {
-          timing = animate.gen_timing.linear { duration = 100, unit = "total" },
+    local animate = require "mini.animate"
+    return {
+      resize = {
+        timing = animate.gen_timing.linear { duration = 100, unit = "total" },
+      },
+      scroll = {
+        timing = animate.gen_timing.linear { duration = 150, unit = "total" },
+        subscroll = animate.gen_subscroll.equal {
+          predicate = function(total_scroll)
+            if mouse_scrolled then
+              mouse_scrolled = false
+              return false
+            end
+            return total_scroll > 1
+          end,
         },
-        scroll = {
-          timing = animate.gen_timing.linear { duration = 150, unit = "total" },
-          subscroll = animate.gen_subscroll.equal {
-            predicate = function(total_scroll)
-              if mouse_scrolled then
-                mouse_scrolled = false
-                return false
-              end
-              return total_scroll > 1
-            end,
-          },
-        },
-        cursor = {
-          timing = animate.gen_timing.linear { duration = 80, unit = "total" },
-        },
-      }
-    end,
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+      },
+      cursor = {
+        timing = animate.gen_timing.linear { duration = 80, unit = "total" },
+      },
+    }
+  end,
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/scrolling/satellite-nvim/init.lua
+++ b/lua/astrocommunity/scrolling/satellite-nvim/init.lua
@@ -1,24 +1,24 @@
 return {
-  {
-    -- scrollbar
-    "lewis6991/satellite.nvim",
-    event = "User AstroFile",
-    opts = { excluded_filetypes = { "prompt", "TelescopePrompt", "noice", "notify", "neo-tree" } },
-  },
-  {
-    "folke/zen-mode.nvim",
-    optional = true,
-    opts = function(_, opts)
-      local utils = require "astrocore"
-      local old_on_open, old_on_close = opts.on_open, opts.on_close
-      opts.on_open = function()
-        utils.conditional_func(old_on_open, true)
-        vim.cmd.SatelliteDisable()
-      end
-      opts.on_close = function()
-        utils.conditional_func(old_on_close, true)
-        vim.cmd.SatelliteEnable()
-      end
-    end,
+  -- scrollbar
+  "lewis6991/satellite.nvim",
+  event = "User AstroFile",
+  opts = { excluded_filetypes = { "prompt", "TelescopePrompt", "noice", "notify", "neo-tree" } },
+  specs = {
+    {
+      "folke/zen-mode.nvim",
+      optional = true,
+      opts = function(_, opts)
+        local utils = require "astrocore"
+        local old_on_open, old_on_close = opts.on_open, opts.on_close
+        opts.on_open = function()
+          utils.conditional_func(old_on_open, true)
+          vim.cmd.SatelliteDisable()
+        end
+        opts.on_close = function()
+          utils.conditional_func(old_on_close, true)
+          vim.cmd.SatelliteEnable()
+        end
+      end,
+    },
   },
 }

--- a/lua/astrocommunity/snippet/nvim-snippets/init.lua
+++ b/lua/astrocommunity/snippet/nvim-snippets/init.lua
@@ -1,17 +1,17 @@
 return {
-  { "L3MON4D3/LuaSnip", enabled = false },
-  {
-    "hrsh7th/nvim-cmp",
-    dependencies = {
-      {
-        "garymjr/nvim-snippets",
-        dependencies = { "rafamadriz/friendly-snippets" },
-        opts = { friendly_snippets = true },
-      },
+  "garymjr/nvim-snippets",
+  dependencies = { "rafamadriz/friendly-snippets" },
+  opts = { friendly_snippets = true },
+  lazy = true,
+  specs = {
+    { "L3MON4D3/LuaSnip", optional = true, enabled = false },
+    {
+      "hrsh7th/nvim-cmp",
+      dependencies = { "garymjr/nvim-snippets" },
+      opts = function(_, opts)
+        if not opts.sources then opts.sources = {} end
+        table.insert(opts.sources, { name = "snippets", priority = 750 })
+      end,
     },
-    opts = function(_, opts)
-      if not opts.sources then opts.sources = {} end
-      table.insert(opts.sources, { name = "snippets", priority = 750 })
-    end,
   },
 }

--- a/lua/astrocommunity/split-and-window/edgy-nvim/init.lua
+++ b/lua/astrocommunity/split-and-window/edgy-nvim/init.lua
@@ -1,83 +1,83 @@
 return {
-  {
-    "folke/edgy.nvim",
-    dependencies = {
-      {
-        "AstroNvim/astrocore",
-        opts = {
-          mappings = {
-            n = {
-              ["<Leader>F"] = { function() require("edgy").toggle() end, desc = "Toggle Sidebars" },
-              ["<Leader>f"] = { function() require("edgy").select() end, desc = "Pick Sidebar" },
-            },
+  "folke/edgy.nvim",
+  dependencies = {
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        mappings = {
+          n = {
+            ["<Leader>F"] = { function() require("edgy").toggle() end, desc = "Toggle Sidebars" },
+            ["<Leader>f"] = { function() require("edgy").select() end, desc = "Pick Sidebar" },
           },
         },
       },
     },
-    opts = {
-      exit_when_last = true,
-      bottom = {
-        { ft = "qf", title = "QuickFix" },
-        {
-          ft = "help",
-          size = { height = 20 },
-          -- don't open help files in edgy that we're editing
-          filter = function(buf) return vim.bo[buf].buftype == "help" end,
+  },
+  specs = {
+    {
+      "nvim-neo-tree/neo-tree.nvim",
+      optional = true,
+      opts = {
+        source_selector = {
+          winbar = false,
+          statusline = false,
         },
-      },
-      left = {
-        {
-          title = "Files",
-          ft = "neo-tree",
-          filter = function(buf) return vim.b[buf].neo_tree_source == "filesystem" end,
-          pinned = true,
-          open = "Neotree position=left filesystem",
-          size = { height = 0.5 },
-        },
-        {
-          title = "Git Status",
-          ft = "neo-tree",
-          filter = function(buf) return vim.b[buf].neo_tree_source == "git_status" end,
-          pinned = true,
-          open = "Neotree position=right git_status",
-        },
-        {
-          title = "Buffers",
-          ft = "neo-tree",
-          filter = function(buf) return vim.b[buf].neo_tree_source == "buffers" end,
-          pinned = true,
-          open = "Neotree position=top buffers",
-        },
-        "neo-tree",
-      },
-      right = {
-        {
-          ft = "aerial",
-          title = "Symbol Outline",
-          pinned = true,
-          open = function() require("aerial").open() end,
-        },
-      },
-      keys = {
-        -- increase width
-        ["<C-Right>"] = function(win) win:resize("width", 2) end,
-        -- decrease width
-        ["<C-Left>"] = function(win) win:resize("width", -2) end,
-        -- increase height
-        ["<C-Up>"] = function(win) win:resize("height", 2) end,
-        -- decrease height
-        ["<C-Down>"] = function(win) win:resize("height", -2) end,
       },
     },
   },
-  {
-    "nvim-neo-tree/neo-tree.nvim",
-    optional = true,
-    opts = {
-      source_selector = {
-        winbar = false,
-        statusline = false,
+  opts = {
+    exit_when_last = true,
+    bottom = {
+      { ft = "qf", title = "QuickFix" },
+      {
+        ft = "help",
+        size = { height = 20 },
+        -- don't open help files in edgy that we're editing
+        filter = function(buf) return vim.bo[buf].buftype == "help" end,
       },
+    },
+    left = {
+      {
+        title = "Files",
+        ft = "neo-tree",
+        filter = function(buf) return vim.b[buf].neo_tree_source == "filesystem" end,
+        pinned = true,
+        open = "Neotree position=left filesystem",
+        size = { height = 0.5 },
+      },
+      {
+        title = "Git Status",
+        ft = "neo-tree",
+        filter = function(buf) return vim.b[buf].neo_tree_source == "git_status" end,
+        pinned = true,
+        open = "Neotree position=right git_status",
+      },
+      {
+        title = "Buffers",
+        ft = "neo-tree",
+        filter = function(buf) return vim.b[buf].neo_tree_source == "buffers" end,
+        pinned = true,
+        open = "Neotree position=top buffers",
+      },
+      "neo-tree",
+    },
+    right = {
+      {
+        ft = "aerial",
+        title = "Symbol Outline",
+        pinned = true,
+        open = function() require("aerial").open() end,
+      },
+    },
+    keys = {
+      -- increase width
+      ["<C-Right>"] = function(win) win:resize("width", 2) end,
+      -- decrease width
+      ["<C-Left>"] = function(win) win:resize("width", -2) end,
+      -- increase height
+      ["<C-Up>"] = function(win) win:resize("height", 2) end,
+      -- decrease height
+      ["<C-Down>"] = function(win) win:resize("height", -2) end,
     },
   },
 }

--- a/lua/astrocommunity/split-and-window/mini-map/init.lua
+++ b/lua/astrocommunity/split-and-window/mini-map/init.lua
@@ -1,39 +1,39 @@
 return {
-  {
-    "echasnovski/mini.map",
-    version = "*",
-    keys = {
-      { "<leader>um", function() require("mini.map").toggle() end, desc = "Toggle minimap" },
-    },
-    opts = function()
-      local map = require "mini.map"
-      return {
-        integrations = {
-          map.gen_integration.builtin_search(),
-          map.gen_integration.gitsigns(),
-          map.gen_integration.diagnostic {
-            error = "DiagnosticFloatingError",
-            warn = "DiagnosticFloatingWarn",
-            info = "DiagnosticFloatingInfo",
-            hint = "DiagnosticFloatingHint",
-          },
-        },
-        symbols = {
-          encode = map.gen_encode_symbols.dot "3x2",
-        },
-        window = {
-          side = "right",
-          width = 22,
-          winblend = 5,
-          show_integration_count = true,
-        },
-      }
-    end,
+  "echasnovski/mini.map",
+  version = "*",
+  keys = {
+    { "<leader>um", function() require("mini.map").toggle() end, desc = "Toggle minimap" },
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { mini = true } },
+  opts = function()
+    local map = require "mini.map"
+    return {
+      integrations = {
+        map.gen_integration.builtin_search(),
+        map.gen_integration.gitsigns(),
+        map.gen_integration.diagnostic {
+          error = "DiagnosticFloatingError",
+          warn = "DiagnosticFloatingWarn",
+          info = "DiagnosticFloatingInfo",
+          hint = "DiagnosticFloatingHint",
+        },
+      },
+      symbols = {
+        encode = map.gen_encode_symbols.dot "3x2",
+      },
+      window = {
+        side = "right",
+        width = 22,
+        winblend = 5,
+        show_integration_count = true,
+      },
+    }
+  end,
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { mini = true } },
+    },
   },
 }

--- a/lua/astrocommunity/startup/fsplash-nvim/init.lua
+++ b/lua/astrocommunity/startup/fsplash-nvim/init.lua
@@ -1,47 +1,47 @@
 return {
-  { "goolord/alpha-nvim", enabled = false },
-  {
-    "jovanlanik/fsplash.nvim",
-    dependencies = {
-      "AstroNvim/astrocore",
-      opts = {
-        autocmds = {
-          fsplash_autostart = {
-            {
-              event = "VimEnter",
-              desc = "Start fsplash when vim is opened with no arguments",
-              callback = function()
-                local should_skip = false
-                if vim.fn.argc() > 0 or vim.fn.line2byte(vim.fn.line "$") ~= -1 or not vim.o.modifiable then
-                  should_skip = true
-                else
-                  for _, arg in pairs(vim.v.argv) do
-                    if arg == "-b" or arg == "-c" or vim.startswith(arg, "+") or arg == "-S" then
-                      should_skip = true
-                      break
-                    end
+  "jovanlanik/fsplash.nvim",
+  dependencies = {
+    "AstroNvim/astrocore",
+    opts = {
+      autocmds = {
+        fsplash_autostart = {
+          {
+            event = "VimEnter",
+            desc = "Start fsplash when vim is opened with no arguments",
+            callback = function()
+              local should_skip = false
+              if vim.fn.argc() > 0 or vim.fn.line2byte(vim.fn.line "$") ~= -1 or not vim.o.modifiable then
+                should_skip = true
+              else
+                for _, arg in pairs(vim.v.argv) do
+                  if arg == "-b" or arg == "-c" or vim.startswith(arg, "+") or arg == "-S" then
+                    should_skip = true
+                    break
                   end
                 end
-                if not should_skip then require("fsplash").open_window() end
-              end,
-            },
+              end
+              if not should_skip then require("fsplash").open_window() end
+            end,
           },
         },
       },
     },
-    opts = {
-      lines = {
-        "    ___         __             _   __      _         ",
-        "   /   |  _____/ /__________  / | / /   __(_)___ ___ ",
-        "  / /| | / ___/ __/ ___/ __ \\/  |/ / | / / / __ `__ \\",
-        " / ___ |(__  ) /_/ /  / /_/ / /|  /| |/ / / / / / / /",
-        "/_/  |_/____/\\__/_/   \\____/_/ |_/ |___/_/_/ /_/ /_/ ",
-      },
-      border = "none",
-      highlights = {
-        NormalFloat = { link = "Normal" },
-      },
+  },
+  specs = {
+    { "goolord/alpha-nvim", optional = true, enabled = false },
+    { "stevearc/resession.nvim", optional = true, opts = { extensions = { fsplash = {} } } },
+  },
+  opts = {
+    lines = {
+      "    ___         __             _   __      _         ",
+      "   /   |  _____/ /__________  / | / /   __(_)___ ___ ",
+      "  / /| | / ___/ __/ ___/ __ \\/  |/ / | / / / __ `__ \\",
+      " / ___ |(__  ) /_/ /  / /_/ / /|  /| |/ / / / / / / /",
+      "/_/  |_/____/\\__/_/   \\____/_/ |_/ |___/_/_/ /_/ /_/ ",
+    },
+    border = "none",
+    highlights = {
+      NormalFloat = { link = "Normal" },
     },
   },
-  { "stevearc/resession.nvim", optional = true, opts = { extensions = { fsplash = {} } } },
 }

--- a/lua/astrocommunity/startup/mini-starter/init.lua
+++ b/lua/astrocommunity/startup/mini-starter/init.lua
@@ -1,27 +1,27 @@
 return {
-  { "goolord/alpha-nvim", enabled = false },
-  {
-    "echasnovski/mini.starter",
-    version = "*", -- stable version
-    config = function() require("mini.starter").setup() end,
-  },
-  {
-    "AstroNvim/astrocore",
-    optional = true,
-    ---@type AstroCoreOpts
-    opts = {
-      mappings = {
-        n = {
-          ["<Leader>c"] = {
-            function()
-              local bufs = vim.fn.getbufinfo { buflisted = true }
-              require("astrocore.buffer").close(0)
-              if require("astrocore").is_available "mini.starter" and not bufs[2] then
-                require("mini.starter").open()
-                require("astrocore.buffer").close_all(true) -- remove empty buffer
-              end
-            end,
-            desc = "Close buffer",
+  "echasnovski/mini.starter",
+  version = "*", -- stable version
+  config = function() require("mini.starter").setup() end,
+  specs = {
+    { "goolord/alpha-nvim", optional = true, enabled = false },
+    {
+      "AstroNvim/astrocore",
+      optional = true,
+      ---@type AstroCoreOpts
+      opts = {
+        mappings = {
+          n = {
+            ["<Leader>c"] = {
+              function()
+                local bufs = vim.fn.getbufinfo { buflisted = true }
+                require("astrocore.buffer").close(0)
+                if require("astrocore").is_available "mini.starter" and not bufs[2] then
+                  require("mini.starter").open()
+                  require("astrocore.buffer").close_all(true) -- remove empty buffer
+                end
+              end,
+              desc = "Close buffer",
+            },
           },
         },
       },

--- a/lua/astrocommunity/syntax/vim-sandwich/init.lua
+++ b/lua/astrocommunity/syntax/vim-sandwich/init.lua
@@ -1,29 +1,29 @@
 return {
-  {
-    "machakann/vim-sandwich",
-    dependencies = {
-      "AstroNvim/astrocore",
-      opts = function(_, opts)
-        opts.options.g.sandwich_no_default_key_mappings = true
+  "machakann/vim-sandwich",
+  dependencies = {
+    "AstroNvim/astrocore",
+    opts = function(_, opts)
+      opts.options.g.sandwich_no_default_key_mappings = true
 
-        local maps = assert(opts.mappings)
-        maps.n.sa = { "<Plug>(sandwich-add)", desc = "Add surrounding" }
-        maps.o.sa = maps.n.sa
-        maps.x.sa = maps.n.sa
-        maps.n.sd = { "<Plug>(sandwich-delete)", desc = "Delete surrounding" }
-        maps.n.sr = { "<Plug>(sandwich-replace)", desc = "Replace surrounding" }
-      end,
-    },
-    keys = {
-      { "<Plug>(sandwich-add)", mode = { "n", "x", "o" } },
-      "<Plug>(sandwich-delete)",
-      "<Plug>(sandwich-replace)",
+      local maps = assert(opts.mappings)
+      maps.n.sa = { "<Plug>(sandwich-add)", desc = "Add surrounding" }
+      maps.o.sa = maps.n.sa
+      maps.x.sa = maps.n.sa
+      maps.n.sd = { "<Plug>(sandwich-delete)", desc = "Delete surrounding" }
+      maps.n.sr = { "<Plug>(sandwich-replace)", desc = "Replace surrounding" }
+    end,
+  },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { sandwich = true } },
     },
   },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { sandwich = true } },
+  keys = {
+    { "<Plug>(sandwich-add)", mode = { "n", "x", "o" } },
+    "<Plug>(sandwich-delete)",
+    "<Plug>(sandwich-replace)",
   },
 }

--- a/lua/astrocommunity/test/neotest/init.lua
+++ b/lua/astrocommunity/test/neotest/init.lua
@@ -1,63 +1,63 @@
 local prefix = "<Leader>T"
 return {
-  {
-    "nvim-neotest/neotest",
-    lazy = true,
-    dependencies = {
-      "nvim-lua/plenary.nvim",
-      "nvim-neotest/nvim-nio",
-      {
-        "AstroNvim/astrocore",
-        opts = {
-          mappings = {
-            n = {
-              [prefix] = { desc = "󰗇 Tests" },
-              [prefix .. "t"] = { function() require("neotest").run.run() end, desc = "Run test" },
-              [prefix .. "d"] = { function() require("neotest").run.run { strategy = "dap" } end, desc = "Debug test" },
-              [prefix .. "f"] = {
-                function() require("neotest").run.run(vim.fn.expand "%") end,
-                desc = "Run all tests in file",
-              },
-              [prefix .. "p"] = {
-                function() require("neotest").run.run(vim.fn.getcwd()) end,
-                desc = "Run all tests in project",
-              },
-              [prefix .. "<CR>"] = { function() require("neotest").summary.toggle() end, desc = "Test Summary" },
-              [prefix .. "o"] = { function() require("neotest").output.open() end, desc = "Output hover" },
-              [prefix .. "O"] = { function() require("neotest").output_panel.toggle() end, desc = "Output window" },
-              ["]T"] = { function() require("neotest").jump.next() end, desc = "Next test" },
-              ["[T"] = { function() require("neotest").jump.prev() end, desc = "previous test" },
+  "nvim-neotest/neotest",
+  lazy = true,
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "nvim-neotest/nvim-nio",
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        mappings = {
+          n = {
+            [prefix] = { desc = "󰗇 Tests" },
+            [prefix .. "t"] = { function() require("neotest").run.run() end, desc = "Run test" },
+            [prefix .. "d"] = { function() require("neotest").run.run { strategy = "dap" } end, desc = "Debug test" },
+            [prefix .. "f"] = {
+              function() require("neotest").run.run(vim.fn.expand "%") end,
+              desc = "Run all tests in file",
             },
+            [prefix .. "p"] = {
+              function() require("neotest").run.run(vim.fn.getcwd()) end,
+              desc = "Run all tests in project",
+            },
+            [prefix .. "<CR>"] = { function() require("neotest").summary.toggle() end, desc = "Test Summary" },
+            [prefix .. "o"] = { function() require("neotest").output.open() end, desc = "Output hover" },
+            [prefix .. "O"] = { function() require("neotest").output_panel.toggle() end, desc = "Output window" },
+            ["]T"] = { function() require("neotest").jump.next() end, desc = "Next test" },
+            ["[T"] = { function() require("neotest").jump.prev() end, desc = "previous test" },
           },
         },
       },
-      {
-        "folke/neodev.nvim",
-        opts = function(_, opts)
-          opts.library = opts.library or {}
-          if opts.library.plugins ~= true then
-            opts.library.plugins = require("astrocore").list_insert_unique(opts.library.plugins, { "neotest" })
-          end
-          opts.library.types = true
+    },
+    {
+      "folke/neodev.nvim",
+      opts = function(_, opts)
+        opts.library = opts.library or {}
+        if opts.library.plugins ~= true then
+          opts.library.plugins = require("astrocore").list_insert_unique(opts.library.plugins, { "neotest" })
+        end
+        opts.library.types = true
+      end,
+    },
+  },
+  specs = {
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { neotest = true } },
+    },
+  },
+  config = function(_, opts)
+    vim.diagnostic.config({
+      virtual_text = {
+        format = function(diagnostic)
+          local message = diagnostic.message:gsub("\n", " "):gsub("\t", " "):gsub("%s+", " "):gsub("^%s+", "")
+          return message
         end,
       },
-    },
-    config = function(_, opts)
-      vim.diagnostic.config({
-        virtual_text = {
-          format = function(diagnostic)
-            local message = diagnostic.message:gsub("\n", " "):gsub("\t", " "):gsub("%s+", " "):gsub("^%s+", "")
-            return message
-          end,
-        },
-      }, vim.api.nvim_create_namespace "neotest")
-      require("neotest").setup(opts)
-    end,
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { neotest = true } },
-  },
+    }, vim.api.nvim_create_namespace "neotest")
+    require("neotest").setup(opts)
+  end,
 }

--- a/lua/astrocommunity/utility/mason-tool-installer-nvim/init.lua
+++ b/lua/astrocommunity/utility/mason-tool-installer-nvim/init.lua
@@ -6,45 +6,45 @@ local setup_without_ensure_installed = function(main, opts)
 end
 
 return {
-  {
-    "WhoIsSethDaniel/mason-tool-installer.nvim",
-    cmd = {
-      "MasonToolsInstall",
-      "MasonToolsInstallSync",
-      "MasonToolsUpdate",
-      "MasonToolsUpdateSync",
-      "MasonToolsClean",
+  "WhoIsSethDaniel/mason-tool-installer.nvim",
+  cmd = {
+    "MasonToolsInstall",
+    "MasonToolsInstallSync",
+    "MasonToolsUpdate",
+    "MasonToolsUpdateSync",
+    "MasonToolsClean",
+  },
+  dependencies = { "williamboman/mason.nvim" },
+  init = function(plugin) require("astrocore").on_load("mason.nvim", plugin.name) end,
+  opts_extend = { "ensure_installed" },
+  opts = {
+    ensure_installed = {},
+    integrations = { ["mason-lspconfig"] = false, ["mason-null-ls"] = false, ["mason-nvim-dap"] = false },
+  },
+  config = function(_, opts)
+    local mason_tool_installer = require "mason-tool-installer"
+    mason_tool_installer.setup(opts)
+    if opts.run_on_start ~= false then mason_tool_installer.run_on_start() end
+  end,
+  specs = {
+    -- disable init and ensure installed of other plugins
+    {
+      "jay-babu/mason-nvim-dap.nvim",
+      optional = true,
+      init = false,
+      config = function(_, opts) setup_without_ensure_installed("mason-nvim-dap", opts) end,
     },
-    dependencies = { "williamboman/mason.nvim" },
-    init = function(plugin) require("astrocore").on_load("mason.nvim", plugin.name) end,
-    opts_extend = { "ensure_installed" },
-    opts = {
-      ensure_installed = {},
-      integrations = { ["mason-lspconfig"] = false, ["mason-null-ls"] = false, ["mason-nvim-dap"] = false },
+    {
+      "williamboman/mason-lspconfig.nvim",
+      optional = true,
+      init = false,
+      config = function(_, opts) setup_without_ensure_installed("mason-lspconfig", opts) end,
     },
-    config = function(_, opts)
-      local mason_tool_installer = require "mason-tool-installer"
-      mason_tool_installer.setup(opts)
-      if opts.run_on_start ~= false then mason_tool_installer.run_on_start() end
-    end,
-  },
-  -- disable init and ensure installed of other plugins
-  {
-    "jay-babu/mason-nvim-dap.nvim",
-    optional = true,
-    init = false,
-    config = function(_, opts) setup_without_ensure_installed("mason-nvim-dap", opts) end,
-  },
-  {
-    "williamboman/mason-lspconfig.nvim",
-    optional = true,
-    init = false,
-    config = function(_, opts) setup_without_ensure_installed("mason-lspconfig", opts) end,
-  },
-  {
-    "jay-babu/mason-null-ls.nvim",
-    optional = true,
-    init = false,
-    config = function(_, opts) setup_without_ensure_installed("mason-null-ls", opts) end,
+    {
+      "jay-babu/mason-null-ls.nvim",
+      optional = true,
+      init = false,
+      config = function(_, opts) setup_without_ensure_installed("mason-null-ls", opts) end,
+    },
   },
 }

--- a/lua/astrocommunity/utility/noice-nvim/init.lua
+++ b/lua/astrocommunity/utility/noice-nvim/init.lua
@@ -1,82 +1,82 @@
 return {
-  {
-    "nvim-treesitter/nvim-treesitter",
-    opts = function(_, opts)
-      if opts.ensure_installed ~= "all" then
-        opts.ensure_installed = require("astrocore").list_insert_unique(
-          opts.ensure_installed,
-          { "bash", "markdown", "markdown_inline", "regex", "vim" }
-        )
-      end
-    end,
-  },
-  {
-    "AstroNvim/astrolsp",
-    optional = true,
-    ---@param opts AstroLSPOpts
-    opts = function(_, opts)
-      local noice_opts = require("astrocore").plugin_opts "noice.nvim"
-      -- disable the necessary handlers in AstroLSP
-      if not opts.lsp_handlers then opts.lsp_handlers = {} end
-      if vim.tbl_get(noice_opts, "lsp", "hover", "enabled") ~= false then
-        opts.lsp_handlers["textDocument/hover"] = false
-      end
-      if vim.tbl_get(noice_opts, "lsp", "signature", "enabled") ~= false then
-        opts.lsp_handlers["textDocument/signatureHelp"] = false
-      end
-    end,
-  },
-  {
-    "heirline.nvim",
-    optional = true,
-    opts = function(_, opts)
-      local noice_opts = require("astrocore").plugin_opts "noice.nvim"
-      if vim.tbl_get(noice_opts, "lsp", "progress", "enabled") ~= false then -- check if lsp progress is enabled
-        opts.statusline[9] = require("astroui.status").component.lsp { lsp_progress = false }
-      end
-    end,
-  },
-  {
-    "folke/noice.nvim",
-    event = "VeryLazy",
-    dependencies = { "MunifTanjim/nui.nvim" },
-    opts = function(_, opts)
-      local utils = require "astrocore"
-      return utils.extend_tbl(opts, {
-        lsp = {
-          -- override markdown rendering so that **cmp** and other plugins use **Treesitter**
-          override = {
-            ["vim.lsp.util.convert_input_to_markdown_lines"] = true,
-            ["vim.lsp.util.stylize_markdown"] = true,
-            ["cmp.entry.get_documentation"] = true,
-          },
+  "folke/noice.nvim",
+  event = "VeryLazy",
+  dependencies = { "MunifTanjim/nui.nvim" },
+  opts = function(_, opts)
+    local utils = require "astrocore"
+    return utils.extend_tbl(opts, {
+      lsp = {
+        -- override markdown rendering so that **cmp** and other plugins use **Treesitter**
+        override = {
+          ["vim.lsp.util.convert_input_to_markdown_lines"] = true,
+          ["vim.lsp.util.stylize_markdown"] = true,
+          ["cmp.entry.get_documentation"] = true,
         },
-        presets = {
-          bottom_search = true, -- use a classic bottom cmdline for search
-          command_palette = true, -- position the cmdline and popupmenu together
-          long_message_to_split = true, -- long messages will be sent to a split
-          inc_rename = utils.is_available "inc-rename.nvim", -- enables an input dialog for inc-rename.nvim
-          lsp_doc_border = false, -- add a border to hover docs and signature help
-        },
-      })
-    end,
-  },
-  {
-    "folke/edgy.nvim",
-    optional = true,
-    opts = function(_, opts)
-      if not opts.bottom then opts.bottom = {} end
-      table.insert(opts.bottom, {
-        ft = "noice",
-        size = { height = 0.4 },
-        filter = function(_, win) return vim.api.nvim_win_get_config(win).relative == "" end,
-      })
-    end,
-  },
-  {
-    "catppuccin",
-    optional = true,
-    ---@type CatppuccinOptions
-    opts = { integrations = { noice = true } },
+      },
+      presets = {
+        bottom_search = true, -- use a classic bottom cmdline for search
+        command_palette = true, -- position the cmdline and popupmenu together
+        long_message_to_split = true, -- long messages will be sent to a split
+        inc_rename = utils.is_available "inc-rename.nvim", -- enables an input dialog for inc-rename.nvim
+        lsp_doc_border = false, -- add a border to hover docs and signature help
+      },
+    })
+  end,
+  specs = {
+    {
+      "nvim-treesitter/nvim-treesitter",
+      opts = function(_, opts)
+        if opts.ensure_installed ~= "all" then
+          opts.ensure_installed = require("astrocore").list_insert_unique(
+            opts.ensure_installed,
+            { "bash", "markdown", "markdown_inline", "regex", "vim" }
+          )
+        end
+      end,
+    },
+    {
+      "AstroNvim/astrolsp",
+      optional = true,
+      ---@param opts AstroLSPOpts
+      opts = function(_, opts)
+        local noice_opts = require("astrocore").plugin_opts "noice.nvim"
+        -- disable the necessary handlers in AstroLSP
+        if not opts.lsp_handlers then opts.lsp_handlers = {} end
+        if vim.tbl_get(noice_opts, "lsp", "hover", "enabled") ~= false then
+          opts.lsp_handlers["textDocument/hover"] = false
+        end
+        if vim.tbl_get(noice_opts, "lsp", "signature", "enabled") ~= false then
+          opts.lsp_handlers["textDocument/signatureHelp"] = false
+        end
+      end,
+    },
+    {
+      "heirline.nvim",
+      optional = true,
+      opts = function(_, opts)
+        local noice_opts = require("astrocore").plugin_opts "noice.nvim"
+        if vim.tbl_get(noice_opts, "lsp", "progress", "enabled") ~= false then -- check if lsp progress is enabled
+          opts.statusline[9] = require("astroui.status").component.lsp { lsp_progress = false }
+        end
+      end,
+    },
+    {
+      "folke/edgy.nvim",
+      optional = true,
+      opts = function(_, opts)
+        if not opts.bottom then opts.bottom = {} end
+        table.insert(opts.bottom, {
+          ft = "noice",
+          size = { height = 0.4 },
+          filter = function(_, win) return vim.api.nvim_win_get_config(win).relative == "" end,
+        })
+      end,
+    },
+    {
+      "catppuccin",
+      optional = true,
+      ---@type CatppuccinOptions
+      opts = { integrations = { noice = true } },
+    },
   },
 }

--- a/lua/astrocommunity/utility/telescope-coc-nvim/init.lua
+++ b/lua/astrocommunity/utility/telescope-coc-nvim/init.lua
@@ -1,12 +1,18 @@
 return {
-  "nvim-telescope/telescope.nvim",
-  dependencies = { "fannheyward/telescope-coc.nvim" },
-  opts = function(_, opts)
-    require("telescope").load_extension "coc"
-    if not opts.extensions then opts.extensions = {} end
-    opts.extensions.coc = {
-      theme = "ivy",
-      prefer_locations = true, -- always use Telescope locations to preview definitions/declarations/implementations etc
-    }
-  end,
+  "fannheyward/telescope-coc.nvim",
+  lazy = true,
+  specs = {
+    {
+      "nvim-telescope/telescope.nvim",
+      dependencies = { "fannheyward/telescope-coc.nvim" },
+      opts = function(_, opts)
+        require("telescope").load_extension "coc"
+        if not opts.extensions then opts.extensions = {} end
+        opts.extensions.coc = {
+          theme = "ivy",
+          prefer_locations = true, -- always use Telescope locations to preview definitions/declarations/implementations etc
+        }
+      end,
+    },
+  },
 }

--- a/lua/astrocommunity/utility/telescope-fzy-native-nvim/init.lua
+++ b/lua/astrocommunity/utility/telescope-fzy-native-nvim/init.lua
@@ -1,12 +1,16 @@
 return {
-  {
-    "nvim-telescope/telescope.nvim",
-    dependencies = { "nvim-telescope/telescope-fzy-native.nvim" },
-    opts = function() require("telescope").load_extension "fzy_native" end,
-  },
-  {
-    "NeogitOrg/neogit",
-    optional = true,
-    opts = { telescope_sorter = function() return require("telescope").extensions.fzy_native.native_fzy_sorter() end },
+  "nvim-telescope/telescope-fzy-native.nvim",
+  lazy = true,
+  specs = {
+    {
+      "nvim-telescope/telescope.nvim",
+      dependencies = { "nvim-telescope/telescope-fzy-native.nvim" },
+      opts = function() require("telescope").load_extension "fzy_native" end,
+    },
+    {
+      "NeogitOrg/neogit",
+      optional = true,
+      opts = { telescope_sorter = function() return require("telescope").extensions.fzy_native.native_fzy_sorter() end },
+    },
   },
 }

--- a/lua/astrocommunity/utility/telescope-lazy-nvim/init.lua
+++ b/lua/astrocommunity/utility/telescope-lazy-nvim/init.lua
@@ -1,5 +1,11 @@
 return {
-  "nvim-telescope/telescope.nvim",
-  dependencies = { "tsakirist/telescope-lazy.nvim" },
-  opts = function() require("telescope").load_extension "lazy" end,
+  "tsakirist/telescope-lazy.nvim",
+  lazy = true,
+  specs = {
+    {
+      "nvim-telescope/telescope.nvim",
+      dependencies = { "tsakirist/telescope-lazy.nvim" },
+      opts = function() require("telescope").load_extension "lazy" end,
+    },
+  },
 }

--- a/lua/astrocommunity/utility/telescope-live-grep-args-nvim/init.lua
+++ b/lua/astrocommunity/utility/telescope-live-grep-args-nvim/init.lua
@@ -1,5 +1,11 @@
 return {
-  "nvim-telescope/telescope.nvim",
-  dependencies = { "nvim-telescope/telescope-live-grep-args.nvim" },
-  opts = function() require("telescope").load_extension "live_grep_args" end,
+  "nvim-telescope/telescope-live-grep-args.nvim",
+  lazy = true,
+  specs = {
+    {
+      "nvim-telescope/telescope.nvim",
+      dependencies = { "nvim-telescope/telescope-live-grep-args.nvim" },
+      opts = function() require("telescope").load_extension "live_grep_args" end,
+    },
+  },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This moves all of the AstroCommunity specs to utilizing the relatively new `specs` table key in Lazy plugins. This allows the specification of plugin specs that are "owned" by a plugin but are not dependencies that are loaded at the time of the plugin. This makes sure that all plugins in AstroCommunity can be disabled on the user side with `{ "<plugin_name>", enabled = false }` and it will be as if the plugin is not imported. This is great for users who may toggle plugins regularly for testing or whatever reason they have.

### TODO

- [x] Update the review checklist to add a new requirement that all plugin entries only return a single plugin spec that is the plugin at the top level and all other specs are included in `spec` to maintain this pattern


