### PR TITLE
fix(trouble-nvim): prevent clashes with existing `<Leader>x` mappings

### DIFF
--- a/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
@@ -8,21 +8,15 @@ return {
       opts = function(_, opts)
         local maps = opts.mappings
         local prefix = "<Leader>x"
-        maps.n[prefix] = { desc = require("astroui").get_icon("Trouble", 1, true) .. "Trouble" }
-        maps.n[prefix .. "X"] = { "<Cmd>Trouble diagnostics toggle<CR>", desc = "Workspace Diagnostics (Trouble)" }
+        maps.n[prefix .. "X"] = { "<Cmd>Trouble diagnostics toggle<CR>", desc = "Trouble Workspace Diagnostics" }
         maps.n[prefix .. "x"] =
-          { "<Cmd>Trouble diagnostics toggle filter.buf=0<CR>", desc = "Document Diagnostics (Trouble)" }
-        maps.n[prefix .. "l"] = { "<Cmd>Trouble loclist toggle<CR>", desc = "Location List (Trouble)" }
-        maps.n[prefix .. "q"] = { "<Cmd>Trouble quickfix toggle<CR>", desc = "Quickfix List (Trouble)" }
+          { "<Cmd>Trouble diagnostics toggle filter.buf=0<CR>", desc = "Trouble Document Diagnostics" }
+        maps.n[prefix .. "L"] = { "<Cmd>Trouble loclist toggle<CR>", desc = "Trouble Location List" }
+        maps.n[prefix .. "Q"] = { "<Cmd>Trouble quickfix toggle<CR>", desc = "Trouble Quickfix List" }
         if require("astrocore").is_available "todo-comments.nvim" then
-          maps.n[prefix .. "t"] = {
-            "<cmd>Trouble todo<cr>",
-            desc = "Todo (Trouble)",
-          }
-          maps.n[prefix .. "T"] = {
-            "<cmd>Trouble todo filter={tag={TODO,FIX,FIXME}}<cr>",
-            desc = "Todo/Fix/Fixme (Trouble)",
-          }
+          maps.n[prefix .. "t"] = { "<cmd>Trouble todo<cr>", desc = "Trouble Todo" }
+          maps.n[prefix .. "T"] =
+            { "<cmd>Trouble todo filter={tag={TODO,FIX,FIXME}}<cr>", desc = "Trouble Todo/Fix/Fixme" }
         end
       end,
     },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This is to avoid clashes with the [recent addition of `<Leader>x` to AstroNvim](https://github.com/AstroNvim/AstroNvim/commit/99c2b13df7b4943b3f82ca772db3dfb8f13f42e7).

This PR has also simplified some mapping descriptions.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

<!-- ## ℹ Additional Information -->

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
