### PR TITLE
feat(neotest): add watch keybindings

### DIFF
--- a/lua/astrocommunity/test/neotest/init.lua
+++ b/lua/astrocommunity/test/neotest/init.lua
@@ -1,4 +1,6 @@
 local prefix = "<Leader>T"
+local watch_prefix = prefix .. "W"
+
 return {
   "nvim-neotest/neotest",
   lazy = true,
@@ -26,6 +28,29 @@ return {
             [prefix .. "O"] = { function() require("neotest").output_panel.toggle() end, desc = "Output window" },
             ["]T"] = { function() require("neotest").jump.next() end, desc = "Next test" },
             ["[T"] = { function() require("neotest").jump.prev() end, desc = "previous test" },
+
+            [watch_prefix] = { desc = " Watch" },
+            [watch_prefix .. "t"] = {
+              function() require("neotest").watch.toggle() end,
+              desc = "Toggle watch test",
+            },
+            [watch_prefix .. "f"] = {
+              function() require("neotest").watch.toggle(vim.fn.expand "%") end,
+              desc = "Toggle watch all test in file",
+            },
+            [watch_prefix .. "p"] = {
+              function() require("neotest").watch.toggle(vim.fn.getcwd()) end,
+              desc = "Toggle watch all tests in project",
+            },
+            [watch_prefix .. "S"] = {
+              function()
+                --- NOTE: The proper type of the argument is missing in the documentation
+                ---@see https://github.com/nvim-neotest/neotest/blob/master/doc/neotest.txt#L626
+                ---@diagnostic disable-next-line: missing-parameter
+                require("neotest").watch.stop()
+              end,
+              desc = "Stop all watches",
+            },
           },
         },
       },

--- a/lua/astrocommunity/test/neotest/init.lua
+++ b/lua/astrocommunity/test/neotest/init.lua
@@ -1,6 +1,4 @@
-local prefix = "<Leader>T"
-local watch_prefix = prefix .. "W"
-
+---@type LazySpec
 return {
   "nvim-neotest/neotest",
   lazy = true,
@@ -8,52 +6,91 @@ return {
     "nvim-lua/plenary.nvim",
     "nvim-neotest/nvim-nio",
     {
-      "AstroNvim/astrocore",
+      "AstroNvim/astroui",
       opts = {
-        mappings = {
-          n = {
-            [prefix] = { desc = "󰗇 Tests" },
-            [prefix .. "t"] = { function() require("neotest").run.run() end, desc = "Run test" },
-            [prefix .. "d"] = { function() require("neotest").run.run { strategy = "dap" } end, desc = "Debug test" },
-            [prefix .. "f"] = {
-              function() require("neotest").run.run(vim.fn.expand "%") end,
-              desc = "Run all tests in file",
-            },
-            [prefix .. "p"] = {
-              function() require("neotest").run.run(vim.fn.getcwd()) end,
-              desc = "Run all tests in project",
-            },
-            [prefix .. "<CR>"] = { function() require("neotest").summary.toggle() end, desc = "Test Summary" },
-            [prefix .. "o"] = { function() require("neotest").output.open() end, desc = "Output hover" },
-            [prefix .. "O"] = { function() require("neotest").output_panel.toggle() end, desc = "Output window" },
-            ["]T"] = { function() require("neotest").jump.next() end, desc = "Next test" },
-            ["[T"] = { function() require("neotest").jump.prev() end, desc = "previous test" },
-
-            [watch_prefix] = { desc = " Watch" },
-            [watch_prefix .. "t"] = {
-              function() require("neotest").watch.toggle() end,
-              desc = "Toggle watch test",
-            },
-            [watch_prefix .. "f"] = {
-              function() require("neotest").watch.toggle(vim.fn.expand "%") end,
-              desc = "Toggle watch all test in file",
-            },
-            [watch_prefix .. "p"] = {
-              function() require("neotest").watch.toggle(vim.fn.getcwd()) end,
-              desc = "Toggle watch all tests in project",
-            },
-            [watch_prefix .. "S"] = {
-              function()
-                --- NOTE: The proper type of the argument is missing in the documentation
-                ---@see https://github.com/nvim-neotest/neotest/blob/master/doc/neotest.txt#L626
-                ---@diagnostic disable-next-line: missing-parameter
-                require("neotest").watch.stop()
-              end,
-              desc = "Stop all watches",
-            },
-          },
+        icons = {
+          Tests = "󰗇",
+          Watch = "",
         },
       },
+    },
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+
+        local get_file_path = function() return vim.fn.expand "%" end
+        local get_project_path = function() return vim.fn.getcwd() end
+
+        local prefix = "<Leader>T"
+
+        maps.n[prefix] = {
+          desc = require("astroui").get_icon("Tests", 1, true) .. "Tests",
+        }
+        maps.n[prefix .. "t"] = {
+          function() require("neotest").run.run() end,
+          desc = "Run test",
+        }
+        maps.n[prefix .. "d"] = {
+          function() require("neotest").run.run { strategy = "dap" } end,
+          desc = "Debug test",
+        }
+        maps.n[prefix .. "f"] = {
+          function() require("neotest").run.run(get_file_path()) end,
+          desc = "Run all tests in file",
+        }
+        maps.n[prefix .. "p"] = {
+          function() require("neotest").run.run(get_project_path()) end,
+          desc = "Run all tests in project",
+        }
+        maps.n[prefix .. "<CR>"] = {
+          function() require("neotest").summary.toggle() end,
+          desc = "Test Summary",
+        }
+        maps.n[prefix .. "o"] = {
+          function() require("neotest").output.open() end,
+          desc = "Output hover",
+        }
+        maps.n[prefix .. "O"] = {
+          function() require("neotest").output_panel.toggle() end,
+          desc = "Output window",
+        }
+        maps.n["]T"] = {
+          function() require("neotest").jump.next() end,
+          desc = "Next test",
+        }
+        maps.n["[T"] = {
+          function() require("neotest").jump.prev() end,
+          desc = "Previous test",
+        }
+
+        local watch_prefix = prefix .. "W"
+
+        maps.n[watch_prefix] = {
+          desc = require("astroui").get_icon("Watch", 1, true) .. "Watch",
+        }
+        maps.n[watch_prefix .. "t"] = {
+          function() require("neotest").watch.toggle() end,
+          desc = "Toggle watch test",
+        }
+        maps.n[watch_prefix .. "f"] = {
+          function() require("neotest").watch.toggle(get_file_path()) end,
+          desc = "Toggle watch all test in file",
+        }
+        maps.n[watch_prefix .. "p"] = {
+          function() require("neotest").watch.toggle(get_project_path()) end,
+          desc = "Toggle watch all tests in project",
+        }
+        maps.n[watch_prefix .. "S"] = {
+          function()
+            --- NOTE: The proper type of the argument is missing in the documentation
+            ---@see https://github.com/nvim-neotest/neotest/blob/master/doc/neotest.txt#L626-L632
+            ---@diagnostic disable-next-line: missing-parameter
+            require("neotest").watch.stop()
+          end,
+          desc = "Stop all watches",
+        }
+      end,
     },
     {
       "folke/neodev.nvim",


### PR DESCRIPTION
## 📑 Description

Add mappings to simplify the usage of watch-related commands when using `neotest`.

It also refactor the keybindings to follow current standards using an `opts` function instead of a table.

## ℹ Additional Information

The API for the usage of `neotest.watch.stop()` is not well defined in terms of the type information for the usage.

This creates the necessity to use `@diagnostic disable-next-line: missing-parameter`.

For a closer look, see https://github.com/nvim-neotest/neotest/blob/master/doc/neotest.txt#L626
