### PR TITLE
fix(helm): better file type detection

### DIFF
--- a/lua/astrocommunity/init.lua
+++ b/lua/astrocommunity/init.lua
@@ -1,0 +1,66 @@
+-- Development utilities for AstroCommunity
+local M = {}
+
+--- Add a new string or function into a potentially existing filetype detection
+---@param default string The default filetype to check for when checking to fallback
+---@param old_ft vim.filetype.mapping.value? The old filetype detection
+---@param new_ft vim.filetype.mapping.value THe new filetype detection prat
+---@return vim.filetype.mapping.value
+function M.merge_filetype(default, old_ft, new_ft)
+  local priority -- store maximum priority of the two filetype mapping values
+  if type(old_ft) == "table" then
+    priority = old_ft[2].priority
+    old_ft = old_ft[1]
+  end
+  if type(new_ft) == "table" then
+    if not priority or priority < new_ft[2].priority then priority = new_ft[2].priority end
+    new_ft = new_ft[1]
+  end
+
+  local out
+  if old_ft == nil then
+    -- if no old filetype, then just return the new filetype
+    out = new_ft
+  elseif type(old_ft) == "string" then
+    if type(new_ft) == "string" then
+      -- if old_ft and new_ft are both strings, only apply the new filetype
+      out = new_ft
+    else
+      -- if the old filetype is a string and the new filetype is a function
+      -- use the string as the new default
+      out = function(...)
+        local ft, pre_ft = new_ft(...)
+        if not ft or ft == default then
+          ft, pre_ft = old_ft, nil
+        end
+        return ft, pre_ft
+      end
+    end
+  else
+    if type(new_ft) == "function" then
+      -- if old filetype and new filetype are both functions
+      -- use the old function as the fallback
+      out = function(...)
+        local ft, pre_ft = new_ft(...)
+        if not ft or ft == default then
+          ft, pre_ft = old_ft(...)
+        end
+        return ft, pre_ft
+      end
+    else
+      -- if the old filetype is a function and the new filetype is a string
+      -- use the new filetype as the fallback to the old filetype
+      out = function(...)
+        local ft, pre_ft = old_ft(...)
+        if not ft or ft == default then
+          ft, pre_ft = new_ft, nil
+        end
+        return ft, pre_ft
+      end
+    end
+  end
+  -- add the priority if necessary
+  return priority and { out, { priority = priority } } or out
+end
+
+return M

