### PR TITLE
fix(go): automatically install gofumpt and goimports

### DIFF
--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -87,7 +87,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(
         opts.ensure_installed,
-        { "delve", "gopls", "gomodifytags", "gotests", "iferr", "impl" }
+        { "delve", "gopls", "gofumpt", "goimports", "gomodifytags", "gotests", "iferr", "impl" }
       )
     end,
   },


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The go configuration tells conform to use these tools for formatting, but they were not automatically installed. This fix adds them to the mason-tool-installer list so they will be installed with the rest of the go tools.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

These tools are referenced here:
https://github.com/AstroNvim/astrocommunity/blob/bb8089b72bbb11ad850902ce58a9f1fc64277563/lua/astrocommunity/pack/go/init.lua#L134-L142

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
