### PR TITLE
fix(conform-nvim): fix bug caused by wrongly typed opt

### DIFF
--- a/lua/astrocommunity/editing-support/conform-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/conform-nvim/init.lua
@@ -62,7 +62,7 @@ return {
     },
   },
   opts = {
-    default_format_opts = { lsp = "fallback" },
+    default_format_opts = { lsp_format = "fallback" },
     format_on_save = function(bufnr)
       if vim.g.autoformat == nil then vim.g.autoformat = true end
       local autoformat = vim.b[bufnr].autoformat


### PR DESCRIPTION
This PR fixes conform not falling back to the LSP for formatting introduced by 876032f. The last commit contains a typo, the proper name for the lsp option is `lsp_format`.
Currently the default config is "never", so formatting does not work if the LSP is the only formatter available.