### PR TITLE
fix(colorscheme): lazy load all colorschemes

### DIFF
--- a/lua/astrocommunity/colorscheme/aurora/init.lua
+++ b/lua/astrocommunity/colorscheme/aurora/init.lua
@@ -1,3 +1,1 @@
-return {
-  "ray-x/aurora",
-}
+return { "ray-x/aurora", lazy = true }

--- a/lua/astrocommunity/colorscheme/bamboo-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/bamboo-nvim/init.lua
@@ -1,3 +1,1 @@
-return {
-  "ribru17/bamboo.nvim",
-}
+return { "ribru17/bamboo.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/bluloco-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/bluloco-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "uloco/bluloco.nvim",
+  lazy = true,
   dependencies = { "rktjmp/lush.nvim" },
   opts = {},
 }

--- a/lua/astrocommunity/colorscheme/catppuccin/init.lua
+++ b/lua/astrocommunity/colorscheme/catppuccin/init.lua
@@ -1,6 +1,7 @@
 return {
   "catppuccin/nvim",
   name = "catppuccin",
+  lazy = true,
   ---@type CatppuccinOptions
   opts = {
     integrations = {

--- a/lua/astrocommunity/colorscheme/citruszest-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/citruszest-nvim/init.lua
@@ -1,3 +1,1 @@
-return {
-  "zootedb0t/citruszest.nvim",
-}
+return { "zootedb0t/citruszest.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/cyberdream-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/cyberdream-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "scottmckendry/cyberdream.nvim",
+  lazy = true,
   opts = {
     transparent = true,
     italic_comments = true,

--- a/lua/astrocommunity/colorscheme/dracula-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/dracula-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "Mofiqul/dracula.nvim" }
+return { "Mofiqul/dracula.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/eldritch-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/eldritch-nvim/init.lua
@@ -1,4 +1,1 @@
-return {
-  "eldritch-theme/eldritch.nvim",
-  opts = {},
-}
+return { "eldritch-theme/eldritch.nvim", lazy = true, opts = {} }

--- a/lua/astrocommunity/colorscheme/everforest/init.lua
+++ b/lua/astrocommunity/colorscheme/everforest/init.lua
@@ -1,1 +1,1 @@
-return { "sainnhe/everforest" }
+return { "sainnhe/everforest", lazy = true }

--- a/lua/astrocommunity/colorscheme/fluoromachine-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/fluoromachine-nvim/init.lua
@@ -1,4 +1,1 @@
-return {
-  "maxmx03/fluoromachine.nvim",
-  opts = {},
-}
+return { "maxmx03/fluoromachine.nvim", lazy = true, opts = {} }

--- a/lua/astrocommunity/colorscheme/github-nvim-theme/init.lua
+++ b/lua/astrocommunity/colorscheme/github-nvim-theme/init.lua
@@ -1,3 +1,1 @@
-return {
-  "projekt0n/github-nvim-theme",
-}
+return { "projekt0n/github-nvim-theme", lazy = true }

--- a/lua/astrocommunity/colorscheme/gruvbox-baby/init.lua
+++ b/lua/astrocommunity/colorscheme/gruvbox-baby/init.lua
@@ -1,1 +1,1 @@
-return { "luisiacc/gruvbox-baby" }
+return { "luisiacc/gruvbox-baby", lazy = true }

--- a/lua/astrocommunity/colorscheme/gruvbox-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/gruvbox-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "ellisonleao/gruvbox.nvim" }
+return { "ellisonleao/gruvbox.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/helix-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/helix-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "oneslash/helix-nvim" }
+return { "oneslash/helix-nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/hybrid-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/hybrid-nvim/init.lua
@@ -1,4 +1,1 @@
-return {
-  "HoNamDuong/hybrid.nvim",
-  opts = {},
-}
+return { "HoNamDuong/hybrid.nvim", lazy = true, opts = {} }

--- a/lua/astrocommunity/colorscheme/iceberg-vim/init.lua
+++ b/lua/astrocommunity/colorscheme/iceberg-vim/init.lua
@@ -1,1 +1,1 @@
-return { "cocopon/iceberg.vim" }
+return { "cocopon/iceberg.vim", lazy = true }

--- a/lua/astrocommunity/colorscheme/kanagawa-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/kanagawa-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "rebelot/kanagawa.nvim" }
+return { "rebelot/kanagawa.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/kanagawa-paper-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/kanagawa-paper-nvim/init.lua
@@ -1,5 +1,1 @@
-return {
-  "sho-87/kanagawa-paper.nvim",
-  priority = 1000,
-  opts = {},
-}
+return { "sho-87/kanagawa-paper.nvim", lazy = true, opts = {} }

--- a/lua/astrocommunity/colorscheme/lackluster-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/lackluster-nvim/init.lua
@@ -1,3 +1,1 @@
-return {
-  "slugbyte/lackluster.nvim",
-}
+return { "slugbyte/lackluster.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/melange-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/melange-nvim/init.lua
@@ -1,3 +1,1 @@
-return {
-  "savq/melange-nvim",
-}
+return { "savq/melange-nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/mellifluous-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/mellifluous-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "ramojus/mellifluous.nvim" }
+return { "ramojus/mellifluous.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/mellow-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/mellow-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "kvrohit/mellow.nvim" }
+return { "kvrohit/mellow.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/miasma-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/miasma-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "xero/miasma.nvim" }
+return { "xero/miasma.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/mini-base16/init.lua
+++ b/lua/astrocommunity/colorscheme/mini-base16/init.lua
@@ -1,5 +1,6 @@
 return {
   "echasnovski/mini.base16",
+  lazy = true,
   specs = {
     {
       "catppuccin",

--- a/lua/astrocommunity/colorscheme/modus-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/modus-nvim/init.lua
@@ -1,3 +1,1 @@
-return {
-  "miikanissi/modus-themes.nvim",
-}
+return { "miikanissi/modus-themes.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/monokai-pro-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/monokai-pro-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "loctvl842/monokai-pro.nvim",
+  lazy = true,
   opts = {
     terminal_colors = true,
     devicons = true, -- highlight the icons of `nvim-web-devicons`

--- a/lua/astrocommunity/colorscheme/neofusion-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/neofusion-nvim/init.lua
@@ -1,6 +1,6 @@
 return {
   "diegoulloao/neofusion.nvim",
-  priority = 1000,
+  lazy = true,
   config = true,
   opts = {
     terminal_colors = true, -- add neovim terminal colors

--- a/lua/astrocommunity/colorscheme/neosolarized-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/neosolarized-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "svrana/neosolarized.nvim",
+  lazy = true,
   dependencies = { "tjdevries/colorbuddy.nvim" },
   opts = { background_set = true },
 }

--- a/lua/astrocommunity/colorscheme/night-owl-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/night-owl-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "oxfist/night-owl.nvim" }
+return { "oxfist/night-owl.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/nightfox-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/nightfox-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "EdenEast/nightfox.nvim",
+  lazy = true,
   opts = {
     options = {
       module_default = false,

--- a/lua/astrocommunity/colorscheme/nord-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/nord-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "shaunsingh/nord.nvim",
+  lazy = true,
   dependencies = {
     "AstroNvim/astrocore",
     opts = {

--- a/lua/astrocommunity/colorscheme/nordic-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/nordic-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "AlexvZyl/nordic.nvim", opts = {} }
+return { "AlexvZyl/nordic.nvim", lazy = true, opts = {} }

--- a/lua/astrocommunity/colorscheme/nvim-juliana/init.lua
+++ b/lua/astrocommunity/colorscheme/nvim-juliana/init.lua
@@ -1,1 +1,1 @@
-return { "kaiuri/nvim-juliana" }
+return { "kaiuri/nvim-juliana", lazy = true }

--- a/lua/astrocommunity/colorscheme/oldworld-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/oldworld-nvim/init.lua
@@ -1,3 +1,1 @@
-return {
-  "dgox16/oldworld.nvim",
-}
+return { "dgox16/oldworld.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/onedarkpro-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/onedarkpro-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "olimorris/onedarkpro.nvim",
+  lazy = true,
   opts = {
     options = {
       highlight_inactive_windows = true,

--- a/lua/astrocommunity/colorscheme/oxocarbon-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/oxocarbon-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "nyoom-engineering/oxocarbon.nvim" }
+return { "nyoom-engineering/oxocarbon.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/poimandres-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/poimandres-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "olivercederborg/poimandres.nvim", opts = {} }
+return { "olivercederborg/poimandres.nvim", lazy = true, opts = {} }

--- a/lua/astrocommunity/colorscheme/rose-pine/init.lua
+++ b/lua/astrocommunity/colorscheme/rose-pine/init.lua
@@ -1,1 +1,1 @@
-return { "rose-pine/neovim", name = "rose-pine", opts = {} }
+return { "rose-pine/neovim", name = "rose-pine", lazy = true, opts = {} }

--- a/lua/astrocommunity/colorscheme/solarized-osaka-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/solarized-osaka-nvim/init.lua
@@ -1,4 +1,1 @@
-return {
-  "craftzdog/solarized-osaka.nvim",
-  opts = {},
-}
+return { "craftzdog/solarized-osaka.nvim", lazy = true, opts = {} }

--- a/lua/astrocommunity/colorscheme/sonokai/init.lua
+++ b/lua/astrocommunity/colorscheme/sonokai/init.lua
@@ -1,5 +1,6 @@
 return {
   "sainnhe/sonokai",
+  lazy = true,
   dependencies = {
     "AstroNvim/astrocore",
     opts = { options = { g = {

--- a/lua/astrocommunity/colorscheme/tokyodark-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/tokyodark-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "tiagovla/tokyodark.nvim" }
+return { "tiagovla/tokyodark.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/tokyonight-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/tokyonight-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "folke/tokyonight.nvim" }
+return { "folke/tokyonight.nvim", lazy = true }

--- a/lua/astrocommunity/colorscheme/vim-dogrun/init.lua
+++ b/lua/astrocommunity/colorscheme/vim-dogrun/init.lua
@@ -1,1 +1,1 @@
-return { "wadackel/vim-dogrun" }
+return { "wadackel/vim-dogrun", lazy = true }

--- a/lua/astrocommunity/colorscheme/vscode-nvim/init.lua
+++ b/lua/astrocommunity/colorscheme/vscode-nvim/init.lua
@@ -1,1 +1,1 @@
-return { "Mofiqul/vscode.nvim" }
+return { "Mofiqul/vscode.nvim", lazy = true }


### PR DESCRIPTION
## 📑 Description

This adds lazy loading to all colorschemes by default. As of last week Telescope's colorscheme picker allows for picking lazy loaded colorschemes (https://github.com/nvim-telescope/telescope.nvim/pull/3295)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
