### PR TITLE
fix(copilotchat-nvim): use custom prefix from astro core if defined

### DIFF
--- a/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
@@ -31,7 +31,7 @@ return {
       ---@param opts AstroCoreOpts
       opts = function(_, opts)
         local maps = assert(opts.mappings)
-        local prefix = "<Leader>P"
+        local prefix = opts.options.g.copilot_chat_prefix or "<Leader>P"
         local astroui = require "astroui"
 
         maps.n[prefix] = { desc = astroui.get_icon("CopilotChat", 1, true) .. "CopilotChat" }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

With this PR it is possible to define the prefix for CopilotChat.nvim via `AstroNvim/astrocore` `opts.options.g.copilot_chat_prefix` or if not defined use `<leader>P` as default.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
 @-->
