### PR TITLE
feat(debugging): add `quicker.nvim`

### DIFF
--- a/lua/astrocommunity/debugging/nvim-bqf/README.md
+++ b/lua/astrocommunity/debugging/nvim-bqf/README.md
@@ -1,5 +1,3 @@
 # nvim-bqf
 
-Better quickfix window in Neovim, polish old quickfix window.
-
-**Repository:** <https://github.com/kevinhwang91/nvim-bqf>
+**DEPRECATED** Use the new location: [`quickfix/nvim-bqf`](/lua/astrocommunity/quickfix/nvim-bqf)

--- a/lua/astrocommunity/debugging/nvim-bqf/init.lua
+++ b/lua/astrocommunity/debugging/nvim-bqf/init.lua
@@ -1,13 +1,5 @@
-return {
-  "kevinhwang91/nvim-bqf",
-  ft = "qf",
-  dependencies = {
-    "AstroNvim/astrocore",
-    ---@param opts AstroCoreOpts
-    opts = function(_, opts)
-      if not opts.signs then opts.signs = {} end
-      opts.signs.BqfSign = { text = " " .. require("astroui").get_icon "Selected", texthl = "BqfSign" }
-    end,
-  },
-  opts = {},
-}
+vim.notify(
+  "**DEPRECATED** astrocommunity.debugging.nvim-bqf\n\nPlease use new location:\n`astrocommunity.quickfix.nvim-bqf`",
+  vim.log.levels.ERROR
+)
+return { import = "astrocommunity.quickfix.nvim-bqf" }

--- a/lua/astrocommunity/quickfix/nvim-bqf/README.md
+++ b/lua/astrocommunity/quickfix/nvim-bqf/README.md
@@ -1,0 +1,5 @@
+# nvim-bqf
+
+Better quickfix window in Neovim, polish old quickfix window.
+
+**Repository:** <https://github.com/kevinhwang91/nvim-bqf>

--- a/lua/astrocommunity/quickfix/nvim-bqf/init.lua
+++ b/lua/astrocommunity/quickfix/nvim-bqf/init.lua
@@ -1,0 +1,13 @@
+return {
+  "kevinhwang91/nvim-bqf",
+  ft = "qf",
+  dependencies = {
+    "AstroNvim/astrocore",
+    ---@param opts AstroCoreOpts
+    opts = function(_, opts)
+      if not opts.signs then opts.signs = {} end
+      opts.signs.BqfSign = { text = " " .. require("astroui").get_icon "Selected", texthl = "BqfSign" }
+    end,
+  },
+  opts = {},
+}

--- a/lua/astrocommunity/quickfix/quicker-nvim/README.md
+++ b/lua/astrocommunity/quickfix/quicker-nvim/README.md
@@ -1,0 +1,5 @@
+# quicker.nvim
+
+Improved UI and workflow for the Neovim quickfix
+
+**Repository:** <https://github.com/stevearc/quicker.nvim>

--- a/lua/astrocommunity/quickfix/quicker-nvim/init.lua
+++ b/lua/astrocommunity/quickfix/quicker-nvim/init.lua
@@ -1,0 +1,43 @@
+return {
+  "stevearc/quicker.nvim",
+  ft = "qf",
+  specs = {
+    {
+      "AstroNvim/astrocore",
+      ---@type AstroCoreOpts
+      opts = {
+        options = {
+          opt = {
+            -- allow lazy loading on quickfix opening
+            quickfixtextfunc = "v:lua.require'quicker.display'.quickfixtextfunc",
+          },
+        },
+        mappings = {
+          n = {
+            ["<Leader>xq"] = { function() require("quicker").toggle { focus = true } end, desc = "Toggle quickfix" },
+            ["<Leader>xl"] = {
+              function() require("quicker").toggle { focus = true, loclist = true } end,
+              desc = "Toggle loclist",
+            },
+          },
+        },
+      },
+    },
+  },
+  ---@module "quicker"
+  ---@type quicker.SetupOptions
+  opts = {
+    keys = {
+      {
+        ">",
+        function() require("quicker").expand { before = 2, after = 2, add_to_existing = true } end,
+        desc = "Expand quickfix context",
+      },
+      {
+        "<",
+        function() require("quicker").collapse() end,
+        desc = "Collapse quickfix context",
+      },
+    },
+  },
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This adds the new [`quicker.nvim`](https://github.com/stevearc/quicker.nvim) plugin by the legendary `stevearc`

This also makes a new category `quickfix` since `debugging` isn't super clear. It deprecates the old `nvim-bqf` location and warns the user to migrate their configuration so it's non-breaking atm.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
