### PR TITLE
fix(cpp): tbl extend on opts.config instead of opts

### DIFF
--- a/lua/astrocommunity/pack/cpp/init.lua
+++ b/lua/astrocommunity/pack/cpp/init.lua
@@ -6,7 +6,7 @@ return {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts)
-      opts.config = vim.tbl_deep_extend("keep", opts, {
+      opts.config = vim.tbl_deep_extend("keep", opts.config, {
         clangd = {
           capabilities = {
             offsetEncoding = "utf-8",


### PR DESCRIPTION
## 📑 Description

Fix tbl extend on opts.config instead of opts

I believe this was a typo because assigning opts.config to a modified table of opts doesn't make sense