### PR TITLE
feat(grug-far-nvim)!: add more features and align with recommended `spectre.nvim` mappings

### DIFF
--- a/lua/astrocommunity/search/grug-far-nvim/init.lua
+++ b/lua/astrocommunity/search/grug-far-nvim/init.lua
@@ -81,10 +81,34 @@ return {
         opts.disable.ft = require("astrocore").list_insert_unique(opts.disable.ft, { "grug-far" })
       end,
     },
+    {
+      "nvim-neo-tree/neo-tree.nvim",
+      optional = true,
+      opts = {
+        commands = {
+          grug_far_replace = function(state)
+            local node = state.tree:get_node()
+            local prefills = { paths = node:get_id() }
+            if node.type ~= "directory" then prefills.paths = vim.fn.fnamemodify(prefills.paths, ":h") end
+            local grug_far = require "grug-far"
+            if not grug_far.has_instance "tree" then
+              grug_far.open { instanceName = "tree", prefills = prefills, staticTitle = "Find and Replace from Tree" }
+            else
+              grug_far.open_instance "tree"
+              grug_far.update_instance_prefills("tree", prefills, false)
+            end
+          end,
+        },
+        window = {
+          mappings = {
+            gs = "grug_far_replace",
+          },
+        },
+      },
+    },
   },
   ---@param opts GrugFarOptionsOverride
   opts = function(_, opts)
-    opts.windowCreationCommand = "split"
     if not opts.icons then opts.icons = {} end
     opts.icons.enabled = vim.g.icons_enabled
     if not vim.g.icons_enabled then

--- a/lua/astrocommunity/search/grug-far-nvim/init.lua
+++ b/lua/astrocommunity/search/grug-far-nvim/init.lua
@@ -12,17 +12,48 @@ return {
       "AstroNvim/astrocore",
       ---@param opts AstroCoreOpts
       opts = function(_, opts)
-        if not opts.mappings then opts.mappings = require("astrocore").empty_map_table() end
-        local maps, prefix = opts.mappings, "<Leader>r"
+        local maps, prefix = opts.mappings, "<Leader>s"
 
-        maps.n[prefix] = {
+        maps.n[prefix] = { desc = require("astroui").get_icon("GrugFar", 1, true) .. "Search/Replace" }
+        maps.n[prefix .. "s"] = {
           function() require("grug-far").open { transient = true } end,
-          desc = require("astroui").get_icon("GrugFar", 1, true) .. "Search and Replace",
+          desc = "Search/Replace workspace",
         }
-
+        maps.n[prefix .. "e"] = {
+          function()
+            local ext = require("astrocore.buffer").is_valid() and vim.fn.expand "%:e" or ""
+            require("grug-far").open {
+              transient = true,
+              prefills = { filesFilter = ext ~= "" and "*." .. ext or nil },
+            }
+          end,
+          desc = "Search/Replace filetype",
+        }
+        maps.n[prefix .. "f"] = {
+          function()
+            local filter = require("astrocore.buffer").is_valid() and vim.fn.expand "%" or nil
+            require("grug-far").open { transient = true, prefills = { paths = filter } }
+          end,
+          desc = "Search/Replace file",
+        }
+        maps.n[prefix .. "w"] = {
+          function()
+            local current_word = vim.fn.expand "<cword>"
+            if current_word ~= "" then
+              require("grug-far").open {
+                transient = true,
+                startCursorRow = 4,
+                prefills = { search = vim.fn.expand "<cword>" },
+              }
+            else
+              vim.notify("No word under cursor", vim.log.levels.WARN, { title = "Grug-far" })
+            end
+          end,
+          desc = "Replace current word",
+        }
         maps.x[prefix] = {
           function() require("grug-far").open { transient = true, startCursorRow = 4 } end,
-          desc = require("astroui").get_icon("GrugFar", 1, true) .. "Search and Replace (current word)",
+          desc = "Replace selection",
         }
       end,
     },
@@ -42,9 +73,18 @@ return {
       ---@type CatppuccinOptions
       opts = { integrations = { grug_far = true } },
     },
+    {
+      "folke/which-key.nvim",
+      optional = true,
+      opts = function(_, opts)
+        if not opts.disable then opts.disable = {} end
+        opts.disable.ft = require("astrocore").list_insert_unique(opts.disable.ft, { "grug-far" })
+      end,
+    },
   },
   ---@param opts GrugFarOptionsOverride
   opts = function(_, opts)
+    opts.windowCreationCommand = "split"
     if not opts.icons then opts.icons = {} end
     opts.icons.enabled = vim.g.icons_enabled
     if not vim.g.icons_enabled then

--- a/lua/astrocommunity/search/grug-far-nvim/init.lua
+++ b/lua/astrocommunity/search/grug-far-nvim/init.lua
@@ -1,3 +1,17 @@
+local function grug_far_explorer(dir)
+  local grug_far, prefills = require "grug-far", { paths = dir }
+  if not grug_far.has_instance "explorer" then
+    grug_far.open {
+      instanceName = "explorer",
+      prefills = prefills,
+      staticTitle = "Find and Replace from Explorer",
+    }
+  else
+    grug_far.open_instance "explorer"
+    grug_far.update_instance_prefills("explorer", prefills, false)
+  end
+end
+
 ---@type LazySpec
 return {
   "MagicDuck/grug-far.nvim",
@@ -88,20 +102,24 @@ return {
         commands = {
           grug_far_replace = function(state)
             local node = state.tree:get_node()
-            local prefills = { paths = node:get_id() }
-            if node.type ~= "directory" then prefills.paths = vim.fn.fnamemodify(prefills.paths, ":h") end
-            local grug_far = require "grug-far"
-            if not grug_far.has_instance "tree" then
-              grug_far.open { instanceName = "tree", prefills = prefills, staticTitle = "Find and Replace from Tree" }
-            else
-              grug_far.open_instance "tree"
-              grug_far.update_instance_prefills("tree", prefills, false)
-            end
+            grug_far_explorer(node.type == "directory" and node:get_id() or vim.fn.fnamemodify(node:get_id(), ":h"))
           end,
         },
         window = {
           mappings = {
-            gs = "grug_far_replace",
+            gS = "grug_far_replace",
+          },
+        },
+      },
+    },
+    {
+      "stevearc/oil.nvim",
+      optional = true,
+      opts = {
+        keymaps = {
+          gS = {
+            function() grug_far_explorer(require("oil").get_current_dir()) end,
+            desc = "Search/Replace in directory",
           },
         },
       },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This does a major refactor on the `grug-far.nvim` spec that adds a lot more bindings and options for searching and replacing. It also aligns the recommended keymaps with what we have been using for `spectre.nvim` which is a very nice workflow.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
