### PR TITLE
fix(auto-save-nvim): not restoring buffer settings

### DIFF
--- a/lua/astrocommunity/editing-support/auto-save-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/auto-save-nvim/init.lua
@@ -15,14 +15,17 @@ return {
               -- Save global autoformat status
               vim.g.OLD_AUTOFORMAT = vim.g.autoformat
               vim.g.autoformat = false
-              vim.g.OLD_AUTOFORMAT_BUFFERS = {}
+
+              local old_autoformat_buffers = {}
               -- Disable all manually enabled buffers
               for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
                 if vim.b[bufnr].autoformat then
-                  table.insert(vim.g.OLD_AUTOFORMAT_BUFFERS, bufnr)
+                  table.insert(old_autoformat_buffers, bufnr)
                   vim.b[bufnr].autoformat = false
                 end
               end
+
+              vim.g.OLD_AUTOFORMAT_BUFFERS = old_autoformat_buffers
             end,
           },
           -- Re-enable autoformat after saving


### PR DESCRIPTION
## 📑 Description
When testing this more, I noticed that the `table.insert` directly into `vim.g.OLD_AUTOFORMAT_BUFFERS` didn't seem to work, at the end of the for loop if you `table.inspect` it, it will be `{}`.

This means, that if you went into insert mode, did something, went to normal mode and then `:w` it wouldn't format even if you had it enabled before.