### PR TITLE
fix: `tsserver` renamed to `ts_ls` upstream

### DIFF
--- a/lua/astrocommunity/lsp/ts-error-translator-nvim/init.lua
+++ b/lua/astrocommunity/lsp/ts-error-translator-nvim/init.lua
@@ -16,7 +16,7 @@ return {
           and vim.tbl_contains({
             "astro",
             "svelte",
-            "tsserver",
+            "ts_ls",
             "typescript-tools",
             "volar",
             "vtsls",

--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -28,7 +28,7 @@ local has_prettier = function(bufnr)
     lsp_rooter = rooter.resolve("lsp", {
       ignore = {
         servers = function(client)
-          return not vim.tbl_contains({ "vtsls", "typescript-tools", "volar", "eslint", "tsserver" }, client.name)
+          return not vim.tbl_contains({ "eslint", "ts_ls", "typescript-tools", "volar", "vtsls" }, client.name)
         end,
       },
     })


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This updates references to `tsserver` to `ts_ls`. This is currently blocked by https://github.com/dmmulroy/ts-error-translator.nvim/pull/28

Once that is merged in then we can merge this as well. I am also holding back the `lspconfig` update from AstroNvim until we mitigate references to `tsserver` where possible (https://github.com/williamboman/mason-lspconfig.nvim/issues/458)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
