### PR TITLE
feat(markdown): added markdown-preview.nvim plugin.

### DIFF
--- a/lua/astrocommunity/pack/markdown/README.md
+++ b/lua/astrocommunity/pack/markdown/README.md
@@ -5,3 +5,4 @@ This plugin pack does the following:
 - Adds `markdown` and `markdown_inline` Treesitter parsers
 - Adds `marksman` language server
 - Adds `prettierd` formatter
+- Adds `markdown-preview.nvim` for real-time preview

--- a/lua/astrocommunity/pack/markdown/init.lua
+++ b/lua/astrocommunity/pack/markdown/init.lua
@@ -1,5 +1,21 @@
 return {
   {
+    "iamcco/markdown-preview.nvim",
+    cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
+    ft = { "markdown" },
+    build = function(plugin)
+      if vim.fn.executable "npx" then
+        vim.cmd("!cd " .. plugin.dir .. " && cd app && npx --yes yarn install")
+      else
+        vim.cmd [[Lazy load markdown-preview.nvim]]
+        vim.fn["mkdp#util#install"]()
+      end
+    end,
+    init = function()
+      if vim.fn.executable "npx" then vim.g.mkdp_filetypes = { "markdown" } end
+    end,
+  },
+  {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)


### PR DESCRIPTION
Use command `MarkdownPreview` to open the browser for real-time preview.