### PR TITLE
fix(pack): fix stevearc/conform.nvim yaml setup

### DIFF
--- a/lua/astrocommunity/pack/yaml/init.lua
+++ b/lua/astrocommunity/pack/yaml/init.lua
@@ -61,7 +61,7 @@ return {
     optional = true,
     opts = {
       formatters_by_ft = {
-        yaml = { { "prettierd", "prettier" } },
+        yaml = { "prettierd", "prettier" },
       },
     },
   },


### PR DESCRIPTION
## 📑 Description

This PR updates stevearc/conform.nvim's setup, addressing the deprecation warning that comes up when opening any yaml file while using the yaml pack:
```
deprecated[conform]: The nested {} syntax to run the first formatter has been replaced by the stop_after_first option (see :help conform.format).
Support for the old syntax will be dropped on 2025-01-01.
```