### PR TITLE
docs: add extention 'autolink_bare_uris'

### DIFF
--- a/docs/pages_create.sh
+++ b/docs/pages_create.sh
@@ -46,7 +46,7 @@ EOF
 # Use pandoc to convert from markdown to html.
 docker run -i --rm --mount type=bind,source="$PWD",target="$PWD",readonly --workdir "$PWD" \
   pandoc/core:3.5 \
-  --from markdown \
+  --from markdown+autolink_bare_uris \
   --standalone \
   --toc \
   --toc-depth 2 \


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
Some plugin documentation doesn't work because the links are written in just text instead of link markdown syntax.
Pandoc has an option to automatically convert this, so adding it to the site build process removes the need for contributors to check it.

I checked by running the pages_create.sh script on my local environment and only link text without braces is converted.

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
https://pandoc.org/MANUAL.html#extension-autolink_bare_uris