### PR TITLE
docs: fix relative font path

### DIFF
--- a/docs/assets/template.html5
+++ b/docs/assets/template.html5
@@ -30,14 +30,14 @@
     <!-- preload most used fonts -->
     <link
       rel="preload"
-      href="/assets/fonts/web/InterVariable.woff2"
+      href="./assets/fonts/web/InterVariable.woff2"
       as="font"
       type="font/woff2"
       crossorigin="anonymous"
     />
     <link
       rel="preload"
-      href="/assets/fonts/webfonts/JetBrainsMono-Regular.woff2"
+      href="./assets/fonts/webfonts/JetBrainsMono-Regular.woff2"
       as="font"
       type="font/woff2"
       crossorigin="anonymous"


### PR DESCRIPTION
Forgot about the leading path in github pages `/astrocommunity/` so we need to add a dot to the font preload to avoid flash of unstyled text.

<img width="827" alt="Capture d’écran 2025-01-04 à 14 07 17" src="https://github.com/user-attachments/assets/7466f65c-c992-4c35-afc8-c21cd2b96541" />
