### PR TITLE
fix(leap-nvim): Fix cursor invisible bug on nvim 0.10+

### DIFF
--- a/lua/astrocommunity/motion/leap-nvim/init.lua
+++ b/lua/astrocommunity/motion/leap-nvim/init.lua
@@ -5,26 +5,28 @@ return {
     {
       "AstroNvim/astrocore",
       opts = {
-        autocmds = {
-          leap_cursor = { -- https://github.com/ggandor/leap.nvim/issues/70#issuecomment-1521177534
-            {
-              event = "User",
-              pattern = "LeapEnter",
-              callback = function()
-                vim.cmd.hi("Cursor", "blend=100")
-                vim.opt.guicursor:append { "a:Cursor/lCursor" }
-              end,
-            },
-            {
-              event = "User",
-              pattern = "LeapLeave",
-              callback = function()
-                vim.cmd.hi("Cursor", "blend=0")
-                vim.opt.guicursor:remove { "a:Cursor/lCursor" }
-              end,
-            },
-          },
-        },
+        autocmds = vim.version().minor < 10
+            and {
+              leap_cursor = { -- https://github.com/ggandor/leap.nvim/issues/70#issuecomment-1521177534
+                {
+                  event = "User",
+                  pattern = "LeapEnter",
+                  callback = function()
+                    vim.cmd.hi("Cursor", "blend=100")
+                    vim.opt.guicursor:append { "a:Cursor/lCursor" }
+                  end,
+                },
+                {
+                  event = "User",
+                  pattern = "LeapLeave",
+                  callback = function()
+                    vim.cmd.hi("Cursor", "blend=0")
+                    vim.opt.guicursor:remove { "a:Cursor/lCursor" }
+                  end,
+                },
+              },
+            }
+          or {},
         mappings = {
           n = {
             ["s"] = { "<Plug>(leap-forward)", desc = "Leap forward" },


### PR DESCRIPTION
Closes #1219 

## 📑 Description

The workaround breaks on 0.10+ so I've made it only apply when the minor version is less than 10.