### PR TITLE
fix(blink-cmp): fix tab key handling

### DIFF
--- a/lua/astrocommunity/completion/blink-cmp/init.lua
+++ b/lua/astrocommunity/completion/blink-cmp/init.lua
@@ -26,28 +26,8 @@ return {
       ["<C-D>"] = { "scroll_documentation_down", "fallback" },
       ["<C-e>"] = { "hide", "fallback" },
       ["<CR>"] = { "accept", "fallback" },
-      ["<Tab>"] = {
-        function(cmp)
-          if cmp.windows.autocomplete.win:is_open() then
-            return cmp.select_next()
-          elseif cmp.is_in_snippet() then
-            return cmp.snippet_forward()
-          elseif has_words_before() then
-            return cmp.show()
-          end
-        end,
-        "fallback",
-      },
-      ["<S-Tab>"] = {
-        function(cmp)
-          if cmp.windows.autocomplete.win:is_open() then
-            return cmp.select_prev()
-          elseif cmp.is_in_snippet() then
-            return cmp.snippet_backward()
-          end
-        end,
-        "fallback",
-      },
+      ["<Tab>"] = { "select_next", "snippet_forward", "show", "fallback" },
+      ["<S-Tab>"] = { "select_prev", "snippet_backward", "fallback" },
     },
     windows = {
       autocomplete = {

--- a/lua/astrocommunity/completion/blink-cmp/init.lua
+++ b/lua/astrocommunity/completion/blink-cmp/init.lua
@@ -1,8 +1,3 @@
-local function has_words_before()
-  local line, col = (unpack or table.unpack)(vim.api.nvim_win_get_cursor(0))
-  return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match "%s" == nil
-end
-
 return {
   "Saghen/blink.cmp",
   event = "InsertEnter",


### PR DESCRIPTION
The previous attempt of conditional logic using cmp objects does not work. blink-cmp rather uses a simple approach by just defining a list of actions in order.

For example, the error occuring when hitting `<Tab>` was:

```
E5108: Error executing lua: ...mmunity/lua/astrocommunity/completion/blink-cmp/init.lua:31: attempt to index field 'windows' (a nil value)
stack traceback:
	...mmunity/lua/astrocommunity/completion/blink-cmp/init.lua:31: in function 'command'
	...share/nvim/lazy/blink.cmp/lua/blink/cmp/keymap/apply.lua:27: in function <...share/nvim/lazy/blink.cmp/lua/blink/cmp/keymap/apply.lua:19>
```

Which is clear because blink-cmp does not provide a method `.windows` or similar.