### PR TITLE
feat(mini-icons): add `neo-tree.nvim` integration

### DIFF
--- a/lua/astrocommunity/icon/mini-icons/init.lua
+++ b/lua/astrocommunity/icon/mini-icons/init.lua
@@ -6,6 +6,33 @@ return {
   lazy = true,
   specs = {
     { "nvim-tree/nvim-web-devicons", enabled = false, optional = true },
+    {
+      "nvim-neo-tree/neo-tree.nvim",
+      opts = {
+        default_component_configs = {
+          icon = {
+            provider = function(icon, node)
+              local text, hl
+              local mini_icons = require "mini.icons"
+              if node.type == "file" then
+                text, hl = mini_icons.get("file", node.name)
+              elseif node.type == "directory" then
+                text, hl = mini_icons.get("directory", node.name)
+                if node:is_expanded() then text = nil end
+              end
+
+              if text then icon.text = text end
+              if hl then icon.highlight = hl end
+            end,
+          },
+          kind_icon = {
+            provider = function(icon, node)
+              icon.text, icon.highlight = require("mini.icons").get("lsp", node.extra.kind.name)
+            end,
+          },
+        },
+      },
+    },
   },
   init = function()
     package.preload["nvim-web-devicons"] = function()


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This adds support for the new icon provider feature added into neo-tree.nvim (https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1527). This is currently unreleased but I tested it and it doesn't cause any problems being present in older versions and will just start working when neo-tree gets a new release tagged sometime next week.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
