### PR TITLE
feat(blink.cmp): load lazy when enter cmdline mode.

### DIFF
--- a/lua/astrocommunity/completion/blink-cmp/init.lua
+++ b/lua/astrocommunity/completion/blink-cmp/init.lua
@@ -5,7 +5,7 @@ end
 
 return {
   "Saghen/blink.cmp",
-  event = "InsertEnter",
+  event = { "InsertEnter", "CmdlineEnter" },
   -- TODO: replace build with 'version = "*"' after the next release
   build = "cargo build --release",
   dependencies = { "rafamadriz/friendly-snippets" },


### PR DESCRIPTION
sometimes i enter neovim and use cmdline directly. i can't get cmdline hints.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
