### PR TITLE
feat(haskell): update `haskell-tools` to v4

### DIFF
--- a/lua/astrocommunity/pack/haskell/README.md
+++ b/lua/astrocommunity/pack/haskell/README.md
@@ -3,22 +3,21 @@
 Requires:
 
 - plenary.nvim: Since v3 droppped this requirement, it is handled by the pack
-during install.
+  during install.
 
 Optionally:
 
 - A local [hoogle](https://github.com/ndmitchell/hoogle) installation
-(recommended by haskell-tools)
+  (recommended by haskell-tools)
 - [fast-tags](https://github.com/elaforge/fast-tags) (recommended by
-haskell-tools)
+  haskell-tools)
 
 This plugin pack does the following:
 
 - Adds `haskell` treesitter parsers
 - Adds `haskell-language-server` language server
 - Adds `haskell-debug-adapter` dap adapter
-- Adds [haskell-tools.nvim](https://github.com/mrcjkb/haskell-tools.nvim)
-(either v2 or v3 depending on nvim version)
+- Adds [haskell-tools.nvim](https://github.com/mrcjkb/haskell-tools.nvim) (v3 or v4 depending on nvim version)
 - Adds `yaml` language pack
 - Adds `json` language pack
 - Adds `neotest` from Astrocommunity

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -4,7 +4,7 @@ local is_available = function(plugin)
 end
 local haskell_ft = { "haskell", "lhaskell", "cabal", "cabalproject" }
 
-return {
+local pack = {
   { import = "astrocommunity.pack.yaml" }, -- stack.yaml
   { import = "astrocommunity.pack.json" }, -- hls.json
   { import = "astrocommunity.test.neotest" }, -- neotest-haskell
@@ -15,32 +15,6 @@ return {
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "haskell" })
       end
-    end,
-  },
-  {
-    "mrcjkb/haskell-tools.nvim",
-    ft = haskell_ft,
-    dependencies = {
-      -- vim.fn.has >= nvim 0.9 removes plenary dependency
-      { "nvim-lua/plenary.nvim", optional = vim.fn.has "nvim-0.9" == 1 },
-      { "nvim-telescope/telescope.nvim", optional = true },
-      { "mfussenegger/nvim-dap", optional = true },
-      {
-        "AstroNvim/astrolsp",
-        ---@type AstroLSPOpts
-        opts = {
-          ---@diagnostic disable: missing-fields
-          handlers = { hls = false },
-        },
-      },
-    },
-    -- vim.fn.has >= nvim 0.9 installs version 3
-    version = vim.fn.has "nvim-0.9" == 1 and "^3" or "^2",
-    init = function()
-      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
-      vim.g.haskell_tools = require("astrocore").extend_tbl({
-        hls = astrolsp_avail and { capabilities = astrolsp.config.capabilities, on_attach = astrolsp.on_attach } or {},
-      }, vim.g.haskell_tools)
     end,
   },
   {
@@ -99,3 +73,64 @@ return {
     end,
   },
 }
+
+if vim.fn.has "nvim-0.10" == 1 then
+  -- haskell-tools v4 supports neovim v0.10+
+  table.insert(pack, {
+    "mrcjkb/haskell-tools.nvim",
+    ft = haskell_ft,
+    dependencies = {
+      -- vim.fn.has >= nvim 0.9 removes plenary dependency
+      { "nvim-lua/plenary.nvim", optional = vim.fn.has "nvim-0.9" == 1 },
+      { "nvim-telescope/telescope.nvim", optional = true },
+      { "mfussenegger/nvim-dap", optional = true },
+      {
+        "AstroNvim/astrolsp",
+        ---@type AstroLSPOpts
+        opts = {
+          ---@diagnostic disable: missing-fields
+          handlers = { hls = false },
+        },
+      },
+    },
+    version = "^4",
+    init = function()
+      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
+      vim.g.haskell_tools = require("astrocore").extend_tbl({
+        hls = astrolsp_avail and { capabilities = astrolsp.config.capabilities, on_attach = astrolsp.on_attach } or {},
+      }, vim.g.haskell_tools)
+    end,
+  })
+else
+  -- TODO: Remove this with AstroNvim v5 when dropping Neovim v0.9 support
+  -- haskell-tools v3 is the last version that supports neovim v0.9
+  -- This is simply a copy/paste of the v3 configuration to be left alone just in case
+  -- the setup gets breaking changes and diverges.
+  table.insert(pack, {
+    "mrcjkb/haskell-tools.nvim",
+    ft = haskell_ft,
+    dependencies = {
+      -- vim.fn.has >= nvim 0.9 removes plenary dependency
+      { "nvim-lua/plenary.nvim", optional = vim.fn.has "nvim-0.9" == 1 },
+      { "nvim-telescope/telescope.nvim", optional = true },
+      { "mfussenegger/nvim-dap", optional = true },
+      {
+        "AstroNvim/astrolsp",
+        ---@type AstroLSPOpts
+        opts = {
+          ---@diagnostic disable: missing-fields
+          handlers = { hls = false },
+        },
+      },
+    },
+    version = "^3",
+    init = function()
+      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
+      vim.g.haskell_tools = require("astrocore").extend_tbl({
+        hls = astrolsp_avail and { capabilities = astrolsp.config.capabilities, on_attach = astrolsp.on_attach } or {},
+      }, vim.g.haskell_tools)
+    end,
+  })
+end
+
+return pack


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description


This updates to the new [haskell-tools v4 release](https://github.com/mrcjkb/haskell-tools.nvim/releases/tag/4.0.0). This drops support for neovim v0.9. To add backwards compatibility I simply copied the entired of the spec. This protects against if the `opts` change between the two or something the previous version will always be correct.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
