### PR TITLE
fix(just): use native treesitter parser

### DIFF
--- a/lua/astrocommunity/pack/just/init.lua
+++ b/lua/astrocommunity/pack/just/init.lua
@@ -17,18 +17,6 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
-    opts = function(_, opts)
-      local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
-      parser_config.just = {
-        install_info = {
-          url = "https://github.com/IndianBoy42/tree-sitter-just", -- local path or git repo
-          files = { "src/parser.c", "src/scanner.cc" },
-          branch = "main",
-          use_makefile = true, -- this may be necessary on MacOS (try if you see compiler errors)
-        },
-        maintainers = { "@IndianBoy42" },
-      }
-      require("astrocore").list_insert_unique(opts.ensure_installed, { "just" })
-    end,
+    opts = function(_, opts) require("astrocore").list_insert_unique(opts.ensure_installed, { "just" }) end,
   },
 }


### PR DESCRIPTION
## 📑 Description

The just pack was create a while ago, when nvim-treesitter didn't yet have support for the syntax. However, this support has now been added (and it's been there for quite a while), so there's no reason to add it manually.

Additionally, it turns out the build instructions here are actually wrong, as the repo doesn't contain the `scanner.cc` file anymore, so using the pack actually causes an error when attempting to install the parser. (How did no one notice this? lol):

```
Downloading tree-sitter-just...                                                                         
Creating temporary directory                                                                            
Extracting tree-sitter-just...                                                                          
Compiling...                                                                                            
cc1plus: fatal error: src/scanner.cc: No such file or directory                                         
compilation terminated.                                                                                 
                                                                                                        
Error during compilation                                                                                
Failed to execute the following command:                                                                
{                                                                                                       
  cmd = "cc",                                                                                           
  err = "Error during compilation",                                                                     
  info = "Compiling...",                                                                                
  opts = {                                                                                              
    args = { "-o", "parser.so", "-I./src", "src/parser.c", "src/scanner.cc", "-Os", "-shared", "-lstdc++
", "-fPIC" },                                                                                           
    cwd = "/home/itsdrike/.local/share/nvim/tree-sitter-just"                                           
  }                                                                                                     
} 
Press ENTER or type command to continue 
```