### PR TITLE
fix(tailwindcss): fix TailwindCSS pack not loading in Phoenix projects

### DIFF
--- a/lua/astrocommunity/pack/tailwindcss/init.lua
+++ b/lua/astrocommunity/pack/tailwindcss/init.lua
@@ -21,7 +21,8 @@ return {
                   "tailwind.config.js",
                   "tailwind.config.ts",
                   "postcss.config.js",
-                  "config/tailwind.config.js"
+                  "config/tailwind.config.js",
+                  "assets/tailwind.config.js"
                 )
                 return root_pattern(fname)
               end,


### PR DESCRIPTION
See also https://github.com/AstroNvim/astrocommunity/pull/915

Phoenix projects put the tailwind.config.js file in the root /assets folder. The addition of specific root dir detection in #912 broke the elixir-phoenix pack.

