### PR TITLE
feat(copilot-cmp): load when opening a file

### DIFF
--- a/lua/astrocommunity/completion/copilot-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-cmp/init.lua
@@ -1,6 +1,7 @@
 ---@type LazySpec
 return {
   "zbirenbaum/copilot-cmp",
+  event = "User AstroFile",
   opts = {},
   dependencies = {
     {


### PR DESCRIPTION
## 📑 Description

Lazy load `copilot-cmp` when entering a file, not at the startup.