### PR TITLE
feat(nvim-coverage): add keybindings

### DIFF
--- a/lua/astrocommunity/test/nvim-coverage/init.lua
+++ b/lua/astrocommunity/test/nvim-coverage/init.lua
@@ -2,7 +2,9 @@
 return {
   "andythigpen/nvim-coverage",
   event = "User AstroFile",
-  opts = {},
+  opts = {
+    auto_reload = true,
+  },
   dependencies = {
     "nvim-lua/plenary.nvim",
     {

--- a/lua/astrocommunity/test/nvim-coverage/init.lua
+++ b/lua/astrocommunity/test/nvim-coverage/init.lua
@@ -1,6 +1,42 @@
+---@type LazySpec
 return {
   "andythigpen/nvim-coverage",
   event = "User AstroFile",
-  dependencies = { "nvim-lua/plenary.nvim" },
   opts = {},
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    {
+      "AstroNvim/astroui",
+      opts = {
+        icons = {
+          Tests = "󰗇",
+          Coverage = "",
+        },
+      },
+    },
+    {
+      "AstroNvim/astrocore",
+      optional = true,
+      opts = function(_, opts)
+        local astroui = require "astroui"
+        local maps = opts.mappings
+
+        local tests_prefix = "<Leader>T"
+        local coverage_prefix = tests_prefix .. "C"
+
+        -- INFO: Compatibility with `neotest` and `vim-test`
+        maps.n[tests_prefix] = { desc = astroui.get_icon("Tests", 1, true) .. "Tests" }
+
+        maps.n[coverage_prefix] = { desc = astroui.get_icon("Coverage", 1, true) .. "Coverage" }
+        maps.n[coverage_prefix .. "t"] = { function() require("coverage").toggle() end, desc = "Toggle coverage" }
+        maps.n[coverage_prefix .. "s"] =
+          { function() require("coverage").summary() end, desc = "Show coverage summary" }
+        maps.n[coverage_prefix .. "c"] = { function() require("coverage").clear() end, desc = "Clear coverage" }
+        maps.n[coverage_prefix .. "l"] = {
+          function() require("coverage").load(true) end,
+          desc = "Load and show coverage",
+        }
+      end,
+    },
+  },
 }


### PR DESCRIPTION
## 📑 Description

Add mappings to `nvim-coverage`.

Also, it was added the option to reload the coverage report if it changes, a useful option complemented with the ease to show the coverage added with the mappings.

## ℹ Additional Information

The mapping was added as a second layer behind `Tests` map. This is because `neotest` and `vim-test` use the `<Leader>T` map and name it like that, allowing to complement the usage of those plugins without depending on it.
