### PR TITLE
feat(diagnostics): add `tiny-inline-diagnostic-nvim`

### DIFF
--- a/lua/astrocommunity/diagnostics/tiny-inline-diagnostic-nvim/README.md
+++ b/lua/astrocommunity/diagnostics/tiny-inline-diagnostic-nvim/README.md
@@ -1,0 +1,7 @@
+# tiny-inline-diagnostic.nvim
+
+A Neovim plugin that display prettier diagnostic messages. Display one line diagnostic messages where the cursor is, with icons and colors.
+
+**Repository:** <https://github.com/rachartier/tiny-inline-diagnostic.nvim>
+
+_Note_: This sets the Astrocore diagnostics to level 2

--- a/lua/astrocommunity/diagnostics/tiny-inline-diagnostic-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/tiny-inline-diagnostic-nvim/init.lua
@@ -1,0 +1,14 @@
+return {
+  "rachartier/tiny-inline-diagnostic.nvim",
+  event = "VeryLazy",
+  dependencies = {
+    "astronvim/astrocore",
+    opts = {
+      diagnostics = {
+        -- Disable diagnostics virtual text to prevent duplicates
+        virtual_text = false,
+      },
+    },
+  },
+  opts = {},
+}


### PR DESCRIPTION
## 📑 Description

Adds [tiny-inline-diagnostic.nvim](https://github.com/rachartier/tiny-inline-diagnostic.nvim)

## ℹ Additional Information

This sets the Astrocore diagnostic to level 2, this is prevent two sets of diagnostic info but will still have the icon in the column.
