### PR TITLE
feat(neogit): clear completion sources when adding a git commit message

### DIFF
--- a/lua/astrocommunity/git/neogit/init.lua
+++ b/lua/astrocommunity/git/neogit/init.lua
@@ -41,4 +41,8 @@ return {
       integrations = { telescope = utils.is_available "telescope.nvim" },
     })
   end,
+  config = function()
+    local cmp = require("cmp")
+    cmp.setup.filetype("NeogitCommitMessage", { sources = {} })
+  end,
 }


### PR DESCRIPTION

## 📑 Description

When entering a commit message, I noticed completion was suggesting from the buffer source which doesn't seem very valuable in that context. 

I'm looking for feedback on this PR. For example, maybe I should check if cmp-nvim is installed first (someone may be using blink). 


