### PR TITLE
fix(pack): update `laravel-nvim` required deps from v2 to v3

### DIFF
--- a/lua/astrocommunity/pack/laravel/init.lua
+++ b/lua/astrocommunity/pack/laravel/init.lua
@@ -6,10 +6,10 @@ return {
     "adalessa/laravel.nvim",
     cmd = { "Sail", "Artisan", "Composer", "Npm", "Yarn", "Laravel" },
     dependencies = {
-      "nvim-telescope/telescope.nvim",
       "tpope/vim-dotenv",
+      "nvim-telescope/telescope.nvim",
       "MunifTanjim/nui.nvim",
-      "nvimtools/none-ls.nvim",
+      "kevinhwang91/promise-async",
       {
         "AstroNvim/astrocore",
         ---@param opts AstroCoreOpts


### PR DESCRIPTION
## 📑 Description

```
Failed to run `config` for laravel.nvim

.../.local/share/nvim/lazy/laravel.nvim/lua/laravel/app.lua:179: Promise-async is required for Laravel, please install it

# stacktrace:
  - /laravel.nvim/lua/laravel/app.lua:179 _in_ **validate_instalation**
  - /laravel.nvim/lua/laravel/app.lua:158 _in_ **start**
  - /laravel.nvim/lua/laravel/init.lua:6 _in_ **setup**
```

## ℹ Additional Information

Copied deps from https://adalessa.github.io/laravel-nvim-docs/docs/getting-started/
