### PR TITLE
fix(go): install missing `goimports`

### DIFF
--- a/lua/astrocommunity/pack/go/README.md
+++ b/lua/astrocommunity/pack/go/README.md
@@ -7,6 +7,7 @@ This plugin pack does the following:
 - Adds `go` Treesitter parsers
 - Adds `gopls` language server
 - Adds the following go packages:
+  - [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports?utm_source=godoc)
   - [gomodifytags](https://github.com/fatih/gomodifytags)
   - [gotests](https://github.com/cweill/gotests)
   - [iferr](https://github.com/koron/iferr)

--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -70,8 +70,10 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "gomodifytags", "iferr", "impl", "gotests" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(
+        opts.ensure_installed,
+        { "gomodifytags", "iferr", "impl", "gotests", "goimports" }
+      )
     end,
   },
   {
@@ -87,7 +89,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(
         opts.ensure_installed,
-        { "delve", "gopls", "gomodifytags", "gotests", "iferr", "impl" }
+        { "delve", "gopls", "gomodifytags", "gotests", "iferr", "impl", "goimports" }
       )
     end,
   },
@@ -136,7 +138,7 @@ return {
     optional = true,
     opts = {
       formatters_by_ft = {
-        go = { "goimports", "gofumpt" },
+        go = { "goimports", lsp_format = "last" },
       },
     },
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This supersedes #1162. `gopls` uses `gofumpt` for formatting so we can leverage that after running `goimports`

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
