### PR TITLE
fix(nix): drop none-ls formatter

### DIFF
--- a/lua/astrocommunity/pack/nix/README.md
+++ b/lua/astrocommunity/pack/nix/README.md
@@ -3,7 +3,6 @@
 Requires the following in your `PATH`
 
 - [nixd](https://github.com/nix-community/nixd)
-- [alejandra](https://github.com/kamadorueda/alejandra)
 - [deadnix](https://github.com/astro/deadnix)
 - [statix](https://github.com/nerdypepper/statix)
 
@@ -12,6 +11,5 @@ This plugin pack does the following:
 - Adds `nix` Treesitter parsers
 - Adds `nixd` language server
 - Adds the following `null-ls` sources:
-  - [alejandra](https://github.com/kamadorueda/alejandra)
   - [deadnix](https://github.com/astro/deadnix)
   - [statix](https://github.com/nerdypepper/statix)

--- a/lua/astrocommunity/pack/nix/init.lua
+++ b/lua/astrocommunity/pack/nix/init.lua
@@ -15,7 +15,6 @@ return {
       local builtins = require("null-ls").builtins
       opts.sources = require("astrocore").list_insert_unique(opts.sources, {
         builtins.code_actions.statix,
-        builtins.formatting.alejandra,
         builtins.diagnostics.deadnix,
       })
     end,
@@ -24,15 +23,6 @@ return {
     "AstroNvim/astrolsp",
     optional = true,
     opts = function(_, opts) opts.servers = require("astrocore").list_insert_unique(opts.servers, { "nixd" }) end,
-  },
-  {
-    "stevearc/conform.nvim",
-    optional = true,
-    opts = {
-      formatters_by_ft = {
-        nix = { "alejandra" },
-      },
-    },
   },
   {
     "mfussenegger/nvim-lint",


### PR DESCRIPTION
nixd already provides formatting builtin:

https://github.com/nix-community/nixd/blob/2c25600cb9c91bc06fe8676c044814dc30435274/nixd/docs/configuration.md?plain=1#L62

<!-- ps-id: 1fa3237e-80c0-4325-a86a-cda8aa832f3a -->

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
