### PR TITLE
fix(neorg): Add default workspace for Neorg

### DIFF
--- a/lua/astrocommunity/note-taking/neorg/init.lua
+++ b/lua/astrocommunity/note-taking/neorg/init.lua
@@ -19,7 +19,7 @@ return {
           workspaces = {
             notes = "~/projects/notes",
           },
-          default_workspace = "notes"
+          default_workspace = "notes",
         },
       },
     },

--- a/lua/astrocommunity/note-taking/neorg/init.lua
+++ b/lua/astrocommunity/note-taking/neorg/init.lua
@@ -19,6 +19,7 @@ return {
           workspaces = {
             notes = "~/projects/notes",
           },
+          default_workspace = "notes"
         },
       },
     },


### PR DESCRIPTION
With default workspace, Neorg can start with that workspace. The user does not have to run the command to load the workspace after starting nvim.

