### PR TITLE
fix(nix): Actually use nixd LSP

### DIFF
--- a/lua/astrocommunity/pack/nix/init.lua
+++ b/lua/astrocommunity/pack/nix/init.lua
@@ -23,6 +23,10 @@ return {
     end,
   },
   {
+    "AstroNvim/astrolsp",
+    opts = function(_, opts) opts.servers = require("astrocore").extend_tbl(opts.servers, { "nixd" }) end,
+  },
+  {
     "stevearc/conform.nvim",
     optional = true,
     opts = {

--- a/lua/astrocommunity/pack/nix/init.lua
+++ b/lua/astrocommunity/pack/nix/init.lua
@@ -24,7 +24,7 @@ return {
   },
   {
     "AstroNvim/astrolsp",
-    opts = function(_, opts) opts.servers = require("astrocore").extend_tbl(opts.servers, { "nixd" }) end,
+    opts = function(_, opts) opts.servers = require("astrocore").list_insert_unique(opts.servers, { "nixd" }) end,
   },
   {
     "stevearc/conform.nvim",

--- a/lua/astrocommunity/pack/nix/init.lua
+++ b/lua/astrocommunity/pack/nix/init.lua
@@ -12,14 +12,12 @@ return {
     "nvimtools/none-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      local nls = require "null-ls"
-      if type(opts.sources) == "table" then
-        vim.list_extend(opts.sources, {
-          nls.builtins.code_actions.statix,
-          nls.builtins.formatting.alejandra,
-          nls.builtins.diagnostics.deadnix,
-        })
-      end
+      local builtins = require("null-ls").builtins
+      opts.sources = require("astrocore").list_insert_unique(opts.sources, {
+        builtins.code_actions.statix,
+        builtins.formatting.alejandra,
+        builtins.diagnostics.deadnix,
+      })
     end,
   },
   {


### PR DESCRIPTION
## 📑 Description

In 44e8c959bb66a76a98efee588fe7bc56b8ecf754 an isssue with trying to install nixd via mason was fixed, by removing nixd from required mason packages and instead adding it as a required dependency for the pack, that should be present in the PATH.

However, normally, mason would've also registered nixd to lspconfig, but since mason isn't being used, nixd LSP was never registered, making this requirement pointless.

This actually registers nixd languge server through astrolsp plugin.