### PR TITLE
fix(mini-indentscope): add animation

### DIFF
--- a/lua/astrocommunity/indent/mini-indentscope/init.lua
+++ b/lua/astrocommunity/indent/mini-indentscope/init.lua
@@ -26,6 +26,10 @@ return {
   event = "User AstroFile",
   opts = function()
     return {
+      draw = {
+        delay = 100,
+        animation = function(s, n) return s / n * 10 end,
+      },
       options = { try_as_border = true },
       symbol = require("astrocore").plugin_opts("indent-blankline.nvim").context_char or char,
     }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Adds an animation to `mini-indentscope` with faster border rendering. Personally the slow rendering is very distracting to my eyes. Raising a PR since it feels this distraction is a common perception.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
### Before
![ezgif-5-af0f5dddd8](https://github.com/user-attachments/assets/4b82c691-4f5f-4ad1-9e21-b867cea85c49)

### After
![ezgif-5-343c8f0050](https://github.com/user-attachments/assets/f714950a-702a-4eaf-9507-8eb23c3cb26c)