--- a/lua/astrocommunity/pack/ansible/init.lua
+++ b/lua/astrocommunity/pack/ansible/init.lua
@@ -17,11 +17,17 @@ end
 return {
   {
     "AstroNvim/astrocore",
-    ---@type AstroCoreOpts
-    opts = { filetypes = { extension = {
-      yml = yaml_ft,
-      yaml = yaml_ft,
-    } } },
+    opts = function(_, opts)
+      local utils = require "astrocommunity"
+      return require("astrocore").extend_tbl(opts, {
+        filetypes = {
+          extension = {
+            yml = utils.merge_filetype("yaml", vim.tbl_get(opts, "filetypes", "extension", "yml"), yaml_ft),
+            yaml = utils.merge_filetype("yaml", vim.tbl_get(opts, "filetypes", "extension", "yaml"), yaml_ft),
+          },
+        },
+      })
+    end,
   },
   { import = "astrocommunity.pack.yaml" },
   {

--- a/lua/astrocommunity/pack/helm/init.lua
+++ b/lua/astrocommunity/pack/helm/init.lua
@@ -1,53 +1,44 @@
-local M = {}
-
-function M.is_helm_file(path)
-  local check = vim.fs.find("Chart.yaml", { path = vim.fs.dirname(path), upward = true })
-  return not vim.tbl_isempty(check)
-end
-
---@private
---@return string
-function M.yaml_filetype(path, _) return M.is_helm_file(path) and "helm.yaml" or "yaml" end
-
---@private
---@return string
-function M.tmpl_filetype(path, _) return M.is_helm_file(path) and "helm.tmpl" or "template" end
-
---@private
---@return string
-function M.tpl_filetype(path, _) return M.is_helm_file(path) and "helm.tmpl" or "smarty" end
-
 return {
   {
     "AstroNvim/astrocore",
-    ---@type AstroCoreOpts
-    opts = {
-      autocmds = {
-        helm_commentstring = {
-          {
-            event = "FileType",
-            pattern = "helm",
-            callback = function() vim.opt_local.commentstring = "{{/* %s */}}" end,
+    ---@param opts AstroCoreOpts
+    opts = function(_, opts)
+      local is_helm_file = function(path)
+        local check = vim.fs.find("Chart.yaml", { path = vim.fs.dirname(path), upward = true })
+        return not vim.tbl_isempty(check)
+      end
+      local yaml_filetype = function(path, _) return is_helm_file(path) and "helm.yaml" or "yaml" end
+      local tmpl_filetype = function(path, _) return is_helm_file(path) and "helm.tmpl" or "template" end
+      local tpl_filetype = function(path, _) return is_helm_file(path) and "helm.tmpl" or "smarty" end
+
+      return require("astrocore").extend_tbl(opts, {
+        autocmds = {
+          helm_commentstring = {
+            {
+              event = "FileType",
+              pattern = "helm",
+              callback = function() vim.opt_local.commentstring = "{{/* %s */}}" end,
+            },
           },
         },
-      },
-      filetypes = {
-        extension = {
-          gotmpl = "helm",
-          yaml = M.yaml_filetype,
-          yml = M.yaml_filetype,
-          tmpl = M.tmpl_filetype,
-          tpl = M.tpl_filetype,
+        filetypes = {
+          extension = {
+            gotmpl = "helm",
+            yaml = yaml_filetype,
+            yml = yaml_filetype,
+            tmpl = tmpl_filetype,
+            tpl = tpl_filetype,
+          },
+          filename = {
+            ["Chart.yaml"] = "yaml",
+            ["Chart.lock"] = "yaml",
+          },
+          pattern = {
+            ["helmfile.*%.ya?ml"] = "helm",
+          },
         },
-        filename = {
-          ["Chart.yaml"] = "yaml",
-          ["Chart.lock"] = "yaml",
-        },
-        pattern = {
-          ["helmfile.*%.ya?ml"] = "helm",
-        },
-      },
-    },
+      })
+    end,
   },
   {
     "nvim-treesitter/nvim-treesitter",

--- a/lua/astrocommunity/pack/helm/init.lua
+++ b/lua/astrocommunity/pack/helm/init.lua
@@ -1,20 +1,5 @@
 local M = {}
 
-function M.setup()
-  vim.filetype.add {
-    extension = {
-      yaml = M.yaml_filetype,
-      yml = M.yaml_filetype,
-      tmpl = M.tmpl_filetype,
-      tpl = M.tpl_filetype,
-    },
-    filename = {
-      ["Chart.yaml"] = "yaml",
-      ["Chart.lock"] = "yaml",
-    },
-  }
-end
-
 function M.is_helm_file(path)
   local check = vim.fs.find("Chart.yaml", { path = vim.fs.dirname(path), upward = true })
   return not vim.tbl_isempty(check)

--- a/lua/astrocommunity/pack/helm/init.lua
+++ b/lua/astrocommunity/pack/helm/init.lua
@@ -1,3 +1,37 @@
+local M = {}
+
+function M.setup()
+  vim.filetype.add {
+    extension = {
+      yaml = M.yaml_filetype,
+      yml = M.yaml_filetype,
+      tmpl = M.tmpl_filetype,
+      tpl = M.tpl_filetype,
+    },
+    filename = {
+      ["Chart.yaml"] = "yaml",
+      ["Chart.lock"] = "yaml",
+    },
+  }
+end
+
+function M.is_helm_file(path)
+  local check = vim.fs.find("Chart.yaml", { path = vim.fs.dirname(path), upward = true })
+  return not vim.tbl_isempty(check)
+end
+
+--@private
+--@return string
+function M.yaml_filetype(path, _) return M.is_helm_file(path) and "helm.yaml" or "yaml" end
+
+--@private
+--@return string
+function M.tmpl_filetype(path, _) return M.is_helm_file(path) and "helm.tmpl" or "template" end
+
+--@private
+--@return string
+function M.tpl_filetype(path, _) return M.is_helm_file(path) and "helm.tmpl" or "smarty" end
+
 return {
   {
     "AstroNvim/astrocore",
@@ -13,10 +47,18 @@ return {
         },
       },
       filetypes = {
-        extension = { gotmpl = "helm" },
+        extension = {
+          gotmpl = "helm",
+          yaml = M.yaml_filetype,
+          yml = M.yaml_filetype,
+          tmpl = M.tmpl_filetype,
+          tpl = M.tpl_filetype,
+        },
+        filename = {
+          ["Chart.yaml"] = "yaml",
+          ["Chart.lock"] = "yaml",
+        },
         pattern = {
-          [".*/templates/.*%.ya?ml"] = "helm",
-          [".*/templates/.*%.tpl"] = "helm",
           ["helmfile.*%.ya?ml"] = "helm",
         },
       },

--- a/lua/astrocommunity/pack/helm/init.lua
+++ b/lua/astrocommunity/pack/helm/init.lua
@@ -3,13 +3,14 @@ return {
     "AstroNvim/astrocore",
     ---@param opts AstroCoreOpts
     opts = function(_, opts)
+      local utils = require "astrocommunity"
       local is_helm_file = function(path)
         local check = vim.fs.find("Chart.yaml", { path = vim.fs.dirname(path), upward = true })
         return not vim.tbl_isempty(check)
       end
-      local yaml_filetype = function(path, _) return is_helm_file(path) and "helm.yaml" or "yaml" end
-      local tmpl_filetype = function(path, _) return is_helm_file(path) and "helm.tmpl" or "template" end
-      local tpl_filetype = function(path, _) return is_helm_file(path) and "helm.tmpl" or "smarty" end
+      local yaml_filetype = function(path, _) return is_helm_file(path) and "helm" or "yaml" end
+      local tmpl_filetype = function(path, _) return is_helm_file(path) and "helm" or "template" end
+      local tpl_filetype = function(path, _) return is_helm_file(path) and "helm" or "smarty" end
 
       return require("astrocore").extend_tbl(opts, {
         autocmds = {
@@ -24,10 +25,10 @@ return {
         filetypes = {
           extension = {
             gotmpl = "helm",
-            yaml = yaml_filetype,
-            yml = yaml_filetype,
-            tmpl = tmpl_filetype,
-            tpl = tpl_filetype,
+            yaml = utils.merge_filetype("yaml", vim.tbl_get(opts, "filetypes", "extension", "yaml"), yaml_filetype),
+            yml = utils.merge_filetype("yaml", vim.tbl_get(opts, "filetypes", "extension", "yml"), yaml_filetype),
+            tmpl = utils.merge_filetype("template", vim.tbl_get(opts, "filetypes", "extension", "tmpl"), tmpl_filetype),
+            tpl = utils.merge_filetype("smarty", vim.tbl_get(opts, "filetypes", "extension", "tpl"), tpl_filetype),
           },
           filename = {
             ["Chart.yaml"] = "yaml",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This PR improves filetype detection for helm files.

The current filetype detection often enables yaml-ls for helm templates. yaml-ls then marks helm specific syntax as errors. To avoid this, a few specific rules are added to detect helm files.

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

The new code is mainly based on the following sources:

- https://github.com/mandos/nvim-helm/blob/7b5b5945bf9c84b17dceb2f9a6cabfac7a6d12f1/lua/helm/init.lua
- https://github.com/mandos/nvim-helm/blob/7b5b5945bf9c84b17dceb2f9a6cabfac7a6d12f1/lua/helm/utils.lua

They are under the MIT license. How should I attribute them?

- [x] Add attribution to the source code
- [x] Test the changes (I have tested them but as a separate module, outside of astrocommunity)



