### PR TITLE
feat(pack): remove opinionated config from `rust` pack

### DIFF
--- a/lua/astrocommunity/pack/rust/README.md
+++ b/lua/astrocommunity/pack/rust/README.md
@@ -8,7 +8,7 @@ This plugin pack does the following:
 - Adds [TOML language support](../toml)
 
 > [!NOTE]
-> This pack DOES not add `rust_analyzer`. This should be managed by rustup. To add it to rustup, run:  `rustup component add rust-analyzer`
+> This pack DOES not add `rust_analyzer`. This should be managed by rustup. To add it to rustup, run: `rustup component add rust-analyzer`
 
 ## Additional LSP Configuration Tweaks
 
@@ -40,5 +40,26 @@ return {
       },
     },
   },
+}
+```
+
+## Use `cargo check` for `rust-analyzer.check.command`
+
+By default, this pack configures `rust-analyzer.check.command` to use `cargo clippy` instead of `cargo check`.
+
+In some cases (for example, on large projects where `cargo clippy` is slow), you may want to use `cargo check` instead.
+
+Currently, `rust-analyzer` itself cannot be configured per project, [adding `rust-analyzer.toml` support is still in progress](https://github.com/rust-lang/rust-analyzer/issues/13529).
+However, `rustaceanvim` [supports loading `rust-analyzer.json` files from the root of your project.](https://github.com/mrcjkb/rustaceanvim#how-to-dynamically-load-different-rust-analyzer-settings-per-project)
+If you want to use `cargo check` as your default `rust-analyzer.check.command`, you can create a `rust-analyzer.json` file in the root of your project with the following contents:
+For more information on the `rust-analyzer` configuration, see the [rust-analyzer documentation](https://rust-analyzer.github.io/manual.html#configuration).
+
+```json
+{
+  "rust-analyzer": {
+    "check": {
+      "command": "check"
+    }
+  }
 }
 ```

--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -26,21 +26,6 @@ return {
                   "--no-deps",
                 },
               },
-              assist = {
-                importEnforceGranularity = true,
-                importPrefix = "crate",
-              },
-              completion = {
-                postfix = {
-                  enable = false,
-                },
-              },
-              inlayHints = {
-                lifetimeElisionHints = {
-                  enable = true,
-                  useParameterNames = true,
-                },
-              },
             },
           },
         },


### PR DESCRIPTION
Closes #1109

## 📑 Description

Removes the opinionated `rust-analyzer` configuration except `cargo check` -> `cargo clippy`

