### PR TITLE
fix(go): Remove conform table

### DIFF
--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -132,15 +132,6 @@ return {
     end,
   },
   {
-    "stevearc/conform.nvim",
-    optional = true,
-    opts = {
-      formatters_by_ft = {
-        go = { "goimports", "gofumpt" },
-      },
-    },
-  },
-  {
     "echasnovski/mini.icons",
     optional = true,
     opts = {


### PR DESCRIPTION
This PR removes the conform table in the go back, since conform doesn't support these OOB. They were removed from the original go pack when migrating away from go.nvim.

If merged, it superseeds #1162 