### PR TITLE
feat(rust): update `rustaceanvim` to v5

### DIFF
--- a/lua/astrocommunity/pack/rust/README.md
+++ b/lua/astrocommunity/pack/rust/README.md
@@ -3,7 +3,7 @@
 This plugin pack does the following:
 
 - Adds `rust` Treesitter parsers
-- Adds [rustaceanvim](https://github.com/mrcjkb/rustaceanvim) for language specific tooling
+- Adds [rustaceanvim](https://github.com/mrcjkb/rustaceanvim) for language specific tooling (v4 or v5 depending on nvim version)
 - Adds [crates.nvim](https://github.com/Saecki/crates.nvim) for crate management
 - Adds [TOML language support](../toml)
 

--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -1,4 +1,4 @@
-return {
+local pack = {
   { import = "astrocommunity.pack.toml" },
   {
     "nvim-treesitter/nvim-treesitter",
@@ -47,14 +47,61 @@ return {
     end,
   },
   {
+    "Saecki/crates.nvim",
+    lazy = true,
+    dependencies = {
+      "AstroNvim/astrocore",
+      opts = {
+        autocmds = {
+          CmpSourceCargo = {
+            {
+              event = "BufRead",
+              desc = "Load crates.nvim into Cargo buffers",
+              pattern = "Cargo.toml",
+              callback = function()
+                require("cmp").setup.buffer { sources = { { name = "crates" } } }
+                require "crates"
+              end,
+            },
+          },
+        },
+      },
+    },
+    opts = {
+      completion = {
+        cmp = { enabled = true },
+        crates = {
+          enabled = true,
+        },
+      },
+      null_ls = {
+        enabled = true,
+        name = "crates.nvim",
+      },
+    },
+  },
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    opts = function(_, opts)
+      if not opts.adapters then opts.adapters = {} end
+      local rustaceanvim_avail, rustaceanvim = pcall(require, "rustaceanvim.neotest")
+      if rustaceanvim_avail then table.insert(opts.adapters, rustaceanvim) end
+    end,
+  },
+}
+
+if vim.fn.has "nvim-0.10" then
+  -- Rustaceanvim v5 supports neovim v0.10+
+  table.insert(pack, {
     "mrcjkb/rustaceanvim",
-    version = "^4",
+    version = "^5",
     ft = "rust",
     specs = {
       {
         "AstroNvim/astrolsp",
         optional = true,
-        ---@param opts AstroLSPOpts
+        ---@type AstroLSPOpts
         opts = {
           handlers = { rust_analyzer = false }, -- disable setup of `rust_analyzer`
         },
@@ -103,48 +150,70 @@ return {
       return { server = final_server, dap = { adapter = adapter }, tools = { enable_clippy = false } }
     end,
     config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
-  },
-  {
-    "Saecki/crates.nvim",
-    lazy = true,
-    dependencies = {
-      "AstroNvim/astrocore",
-      opts = {
-        autocmds = {
-          CmpSourceCargo = {
-            {
-              event = "BufRead",
-              desc = "Load crates.nvim into Cargo buffers",
-              pattern = "Cargo.toml",
-              callback = function()
-                require("cmp").setup.buffer { sources = { { name = "crates" } } }
-                require "crates"
-              end,
-            },
-          },
+  })
+else
+  -- TODO: Remove this with AstroNvim v5 when dropping Neovim v0.9 support
+  -- Rustaceanvim v4 is the last version that supports neovim v0.9
+  -- This is simply a copy/paste of the v4 configuration to be left alone just in case
+  -- the setup gets breaking changes and diverges.
+  table.insert(pack, {
+    "mrcjkb/rustaceanvim",
+    version = "^4",
+    ft = "rust",
+    specs = {
+      {
+        "AstroNvim/astrolsp",
+        optional = true,
+        ---@type AstroLSPOpts
+        opts = {
+          handlers = { rust_analyzer = false }, -- disable setup of `rust_analyzer`
         },
       },
     },
-    opts = {
-      completion = {
-        cmp = { enabled = true },
-        crates = {
-          enabled = true,
-        },
-      },
-      null_ls = {
-        enabled = true,
-        name = "crates.nvim",
-      },
-    },
-  },
-  {
-    "nvim-neotest/neotest",
-    optional = true,
-    opts = function(_, opts)
-      if not opts.adapters then opts.adapters = {} end
-      local rustaceanvim_avail, rustaceanvim = pcall(require, "rustaceanvim.neotest")
-      if rustaceanvim_avail then table.insert(opts.adapters, rustaceanvim) end
+    opts = function()
+      local adapter
+      local success, package = pcall(function() return require("mason-registry").get_package "codelldb" end)
+      local cfg = require "rustaceanvim.config"
+      if success then
+        local package_path = package:get_install_path()
+        local codelldb_path = package_path .. "/codelldb"
+        local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
+        local this_os = vim.loop.os_uname().sysname
+
+        -- The path in windows is different
+        if this_os:find "Windows" then
+          codelldb_path = package_path .. "\\extension\\adapter\\codelldb.exe"
+          liblldb_path = package_path .. "\\extension\\lldb\\bin\\liblldb.dll"
+        else
+          -- The liblldb extension is .so for linux and .dylib for macOS
+          liblldb_path = liblldb_path .. (this_os == "Linux" and ".so" or ".dylib")
+        end
+        adapter = cfg.get_codelldb_adapter(codelldb_path, liblldb_path)
+      else
+        adapter = cfg.get_codelldb_adapter()
+      end
+
+      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
+      local astrolsp_opts = (astrolsp_avail and astrolsp.lsp_opts "rust_analyzer") or {}
+      local server = {
+        ---@type table | (fun(project_root:string|nil, default_settings: table|nil):table) -- The rust-analyzer settings or a function that creates them.
+        settings = function(project_root, default_settings)
+          local astrolsp_settings = astrolsp_opts.settings or {}
+
+          local merge_table = require("astrocore").extend_tbl(default_settings or {}, astrolsp_settings)
+          local ra = require "rustaceanvim.config.server"
+          -- load_rust_analyzer_settings merges any found settings with the passed in default settings table and then returns that table
+          return ra.load_rust_analyzer_settings(project_root, {
+            settings_file_pattern = "rust-analyzer.json",
+            default_settings = merge_table,
+          })
+        end,
+      }
+      local final_server = require("astrocore").extend_tbl(astrolsp_opts, server)
+      return { server = final_server, dap = { adapter = adapter }, tools = { enable_clippy = false } }
     end,
-  },
-}
+    config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
+  })
+end
+
+return pack


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This updates to the new [Rustaceanvim v5 release](https://github.com/mrcjkb/rustaceanvim/releases/tag/5.0.0). This drops support for neovim v0.9. To add backwards compatibility I simply copied the entired of the spec. This protects against if the `opts` change between the two or something the previous version will always be correct.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
