### PR TITLE
feat(typescript): add neotest-jest support

### DIFF
--- a/lua/astrocommunity/pack/typescript/README.md
+++ b/lua/astrocommunity/pack/typescript/README.md
@@ -30,10 +30,7 @@ return {
 
 ## How do I customize `neotest-jest`?
 
-To customize the `neotest-jest` plugin, you need to configure it like you would with any other plugin,
-but with a small twist: add a `config` key with an empty function. This step is necessary to prevent
-`lazy` from attempting to call a non-existent `require("neotest-jest").setup()` function, as this plugin
-doesn’t use that setup method.
+To customize the `neotest-jest` plugin, you need to configure it like you would with any other plugin
 
 > Learn more about the spec setup used by `lazy` [here](https://lazy.folke.io/spec#spec-setup).
 
@@ -41,9 +38,7 @@ doesn’t use that setup method.
 ---@type LazySpec
 return {
   "nvim-neotest/neotest-jest",
-  config = function() end, -- You need to add this line!
   opts = function(_, opts)
     -- Add your opts
   end,
 }
-```

--- a/lua/astrocommunity/pack/typescript/README.md
+++ b/lua/astrocommunity/pack/typescript/README.md
@@ -10,6 +10,7 @@ This plugin pack does the following:
 - Adds [nvim-vtsls](https://github.com/yioneko/nvim-vtsls) for language specific tooling
 - Adds [package-info.nvim](https://github.com/vuki656/package-info.nvim) for project package management
 - Adds [nvim-lsp-file-operations](https://github.com/antosha417/nvim-lsp-file-operations) to handles file imports on rename or move within neo-tree
+- Adds [neotest-jest](https://github.com/nvim-neotest/neotest-jest) to ease the test running if `neotest` is installed
 
 ## How do I disable Eslint format on save?
 
@@ -24,5 +25,25 @@ return {
       eslint_fix_on_save = false,
     },
   },
+}
+```
+
+## How do I customize `neotest-jest`?
+
+To customize the `neotest-jest` plugin, you need to configure it like you would with any other plugin,
+but with a small twist: add a `config` key with an empty function. This step is necessary to prevent
+`lazy` from attempting to call a non-existent `require("neotest-jest").setup()` function, as this plugin
+doesn’t use that setup method.
+
+> Learn more about the spec setup used by `lazy` [here](https://lazy.folke.io/spec#spec-setup).
+
+```lua
+---@type LazySpec
+return {
+  "nvim-neotest/neotest-jest",
+  config = function() end, -- You need to add this line!
+  opts = function(_, opts)
+    -- Add your opts
+  end,
 }
 ```

--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -236,7 +236,7 @@ return {
   {
     "nvim-neotest/neotest",
     optional = true,
-    dependencies = { "nvim-neotest/neotest-jest" },
+    dependencies = { { "nvim-neotest/neotest-jest", config = function() end } },
     opts = function(_, opts)
       if not opts.adapters then opts.adapters = {} end
       table.insert(opts.adapters, require "neotest-jest"(require("astrocore").plugin_opts "neotest-jest"))

--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -233,4 +233,13 @@ return {
       },
     },
   },
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    dependencies = { "nvim-neotest/neotest-jest" },
+    opts = function(_, opts)
+      if not opts.adapters then opts.adapters = {} end
+      table.insert(opts.adapters, require "neotest-jest"(require("astrocore").plugin_opts "neotest-jest"))
+    end,
+  },
 }


### PR DESCRIPTION
## 📑 Description

In `typescript` pack, add support for [`neotest-jest`](https://github.com/nvim-neotest/neotest-jest) if [`neotest`](https://github.com/nvim-neotest/neotest) is installed.

## ℹ Additional Information

The usage of `table#insert` function allows to use the same pattern in other language packs without overriding the values (e.g.: use `rustaceanvim` integration for `neotest` in the same `neovim` configuration).

This usage was inspired from the `rust` [language pack](https://github.com/AstroNvim/astrocommunity/blob/main/lua/astrocommunity/pack/rust/init.lua#L83-L91).