### PR TITLE
fix(docker): use default formatter for yaml and turn off from docker_compose_language_service 

### DIFF
--- a/lua/astrocommunity/pack/docker/init.lua
+++ b/lua/astrocommunity/pack/docker/init.lua
@@ -1,8 +1,20 @@
 return {
+  { import = "astrocommunity.pack.yaml" },
   {
     "AstroNvim/astrocore",
     ---@type AstroCoreOpts
     opts = { filetypes = { filename = { ["docker-compose.yaml"] = "yaml.docker-compose" } } },
+  },
+  {
+    "AstroNvim/astrolsp",
+    optional = true,
+    opts = {
+      formatting = {
+        disabled = {
+          "docker_compose_language_service",
+        },
+      },
+    },
   },
   {
     "nvim-treesitter/nvim-treesitter",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->
Closes #1309 

## 📑 Description
This should turn off the default formatter from the docker_compose_language_service and use the one specified in the YAML pack to keep it all uniform and prevent double formatting if both packs are used at the same time. I encountered this issue with double formatting, which caused the code to jump up and down near the networks section.

[Screencast_20250105_205931.webm](https://github.com/user-attachments/assets/708e6d41-8e16-4ee9-a510-254ef3c11c92)


<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
Maybe there is a better way. Feedback is welcome. 🙂
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
