### PR TITLE
fix(remote-sshfs-nvim): use function call result

### DIFF
--- a/lua/astrocommunity/remote-development/remote-sshfs-nvim/init.lua
+++ b/lua/astrocommunity/remote-development/remote-sshfs-nvim/init.lua
@@ -28,7 +28,7 @@ return {
         if type(find_files) == "table" then
           local orig_find_files = find_files[1]
           find_files[1] = function()
-            if require("remote-sshfs.connections").is_connected then
+            if require("remote-sshfs.connections").is_connected() then
               require("remote-sshfs.api").find_files()
             elseif type(orig_find_files) == "function" then
               orig_find_files()
@@ -41,7 +41,7 @@ return {
         if type(live_grep) == "table" then
           local orig_live_grep = live_grep[1]
           live_grep[1] = function()
-            if require("remote-sshfs.connections").is_connected then
+            if require("remote-sshfs.connections").is_connected() then
               require("remote-sshfs.api").live_grep()
             elseif type(orig_live_grep) == "function" then
               orig_live_grep()


### PR DESCRIPTION
## 📑 Description
For now keybinding \<Leader>ff and \<Leader>fw stops to work properly with remote-sshfs-plugin, when there is no ssh connection.
![изображение](https://github.com/user-attachments/assets/106ef16f-2026-4d02-9ac3-28233992a97c)

This happens, because the value of functions checks in the condition instead of call result.
Fixed the issue with calling this function :)


