### PR TITLE
feat(pack): add `neotest` integration to the `moonbit` pack

### DIFF
--- a/lua/astrocommunity/pack/moonbit/README.md
+++ b/lua/astrocommunity/pack/moonbit/README.md
@@ -10,3 +10,4 @@ This plugin pack does the following:
 - Adds [`moonbit.nvim`](https://github.com/tonyfettes/moonbit.nvim) plugin which adds
   - Adds `moonbit` Treesitter parser
   - Adds `moonbit-lsp` language server
+  - Adds `neotest-moonbit` neotest adapter

--- a/lua/astrocommunity/pack/moonbit/init.lua
+++ b/lua/astrocommunity/pack/moonbit/init.lua
@@ -18,6 +18,15 @@ return {
       end
     end,
   },
+  {
+    "nvim-neotest/neotest",
+    optional = true,
+    dependencies = { "moonbit-community/moonbit.nvim" },
+    opts = function(_, opts)
+      if not opts.adapters then opts.adapters = {} end
+      table.insert(opts.adapters, require "neotest-moonbit")
+    end,
+  },
   -- uncomment if/when moonbit-lsp is added to lspconfig and mason-lspconfig
   -- {
   --   "williamboman/mason-lspconfig.nvim",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This PR enables neotest support for the MoonBit language, as implemented in the following PR:
- https://github.com/moonbit-community/moonbit.nvim/pull/10

Tested locally with the same override spec without any issues.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
