### PR TITLE
feat(pack): remove pinned version of `typst-preview.nvim` in `typst` pack

### DIFF
--- a/lua/astrocommunity/pack/typst/init.lua
+++ b/lua/astrocommunity/pack/typst/init.lua
@@ -16,7 +16,6 @@ return {
   {
     "chomosuke/typst-preview.nvim",
     cmd = { "TypstPreview", "TypstPreviewToggle", "TypstPreviewUpdate" },
-    version = "0.1.*",
     build = function() require("typst-preview").update() end,
     opts = {},
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

New releases of this plugin is quite frequent now (https://github.com/chomosuke/typst-preview.nvim/releases), so I don't think we should limit ourselves to `0.1.*`.

## ℹ Additional Information

N/A
