### PR TITLE
fix(vue): correct typo in vue-language-server

### DIFF
--- a/lua/astrocommunity/pack/vue/init.lua
+++ b/lua/astrocommunity/pack/vue/init.lua
@@ -85,7 +85,7 @@ return {
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "vue-language-sever", "js-debug-adapter" })
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "vue-language-server", "js-debug-adapter" })
     end,
   },
 }


### PR DESCRIPTION
## 📑 Description
Fixed a typo in the package name that was causing an error

## ℹ Additional Information
```lua
Error executing vim.schedule lua callback: ...al/nvim-data/lazy/mason.nvim/lua/mason-registry/init.lua:80: Cannot find package "vue-language-sever".
```

The error occurs when installing the package : ***"astrocommunity.pack.vue"***