### PR TITLE
feat(nvim-lint): make autocmd events configurable

### DIFF
--- a/lua/astrocommunity/lsp/nvim-lint/init.lua
+++ b/lua/astrocommunity/lsp/nvim-lint/init.lua
@@ -9,7 +9,7 @@ return {
   opts = {},
   config = function(_, opts)
     local lint, astrocore = require "lint", require "astrocore"
-
+    local autocmd_events = opts.events or { "BufWritePost", "BufReadPost", "InsertLeave", "TextChanged" }
     lint.linters_by_ft = opts.linters_by_ft or {}
     for name, linter in pairs(opts.linters or {}) do
       local base = lint.linters[name]
@@ -41,7 +41,7 @@ return {
 
     lint.try_lint() -- start linter immediately
     local timer = vim.loop.new_timer()
-    vim.api.nvim_create_autocmd({ "BufWritePost", "BufReadPost", "InsertLeave", "TextChanged" }, {
+    vim.api.nvim_create_autocmd(autocmd_events, {
       group = vim.api.nvim_create_augroup("auto_lint", { clear = true }),
       desc = "Automatically try linting",
       callback = function()

--- a/lua/astrocommunity/lsp/nvim-lint/init.lua
+++ b/lua/astrocommunity/lsp/nvim-lint/init.lua
@@ -1,3 +1,4 @@
+local lint -- cache for the nvim-lint package
 ---@type LazySpec
 return {
   "mfussenegger/nvim-lint",
@@ -5,11 +6,34 @@ return {
   dependencies = { "williamboman/mason.nvim" },
   specs = {
     { "jay-babu/mason-null-ls.nvim", optional = true, opts = { methods = { diagnostics = false } } },
+    {
+      "AstroNvim/astrocore",
+      ---@param opts AstroCoreOpts
+      opts = function(_, opts)
+        local timer = (vim.uv or vim.loop).new_timer()
+        if not opts.autocmds then opts.autocmds = {} end
+        opts.autocmds.auto_lint = {
+          {
+            event = { "BufWritePost", "BufReadPost", "InsertLeave", "TextChanged" },
+            desc = "Automatically lint with nvim-lint",
+            callback = function()
+              -- only run autocommand when nvim-lint is loaded
+              if lint then
+                timer:start(100, 0, function()
+                  timer:stop()
+                  vim.schedule(lint.try_lint)
+                end)
+              end
+            end,
+          },
+        }
+      end,
+    },
   },
   opts = {},
   config = function(_, opts)
-    local lint, astrocore = require "lint", require "astrocore"
-    local autocmd_events = opts.events or { "BufWritePost", "BufReadPost", "InsertLeave", "TextChanged" }
+    local astrocore = require "astrocore"
+    lint = require "lint"
     lint.linters_by_ft = opts.linters_by_ft or {}
     for name, linter in pairs(opts.linters or {}) do
       local base = lint.linters[name]
@@ -39,17 +63,6 @@ return {
       return linters
     end)
 
-    lint.try_lint() -- start linter immediately
-    local timer = vim.loop.new_timer()
-    vim.api.nvim_create_autocmd(autocmd_events, {
-      group = vim.api.nvim_create_augroup("auto_lint", { clear = true }),
-      desc = "Automatically try linting",
-      callback = function()
-        timer:start(100, 0, function()
-          timer:stop()
-          vim.schedule(lint.try_lint)
-        end)
-      end,
-    })
+    lint.try_lint()
   end,
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
make `nvim-lint` autocmd events(`"BufWritePost", "BufReadPost", "InsertLeave", "TextChanged"` now) can be configured from `opts.events`
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
