### PR TITLE
fix(proto): replace deprecated `bufls` with `buf_ls`

### DIFF
--- a/lua/astrocommunity/pack/proto/README.md
+++ b/lua/astrocommunity/pack/proto/README.md
@@ -3,5 +3,5 @@
 This plugin pack does the following:
 
 - Adds `proto` Treesitter parsers
-- Adds `bufls` language servers
+- Adds `buf_ls` language servers
 - Adds `buf` formatter

--- a/lua/astrocommunity/pack/proto/init.lua
+++ b/lua/astrocommunity/pack/proto/init.lua
@@ -13,7 +13,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "bufls" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf_ls" })
     end,
   },
   {


### PR DESCRIPTION
Update language server references from `bufls` to `buf_ls` as `bufls` is deprecated and will be removed in lspconfig 0.2.1.