### PR TITLE
fix(grug-far-nvim): fix icon disabled options

### DIFF
--- a/lua/astrocommunity/search/grug-far-nvim/init.lua
+++ b/lua/astrocommunity/search/grug-far-nvim/init.lua
@@ -47,5 +47,14 @@ return {
   opts = function(_, opts)
     if not opts.icons then opts.icons = {} end
     opts.icons.enabled = vim.g.icons_enabled
+    if not vim.g.icons_enabled then
+      opts.resultsSeparatorLineChar = "-"
+      opts.spinnerStates = {
+        "|",
+        "\\",
+        "-",
+        "/",
+      }
+    end
   end,
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
Additional options that should be set for grug-far.nvim if icons are disabled.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

- https://github.com/MagicDuck/grug-far.nvim/blob/main/lua/grug-far/opts.lua#L150-L150
- https://github.com/MagicDuck/grug-far.nvim/blob/main/lua/grug-far/opts.lua#L156-L170

Before:
![Screenshot from 2024-08-17 19-02-54](https://github.com/user-attachments/assets/74109859-2d02-4e8b-9219-cf39908c578f)
After:
![Screenshot from 2024-08-17 19-01-47](https://github.com/user-attachments/assets/5fdcf54f-5c58-4d9d-a626-f16abb1ccd82)

