### PR TITLE
fix(pack): pass `astrolsp.on_attach()` to `moonbit.nvim`

### DIFF
--- a/lua/astrocommunity/pack/moonbit/init.lua
+++ b/lua/astrocommunity/pack/moonbit/init.lua
@@ -12,7 +12,10 @@ return {
       -- only enable the LSP if the lsp command is executable
       if vim.fn.executable "moonbit-lsp" == 1 then
         local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
-        if astrolsp_avail then opts.lsp = astrolsp.lsp_opts "moonbit" end
+        if astrolsp_avail then
+          opts.lsp = astrolsp.lsp_opts "moonbit"
+          opts.on_attach = astrolsp.on_attach
+        end
       else
         opts.lsp = false
       end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

After installing the `moonbit` pack, `moonbit-lsp` still won't launch properly.
This looks like an oversight in #1224. (cc @mehalter)

Tested locally with the following override:

```lua
  {
    "tonyfettes/moonbit.nvim",
    opts = function(_, opts)
      -- only enable treesitter if the plugin is available
      if not require("astrocore").is_available("nvim-treesitter") then
        opts.treesitter = { enabled = false }
      end
      -- only enable the LSP if the lsp command is executable
      if vim.fn.executable("moonbit-lsp") == 1 then
        local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
        if astrolsp_avail then
          opts.lsp = astrolsp.lsp_opts("moonbit")
          opts.on_attach = astrolsp.on_attach
        end
      else
        opts.lsp = false
      end
    end,
  },
```

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
