### PR TITLE
feat(completion): add magazine.nvim

### DIFF
--- a/lua/astrocommunity/completion/magazine-nvim/README.md
+++ b/lua/astrocommunity/completion/magazine-nvim/README.md
@@ -1,0 +1,8 @@
+# magazine.nvim
+
+> [!NOTE]
+> Magazine is a fork of `nvim-cmp`. The way this plugin is setup is to hijack into an existing `nvim-cmp` installation. So make sure that `nvim-cmp` is still installed and enabled for this plugin to work and all configuration is still done through `nvim-cmp` as normal.
+
+Magazine.nvim is a "beta" nvim-cmp to fix bugs & implement new features early
+
+**Repository:** <https://github.com/iguanacucumber/magazine.nvim>

--- a/lua/astrocommunity/completion/magazine-nvim/init.lua
+++ b/lua/astrocommunity/completion/magazine-nvim/init.lua
@@ -1,0 +1,6 @@
+return {
+  "iguanacucumber/magazine.nvim",
+  lazy = true,
+  config = function() vim.opt.rtp:remove(require("astrocore").get_plugin("nvim-cmp").dir) end,
+  specs = { "hrsh7th/nvim-cmp", dependencies = { "iguanacucumber/magazine.nvim" } },
+}


### PR DESCRIPTION
## 📑 Description

Adds [magazine.nvim](https://github.com/iguanacucumber/magazine.nvim), This replaces nvim-cmp and acts as a "beta" with performance and feature improvements before they get up streamed.
