### PR TITLE
fix(pack): Add support for additional Ansible directory structures in `ansible`'s path_regex, and correct docs

### DIFF
--- a/lua/astrocommunity/pack/ansible/README.md
+++ b/lua/astrocommunity/pack/ansible/README.md
@@ -2,8 +2,13 @@
 
 This plugin pack does the following:
 
+- Adds a set of local functions to help with Ansible's filetype detection
 - Adds `yaml` Treesitter parsers
-- Adds `ansiblels` language server
+- Adds `ansible-lint` and `ansible-language-server` via `mason-tool-installer.nvim`, if enabled
+- Sets up `mason-lspconfig.nvim` to use `ansiblels` if enabled
 - Adds the following `null-ls` sources:
   - [ansible-lint](https://github.com/ansible/ansible-lint)
-- Adds [ansible-vim](https://github.com/pearofducks/ansible-vim) for language specific tools
+- Adds the following `nvim-lint` sources:
+  - [ansible-lint](https://github.com/ansible/ansible-lint)
+- Adds [pearofducks/ansible-vim](https://github.com/pearofducks/ansible-vim), and sets it up to be loaded for `yaml.ansible` file types
+- Configures [stevearc/conform.nvim](https://github.com/stevearc/conform.nvim) to use `prettierd` and `prettier` for `yaml.ansible` file types

--- a/lua/astrocommunity/pack/ansible/init.lua
+++ b/lua/astrocommunity/pack/ansible/init.lua
@@ -4,8 +4,9 @@ local function yaml_ft(path, bufnr)
   if type(content) == "table" then content = table.concat(content, "\n") end
 
   -- check if file is in roles, tasks, or handlers folder
-  local path_regex = vim.regex "(tasks\\|roles\\|handlers)/"
+  local path_regex = vim.regex "(ansible\\|group_vars\\|handlers\\|host_vars\\|playbooks\\|roles\\|\\vars\\|tasks)/"
   if path_regex and path_regex:match_str(path) then return "yaml.ansible" end
+
   -- check for known ansible playbook text and if found, return yaml.ansible
   local regex = vim.regex "hosts:\\|tasks:"
   if regex and regex:match_str(content) then return "yaml.ansible" end


### PR DESCRIPTION
## 📑 Description
This PR further extends the regex used to match common Ansible paths, [some of them are documented best practices, even](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable):



We're adding the following paths to the regex:
- ansible/
- playbooks/
- group_vars/
- host_vars/
- vars/
- tasks/

## ℹ Additional Information
Here's an example on how nested variables look like in the wild:
```
├── ansible
│   ├── group_vars
│   ├── host_vars
│   ├── roles
│   │   ├── foo
│   │   │   ├── defaults
│   │   │   ├── tasks
│   │   │   └── vars
│   │   ├── bar
│   │   │   ├── defaults
│   │   │   ├── tasks
│   │   │   ├── templates
│   │   │   └── vars
│   │   └── baz
│   │       ├── vars
│   │       ├── defaults
│   │       └── tasks
│   └── vars
└── tests
    └── charts
        ├── hello
        │   └── templates
        │       └── tests
        └── oauth2
            └── templates
                └── tests
```