### PR TITLE
feat(go): Add golangcilint as default linter

### DIFF
--- a/lua/astrocommunity/pack/go/README.md
+++ b/lua/astrocommunity/pack/go/README.md
@@ -15,3 +15,4 @@ This plugin pack does the following:
   - [impl](https://github.com/josharian/impl)
 - Adds [nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for debugging
 - Adds [gopher.nvim](https://github.com/olexsmir/gopher.nvim) for language specific tools
+- Adds [golangcilint](https://github.com/golangci/golangci-lint) for linting

--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -155,4 +155,13 @@ return {
       },
     },
   },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        go = { "golangcilint" },
+      },
+    },
+  },
 }

--- a/lua/astrocommunity/pack/go/init.lua
+++ b/lua/astrocommunity/pack/go/init.lua
@@ -73,7 +73,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(
         opts.ensure_installed,
-        { "gomodifytags", "iferr", "impl", "gotests", "goimports" }
+        { "gomodifytags", "iferr", "impl", "gotests", "goimports", "golangci_lint" }
       )
     end,
   },
@@ -90,7 +90,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(
         opts.ensure_installed,
-        { "delve", "gopls", "gomodifytags", "gotests", "iferr", "impl", "goimports" }
+        { "delve", "gopls", "gomodifytags", "gotests", "iferr", "impl", "goimports", "golangci-lint" }
       )
     end,
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The PR adds [golangcilint](https://github.com/golangci/golangci-lint) as the default linter for go.pack. Currently no linters as part for the pack.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information


