### PR TITLE
fix(grug-far-nvim): Disable Copilot in grug-far buffers

### DIFF
--- a/lua/astrocommunity/completion/copilot-lua/init.lua
+++ b/lua/astrocommunity/completion/copilot-lua/init.lua
@@ -2,5 +2,14 @@ return {
   "zbirenbaum/copilot.lua",
   cmd = "Copilot",
   event = "User AstroFile",
-  opts = { suggestion = { auto_trigger = true, debounce = 150 } },
+  opts = {
+    filetypes = {
+      ["grug-far"] = false,
+      ["grug-far-history"] = false,
+    },
+    suggestion = {
+      auto_trigger = true,
+      debounce = 150,
+    },
+  },
 }


### PR DESCRIPTION
## 📑 Description

The Copilot community config has a small conflict with the grug-far config. This change disabled Copilot in grug-far windows, preventing the issue.

## Additional Information

See MagicDuck/grug-far.nvim#101 for more info.