### PR TITLE
feat(docker): Add `lazydocker.nvim`

### DIFF
--- a/lua/astrocommunity/docker/lazydocker/README.md
+++ b/lua/astrocommunity/docker/lazydocker/README.md
@@ -1,0 +1,7 @@
+# lazydocker.nvim
+
+A simple terminal UI for both docker and docker-compose.
+
+**Repository**: <https://github.com/mgierada/lazydocker.nvim>
+
+Adds lazydocker.nvim plugin.

--- a/lua/astrocommunity/docker/lazydocker/README.md
+++ b/lua/astrocommunity/docker/lazydocker/README.md
@@ -3,5 +3,3 @@
 A simple terminal UI for both docker and docker-compose.
 
 **Repository**: <https://github.com/mgierada/lazydocker.nvim>
-
-Adds lazydocker.nvim plugin.

--- a/lua/astrocommunity/docker/lazydocker/init.lua
+++ b/lua/astrocommunity/docker/lazydocker/init.lua
@@ -1,0 +1,23 @@
+local prefix = "<Leader>t"
+return {
+  {
+    "mgierada/lazydocker.nvim",
+    dependencies = {
+      "akinsho/toggleterm.nvim",
+      {
+        "AstroNvim/astrocore",
+        opts = {
+          mappings = {
+            n = {
+              [prefix .. "d"] = {
+                function() require("lazydocker").open() end,
+                desc = "ToggleTerm LazyDocker",
+              },
+            },
+          },
+        },
+      },
+    },
+    config = function() require("lazydocker").setup {} end,
+  },
+}

--- a/lua/astrocommunity/docker/lazydocker/init.lua
+++ b/lua/astrocommunity/docker/lazydocker/init.lua
@@ -18,8 +18,6 @@ return {
         },
       },
     },
-    opts = {
-      function() require("lazydocker").setup() end,
-    },
+    opts = {},
   },
 }

--- a/lua/astrocommunity/docker/lazydocker/init.lua
+++ b/lua/astrocommunity/docker/lazydocker/init.lua
@@ -1,4 +1,3 @@
-local prefix = "<Leader>t"
 return {
   {
     "mgierada/lazydocker.nvim",
@@ -9,7 +8,7 @@ return {
         opts = {
           mappings = {
             n = {
-              [prefix .. "d"] = {
+              ["<Leader>t" .. "d"] = {
                 function() require("lazydocker").open() end,
                 desc = "ToggleTerm LazyDocker",
               },

--- a/lua/astrocommunity/docker/lazydocker/init.lua
+++ b/lua/astrocommunity/docker/lazydocker/init.lua
@@ -18,6 +18,8 @@ return {
         },
       },
     },
-    config = function() require("lazydocker").setup {} end,
+    opts = {
+      function() require("lazydocker").setup() end,
+    },
   },
 }


### PR DESCRIPTION
## 📑 Description

<!-- Add a brief description of the pr -->
Adds [Lazy Docker](https://github.com/mgierada/lazydocker.nvim) package to the AstroNvim community.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

This PR adds a new shortcut to `Leader + t` + `d` which runs the Lazy Docker plugin.
It depends only on [lazydocker.nvim](https://github.com/mgierada/lazydocker.nvim) and it uses built-in ToggleTerm support.

No breaking changes or old behavior interference.

![image](https://github.com/user-attachments/assets/01cc5291-c4cd-487f-b1bd-51fb962a875f)

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
