### PR TITLE
feat(pack): replace `typst_lsp` with `tinymist` in `typst` pack

### DIFF
--- a/lua/astrocommunity/pack/typst/README.md
+++ b/lua/astrocommunity/pack/typst/README.md
@@ -3,7 +3,7 @@
 This plugin pack does the following:
 
 - Add `typst.vim` for syntax
-- Add `typst_lsp` language server
+- Add `tinymist` language server
 - Add `typst-preview.nvim` plugin
 
 _Note_: To start the preview - Run TypstPreview

--- a/lua/astrocommunity/pack/typst/init.lua
+++ b/lua/astrocommunity/pack/typst/init.lua
@@ -3,20 +3,24 @@ return {
   {
     "williamboman/mason-lspconfig.nvim",
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "typst_lsp" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "tinymist" })
     end,
   },
   {
     "WhoIsSethDaniel/mason-tool-installer.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "typst-lsp" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "tinymist" })
     end,
   },
   {
     "chomosuke/typst-preview.nvim",
     cmd = { "TypstPreview", "TypstPreviewToggle", "TypstPreviewUpdate" },
     build = function() require("typst-preview").update() end,
-    opts = {},
+    opts = {
+      dependencies_bin = {
+        tinymist = "tinymist",
+      },
+    },
   },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

With this PR, `typst_lsp` in the `typst` pack is replaced by `tinymist`. 

[`tinymist`](https://github.com/Myriad-Dreamin/tinymist) is a more actively-developed language server for the Typst language. Since https://github.com/typst/typst/pull/5193, `tinymist` has replaced `typst_lsp` to become the recommended LSP implementation in Typst's official docs.

## ℹ Additional Information

Also, with this change, the user can now directly use the Mason-installed `tinymist` as the preview backend in `chomosuke/typst-preview.nvim`, without having to separately install a `typst-preview` server, thanks to the fact that this functionality has recently been successfully integrated into `tinymist` itself.

Tested locally (since over 5 months ago) with the following override:

```lua
  {
    "williamboman/mason-lspconfig.nvim",
    opts = function(_, opts)
      opts.ensure_installed =
        require("utils").list_remove_all(opts.ensure_installed, { "typst_lsp" })
      opts.ensure_installed =
        require("astrocore").list_insert_unique(opts.ensure_installed, { "tinymist" })
    end,
  },
  {
    "chomosuke/typst-preview.nvim",
    opts = {
      dependencies_bin = {
        tinymist = "tinymist",
        -- This is because `websocat` is in my `PATH` as well,
        -- but it might not generally apply to everyone.
        websocat = "websocat",
      },
    },
  },
```
