### PR TITLE
feat(lazydocker): load when required only

### DIFF
--- a/lua/astrocommunity/docker/lazydocker/init.lua
+++ b/lua/astrocommunity/docker/lazydocker/init.lua
@@ -1,6 +1,7 @@
 return {
   {
     "mgierada/lazydocker.nvim",
+    lazy = true,
     dependencies = {
       "akinsho/toggleterm.nvim",
       {


### PR DESCRIPTION
## 📑 Description

Add lazy loading to `lazydocker.nvim`. This way, it will only loads when the user request it via `<Leader>td`.

## ℹ Additional Information

This improves the overall startup time of `Neovim`, but increase the perceived startup time of `lazydocker.nvim`.
