### PR TITLE
fix(python-ruff): Ensure formatters are called for python-ruff pack.

### DIFF
--- a/lua/astrocommunity/pack/python-ruff/init.lua
+++ b/lua/astrocommunity/pack/python-ruff/init.lua
@@ -40,6 +40,9 @@ return {
     "stevearc/conform.nvim",
     optional = true,
     opts = {
+      format_on_save = {
+        lsp_format = "fallback",
+      },
       formatters_by_ft = {
         python = { "ruff_organize_imports", "ruff_format" },
       },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Using a freshly cloned [template](https://github.com/AstroNvim/template), changing only the file `lua/astrocommunity.lua` to: 
```
---@type LazySpec
return {
  "AstroNvim/astrocommunity",
  { import = "astrocommunity.pack.python-ruff" },
}
```
then only the `ruff_format` formatter is called when saving a Python file. The `ruff_organize_imports` formatter is not called.

This PR adds `conform` configuration that ensures that both formatters are called.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
