### PR TITLE
fix(harper): fix typo in `harper`'s `mason-lspconfig` override

### DIFF
--- a/lua/astrocommunity/pack/harper/init.lua
+++ b/lua/astrocommunity/pack/harper/init.lua
@@ -26,7 +26,7 @@ return {
   {
     "williamboman/mason-lspconfig.nvim",
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "harper-ls" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "harper_ls" })
     end,
   },
   {


### PR DESCRIPTION
## 📑 Description

According to https://github.com/williamboman/mason-lspconfig.nvim, the correct identifier for this language server in `mason-lspconfig` is `harper_ls`, not `harper-ls`.
