### PR TITLE
feat(test): add vim-test

### DIFF
--- a/lua/astrocommunity/test/vim-test/README.md
+++ b/lua/astrocommunity/test/vim-test/README.md
@@ -1,0 +1,5 @@
+# vim-test
+
+Run your tests at the speed of thought
+
+**Repository:** <https://github.com/vim-test/vim-test>

--- a/lua/astrocommunity/test/vim-test/init.lua
+++ b/lua/astrocommunity/test/vim-test/init.lua
@@ -1,0 +1,29 @@
+return {
+  {
+    "vim-test/vim-test",
+    cmd = { "TestNearest", "TestFile", "TestLast", "TestClass", "TestSuite", "TestVisit" },
+    dependencies = {
+      {
+        "AstroNvim/astrocore",
+        opts = function(_, opts)
+          local maps = opts.mappings
+          local prefix = "<Leader>T"
+          maps.n[prefix] = { desc = require("astroui").get_icon("VimTest", 1, true) .. "Testing" }
+
+          maps.n[prefix .. "n"] = { ":TestNearest<CR>", desc = "Test Nearest" }
+          maps.n[prefix .. "f"] = { ":TestFile<CR>", desc = "Test File" }
+          maps.n[prefix .. "l"] = { ":TestLast<CR>", desc = "Test Last" }
+          maps.n[prefix .. "c"] = { ":TestClass<CR>", desc = "Test Class" }
+          maps.n[prefix .. "s"] = { ":TestSuite<CR>", desc = "Test Suite" }
+          maps.n[prefix .. "v"] = { ":TestVisit<CR>", desc = "Test Visit" }
+
+          -- Set the strategy to open results in a vertical split
+          vim.g["test#strategy"] = "neovim"
+          vim.g["test#neovim#term_position"] = "vert"
+        end,
+      },
+      { "AstroNvim/astroui", opts = { icons = { VimTest = "󰙨" } } },
+    },
+    event = { "VeryLazy" },
+  },
+}

--- a/lua/astrocommunity/test/vim-test/init.lua
+++ b/lua/astrocommunity/test/vim-test/init.lua
@@ -1,34 +1,32 @@
 ---@type LazySpec
 return {
-  {
-    "vim-test/vim-test",
-    cmd = { "TestNearest", "TestFile", "TestLast", "TestClass", "TestSuite", "TestVisit" },
-    dependencies = {
-      {
-        "AstroNvim/astrocore",
-        ---@param opts AstroCoreOpts
-        opts = function(_, opts)
-          local maps = assert(opts.mappings)
+  "vim-test/vim-test",
+  cmd = { "TestNearest", "TestFile", "TestLast", "TestClass", "TestSuite", "TestVisit" },
+  dependencies = {
+    {
+      "AstroNvim/astrocore",
+      ---@param opts AstroCoreOpts
+      opts = function(_, opts)
+        local maps = assert(opts.mappings)
 
-          local prefix = "<Leader>T"
-          maps.n[prefix] = { desc = require("astroui").get_icon("VimTest", 1, true) .. "Testing" }
+        local prefix = "<Leader>T"
+        maps.n[prefix] = { desc = require("astroui").get_icon("VimTest", 1, true) .. "Testing" }
 
-          maps.n[prefix .. "n"] = { ":TestNearest<CR>", desc = "Test Nearest" }
-          maps.n[prefix .. "f"] = { ":TestFile<CR>", desc = "Test File" }
-          maps.n[prefix .. "l"] = { ":TestLast<CR>", desc = "Test Last" }
-          maps.n[prefix .. "c"] = { ":TestClass<CR>", desc = "Test Class" }
-          maps.n[prefix .. "s"] = { ":TestSuite<CR>", desc = "Test Suite" }
-          maps.n[prefix .. "v"] = { ":TestVisit<CR>", desc = "Test Visit" }
+        maps.n[prefix .. "n"] = { ":TestNearest<CR>", desc = "Test Nearest" }
+        maps.n[prefix .. "f"] = { ":TestFile<CR>", desc = "Test File" }
+        maps.n[prefix .. "l"] = { ":TestLast<CR>", desc = "Test Last" }
+        maps.n[prefix .. "c"] = { ":TestClass<CR>", desc = "Test Class" }
+        maps.n[prefix .. "s"] = { ":TestSuite<CR>", desc = "Test Suite" }
+        maps.n[prefix .. "v"] = { ":TestVisit<CR>", desc = "Test Visit" }
 
-          -- Set the strategy to open results in a vertical split
-          if not opts.options then opts.options = {} end
-          if not opts.options.g then opts.options.g = {} end
-          opts.options.g["test#strategy"] = "neovim"
-          opts.options.g["test#neovim#term_position"] = "vert"
-        end,
-      },
-      { "AstroNvim/astroui", opts = { icons = { VimTest = "󰙨" } } },
+        -- Set the strategy to open results in a vertical split
+        if not opts.options then opts.options = {} end
+        if not opts.options.g then opts.options.g = {} end
+        opts.options.g["test#strategy"] = "neovim"
+        opts.options.g["test#neovim#term_position"] = "vert"
+      end,
     },
-    event = { "VeryLazy" },
+    { "AstroNvim/astroui", opts = { icons = { VimTest = "󰙨" } } },
   },
+  event = { "VeryLazy" },
 }

--- a/lua/astrocommunity/test/vim-test/init.lua
+++ b/lua/astrocommunity/test/vim-test/init.lua
@@ -1,3 +1,4 @@
+---@type LazySpec
 return {
   {
     "vim-test/vim-test",
@@ -5,8 +6,10 @@ return {
     dependencies = {
       {
         "AstroNvim/astrocore",
+        ---@param opts AstroCoreOpts
         opts = function(_, opts)
-          local maps = opts.mappings
+          local maps = assert(opts.mappings)
+
           local prefix = "<Leader>T"
           maps.n[prefix] = { desc = require("astroui").get_icon("VimTest", 1, true) .. "Testing" }
 
@@ -18,6 +21,8 @@ return {
           maps.n[prefix .. "v"] = { ":TestVisit<CR>", desc = "Test Visit" }
 
           -- Set the strategy to open results in a vertical split
+          if not opts.options then opts.options = {} end
+          if not opts.options.g then opts.options.g = {} end
           opts.options.g["test#strategy"] = "neovim"
           opts.options.g["test#neovim#term_position"] = "vert"
         end,

--- a/lua/astrocommunity/test/vim-test/init.lua
+++ b/lua/astrocommunity/test/vim-test/init.lua
@@ -18,8 +18,8 @@ return {
           maps.n[prefix .. "v"] = { ":TestVisit<CR>", desc = "Test Visit" }
 
           -- Set the strategy to open results in a vertical split
-          vim.g["test#strategy"] = "neovim"
-          vim.g["test#neovim#term_position"] = "vert"
+          opts.options.g["test#strategy"] = "neovim"
+          opts.options.g["test#neovim#term_position"] = "vert"
         end,
       },
       { "AstroNvim/astroui", opts = { icons = { VimTest = "󰙨" } } },


### PR DESCRIPTION
## 📑 Description

Add support for vim-test which out of the box a wide range of languages, https://github.com/vim-test/vim-test?tab=readme-ov-file#features


## ℹ Additional Information

I've kept these since they seem like _reasonable defaults_ but I am happy to remove these
```
          vim.g["test#strategy"] = "neovim"
          vim.g["test#neovim#term_position"] = "vert"
```
