### PR TITLE
fix(tabout-nvim): make `nvim-cmp` optional and add support for `vim.snippet`

### DIFF
--- a/lua/astrocommunity/motion/tabout-nvim/init.lua
+++ b/lua/astrocommunity/motion/tabout-nvim/init.lua
@@ -1,18 +1,25 @@
 return {
   "abecodes/tabout.nvim",
   event = "InsertEnter",
-  dependencies = {
-    "nvim-treesitter/nvim-treesitter",
+  dependencies = { "nvim-treesitter/nvim-treesitter" },
+  specs = {
     {
       "hrsh7th/nvim-cmp",
+      optional = true,
       opts = function(_, opts)
         local cmp = require "cmp"
+        local snippet_jumpable = function() return vim.snippet and vim.snippet.active { direction = 1 } end
+        local snippet_jump = vim.schedule_wrap(function() vim.snippet.jump(1) end)
         local luasnip_avail, luasnip = pcall(require, "luasnip")
+        if luasnip_avail then
+          snippet_jumpable = luasnip.expand_or_jumpable
+          snippet_jump = luasnip.expand_or_jump
+        end
         opts.mapping["<Tab>"] = cmp.mapping(function(fallback)
           if cmp.visible() then
             cmp.select_next_item()
-          elseif luasnip_avail and luasnip.expand_or_jumpable() then
-            luasnip.expand_or_jump()
+          elseif vim.api.nvim_get_mode() ~= "c" and snippet_jumpable() then
+            snippet_jump()
           elseif not luasnip_avail and pcall(vim.snippet.active, { direction = 1 }) then
             vim.snippet.jump(1)
           else


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This cleans up the `tabout.nvim` spec to make sure it doesn't require `nvim-cmp` and also adds support for native vim snippets integration

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
