### PR TITLE
fix(transparent-nvim): make `transparent.nvim` actually work with Heirline (also makes the `opts` table work as well)

### DIFF
--- a/lua/astrocommunity/color/transparent-nvim/init.lua
+++ b/lua/astrocommunity/color/transparent-nvim/init.lua
@@ -1,14 +1,15 @@
 return {
   "xiyaowong/transparent.nvim",
   lazy = false,
-  config = function()
+  opts = {
+    extra_groups = {
+      "NormalFloat",
+      "NvimTreeNormal",
+    },
+  },
+  config = function(_, opts)
     local transparent = require "transparent"
-    transparent.setup {
-      extra_groups = {
-        "NormalFloat",
-        "NvimTreeNormal",
-      },
-    }
+    transparent.setup(opts)
     transparent.clear_prefix "BufferLine"
     transparent.clear_prefix "NeoTree"
     transparent.clear_prefix "lualine"

--- a/lua/astrocommunity/color/transparent-nvim/init.lua
+++ b/lua/astrocommunity/color/transparent-nvim/init.lua
@@ -17,13 +17,19 @@ return {
   dependencies = {
     {
       "AstroNvim/astrocore",
-      opts = {
-        mappings = {
-          n = {
-            ["<Leader>uT"] = { "<Cmd>TransparentToggle<CR>", desc = "Toggle transparency" },
-          },
-        },
-      },
+      opts = function(_, opts)
+        opts.mappings.n["<Leader>uT"] = { "<Cmd>TransparentToggle<CR>", desc = "Toggle transparency" }
+        if vim.tbl_get(opts, "autocmds", "heirline_colors") then
+          table.insert(opts.autocmds.heirline_colors, {
+            event = "User",
+            pattern = "TransparentClear",
+            desc = "Refresh heirline colors",
+            callback = function()
+              if package.loaded["heirline"] then require("astroui.status.heirline").refresh_colors() end
+            end,
+          })
+        end
+      end,
     },
   },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This makes `transparent.nvim` actually work with Heirline now that features have been added that allow it to support it. This also fixes the fact that the `transparent.nvim` spec apparently wasn't using the `opts` table. So it's actually configurable by the user now.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
