### PR TITLE
feat(completion): add `blink.cmp`

### DIFF
--- a/lua/astrocommunity/completion/blink-cmp/README.md
+++ b/lua/astrocommunity/completion/blink-cmp/README.md
@@ -1,0 +1,5 @@
+# Blink Completion (blink.cmp)
+
+Performant, batteries-included completion plugin for Neovim
+
+**Repository:** <https://github.com/Saghen/blink.cmp>

--- a/lua/astrocommunity/completion/blink-cmp/init.lua
+++ b/lua/astrocommunity/completion/blink-cmp/init.lua
@@ -1,0 +1,38 @@
+return {
+  "Saghen/blink.cmp",
+  event = "InsertEnter",
+  version = "v0.*",
+  dependencies = { "rafamadriz/friendly-snippets" },
+  opts = {
+    keymap = {
+      show = { "<C-Space>", "<C-N>", "<C-P>" },
+      accept = { "<Tab>", "<CR>" },
+      select_prev = { "<Up>", "<C-P>", "<C-K>" },
+      select_next = { "<Down>", "<C-N>", "<C-J>" },
+      scroll_documentation_up = "<C-D>",
+      scroll_documentation_down = "<C-U>",
+    },
+    windows = {
+      autocomplete = {
+        border = "rounded",
+        winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:PmenuSel,Search:None",
+      },
+      documentation = {
+        auto_show = true,
+        border = "rounded",
+        winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:PmenuSel,Search:None",
+      },
+      signature_help = {
+        border = "rounded",
+        winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder",
+      },
+    },
+  },
+  specs = {
+    -- disable built in completion plugins
+    { "hrsh7th/nvim-cmp", enabled = false },
+    { "rcarriga/cmp-dap", enabled = false },
+    { "L3MON4D3/LuaSnip", enabled = false },
+    { "onsails/lspkind.nvim", enabled = false },
+  },
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This adds a the new completion plugin [`blink.cmp`](https://github.com/Saghen/blink.cmp)

### TODO

- [x] Testing
- [x] Update mappings and configure it to match default AstroNvim completion behavior

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
