### PR TITLE
fix(tint-nvim): update neo-tree → NeoTree (ignore_patterns)

### DIFF
--- a/lua/astrocommunity/color/tint-nvim/init.lua
+++ b/lua/astrocommunity/color/tint-nvim/init.lua
@@ -2,7 +2,7 @@ return {
   "levouh/tint.nvim",
   event = "User AstroFile",
   opts = {
-    highlight_ignore_patterns = { "WinSeparator", "neo-tree", "Status.*" },
+    highlight_ignore_patterns = { "WinSeparator", "NeoTree", "Status.*" },
     tint = -45, -- Darken colors, use a positive value to brighten
     saturation = 0.6, -- Saturation to preserve
   },


### PR DESCRIPTION
## 📑 Description

In the `highlight_ignore_patterns`, `neo-tree` wasn't working at all, so I tried `NeoTree`. That worked except for the icons still dim. That's an acceptable limitation for now IMO. Perhaps in the future we can fix it so the icon hl group doesn't dim, either. But this is less broken than it was.