### PR TITLE
feat(copilotchat-nvim)!: update to v3

### DIFF
--- a/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
@@ -1,7 +1,7 @@
 ---@type LazySpec
 return {
   "CopilotC-Nvim/CopilotChat.nvim",
-  version = "^2",
+  version = "^3",
   cmd = {
     "CopilotChat",
     "CopilotChatOpen",
@@ -13,14 +13,14 @@ return {
     "CopilotChatLoad",
     "CopilotChatDebugInfo",
     "CopilotChatModels",
+    "CopilotChatAgents",
     "CopilotChatExplain",
     "CopilotChatReview",
     "CopilotChatFix",
     "CopilotChatOptimize",
     "CopilotChatDocs",
-    "CopilotChatFixDiagnostic",
+    "CopilotChatFixTests",
     "CopilotChatCommit",
-    "CopilotChatCommitStaged",
   },
   dependencies = {
     { "zbirenbaum/copilot.lua" },
@@ -87,16 +87,6 @@ return {
           desc = "Prompt actions",
         }
 
-        maps.n[prefix .. "d"] = {
-          create_mapping("help_actions", "buffer"),
-          desc = "LSP Diagnostics actions",
-        }
-
-        maps.v[prefix .. "d"] = {
-          create_mapping("help_actions", "visual"),
-          desc = "LSP Diagnostics actions",
-        }
-
         -- Quick Chat function
         local function quick_chat(selection_type)
           return function()
@@ -121,13 +111,5 @@ return {
     },
     { "AstroNvim/astroui", opts = { icons = { CopilotChat = "" } } },
   },
-  opts = {
-    window = {
-      layout = "float",
-      width = 74, -- absolute width in columns
-      height = vim.o.lines - 4, -- absolute height in rows, subtract for command line and status line
-      row = 1, -- row position of the window, starting from the top
-      col = vim.o.columns - 74, -- column position of the window, aligned to the right
-    },
-  },
+  opts = {},
 }


### PR DESCRIPTION
Closes #1291

## 📑 Description

Updates to v3 and removes the opts window changes as they have issues with window resizing and other issues when trying to move buffers around

## ℹ Additional Information

They've updated the prompt actions
https://github.com/CopilotC-Nvim/CopilotChat.nvim/compare/v2.16.0...v3.0.0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-L128

`help_actions` was deprecated and now just uses prompt actions
https://github.com/CopilotC-Nvim/CopilotChat.nvim/compare/v2.16.0...v3.0.0#diff-48b86e8f407d8316ff351556d1495ecbe87b72a450d19713b83829c5165eba37R10-R12

I've removed the opts windows setting since they are too personal and was causing issues. people can add it into their own configs
```lua
    window = {
      layout = "float",
      width = 74, -- absolute width in columns
      height = vim.o.lines - 4, -- absolute height in rows, subtract for command line and status line
      row = 1, -- row position of the window, starting from the top
      col = vim.o.columns - 74, -- column position of the window, aligned to the right
    },
```