### PR TITLE
feat(split-and-window): add colorful-winsep.nvim plugin

### DIFF
--- a/lua/astrocommunity/colorscheme/catppuccin/init.lua
+++ b/lua/astrocommunity/colorscheme/catppuccin/init.lua
@@ -25,6 +25,7 @@ return {
       ufo = true,
       which_key = true,
       window_picker = true,
+      colorful_winsep = { enabled = true, color = "lavender" },
     },
   },
   specs = {

--- a/lua/astrocommunity/split-and-window/colorful-winsep-nvim/README.md
+++ b/lua/astrocommunity/split-and-window/colorful-winsep-nvim/README.md
@@ -1,0 +1,5 @@
+# colorful-winsep.nvim
+
+Make your nvim window separators colorful with smooth animations
+
+**Repository:** <https://github.com/nvim-zh/colorful-winsep.nvim>

--- a/lua/astrocommunity/split-and-window/colorful-winsep-nvim/init.lua
+++ b/lua/astrocommunity/split-and-window/colorful-winsep-nvim/init.lua
@@ -1,0 +1,5 @@
+return {
+  "nvim-zh/colorful-winsep.nvim",
+  event = "WinLeave",
+  config = true,
+}

--- a/lua/astrocommunity/split-and-window/colorful-winsep-nvim/init.lua
+++ b/lua/astrocommunity/split-and-window/colorful-winsep-nvim/init.lua
@@ -1,5 +1,5 @@
 return {
   "nvim-zh/colorful-winsep.nvim",
   event = "WinLeave",
-  config = true,
+  opts = {},
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
This plugin adds beautiful colors to the borders of your split windows. Additionally, it includes a smooth and pleasant animation when switching between them.

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

This PR also adds colorful-winsep.nvim integration to the catppuccin colorscheme
_Note_: For some reason, the integration doesn't work when specified as an optional spec, so I had to include it in the Catppuccin plugin specification.
