### PR TITLE
fix(markdown-preview-nvim): build using yarn when possible

### DIFF
--- a/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/README.md
+++ b/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/README.md
@@ -1,5 +1,8 @@
 # markdown-preview.nvim
 
+> This plugin requires Node.js to be installed on your system.
+> Without it, the installation process will fail, and the plugin won't work.
+
 markdown preview plugin for (neo)vim
 
 **Repository:** <https://github.com/iamcco/markdown-preview.nvim>

--- a/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
@@ -1,7 +1,22 @@
 ---@type LazySpec
 return {
   "iamcco/markdown-preview.nvim",
-  build = function() vim.fn["mkdp#util#install"]() end,
+  build = function(plugin)
+    local package_manager = vim.fn.executable "yarn" and "yarn" or vim.fn.executable "npx" and "npx -y yarn" or false
+
+    --- HACK: Use `yarn` or `npx` when possible, otherwise throw an error
+    ---@see https://github.com/iamcco/markdown-preview.nvim/issues/690
+    ---@see https://github.com/iamcco/markdown-preview.nvim/issues/695
+    if not package_manager then error "Missing `yarn` or `npx` in the PATH" end
+
+    local cmd = string.format(
+      "!cd %s && cd app && COREPACK_ENABLE_AUTO_PIN=0 %s install --frozen-lockfile",
+      plugin.dir,
+      package_manager
+    )
+
+    vim.cmd(cmd)
+  end,
   ft = { "markdown", "markdown.mdx" },
   cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
   init = function()


### PR DESCRIPTION
## 📑 Description

Fix the installation process of `markdown-preview-nvim`.

This PR uses the recommendations given in the [comment](https://github.com/iamcco/markdown-preview.nvim/issues/690#issuecomment-2254280534) related with the reported issue about installing the plugin using `lazy.nvim`.

## ℹ Additional Information

The plugin [Markdown Preview](https://github.com/iamcco/markdown-preview.nvim) seems to be unmaintained and the installation process provided in his documentation [fails when installed through `lazy.nvim`](https://github.com/iamcco/markdown-preview.nvim/issues/690).

Also, I added the variable `COREPACK_ENABLE_AUTO_PIN=0` to avoid the modification of the `package.json` ([described here](https://github.com/nodejs/corepack/blob/main/README.md#environment-variables)) used by the plugin, in case the user is using `Corepack`.