### PR TITLE
fix(lsp_lines-nvim): disable plugin in `lazy` UI

### DIFF
--- a/lua/astrocommunity/diagnostics/lsp_lines-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/lsp_lines-nvim/init.lua
@@ -10,6 +10,30 @@ return {
             ["<Leader>uD"] = { function() require("lsp_lines").toggle() end, desc = "Toggle virtual diagnostic lines" },
           },
         },
+        autocmds = {
+          LspLinesPlugin = {
+            {
+              event = "FileType",
+              pattern = "lazy",
+              desc = "Disable plugin when opening `lazy` UI to avoid artifacts",
+              callback = function()
+                ---@diagnostic disable-next-line: undefined-field
+                if not vim.diagnostic.config().virtual_lines then return end
+                require("lsp_lines").toggle()
+                vim.b.lsp_lines_temp_disabled_for_lazy_ft = true
+              end,
+            },
+            {
+              event = "BufLeave",
+              desc = "Enable plugin when closing `lazy` UI",
+              callback = function(args)
+                if vim.bo[args.buf].filetype == "lazy" and vim.b.lsp_lines_temp_disabled_for_lazy_ft then
+                  require("lsp_lines").toggle()
+                end
+              end,
+            },
+          },
+        },
       },
     },
     {


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
enabled plugin causes diagnostics duplication and looks horrible IMO
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
before:
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/26b0c172-b48f-4a9f-887d-7fc93b962c71">

after:
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/d1f5d86f-a282-4ba6-9093-83b7afa7fa73">

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
