### PR TITLE
fix(dart): disable treesitter textobjects for Dart

### DIFF
--- a/lua/astrocommunity/pack/dart/init.lua
+++ b/lua/astrocommunity/pack/dart/init.lua
@@ -16,6 +16,11 @@ return {
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "dart" })
       end
+
+      -- HACK: Disables the select treesitter textobjects because the Dart treesitter parser is very inefficient. Hopefully this gets fixed and this block can be removed in the future.
+      -- Reference: https://github.com/AstroNvim/AstroNvim/issues/2707
+      local select = vim.tbl_get(opts, "textobjects", "select")
+      if select then select.disable = require("astrocore").list_insert_unique(select.disable, { "dart" }) end
     end,
   },
   {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This disables `nvim-treesitter-textobjects` for Dart, specifically the Select ones. This is due to Dart having a poorly implemented treesitter parser.

Related Issues:
- https://github.com/AstroNvim/AstroNvim/issues/2707
- https://github.com/nvim-treesitter/nvim-treesitter/issues/2126

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
