### PR TITLE
feat(copilotchat-nvim): select a picker based on installed one

### DIFF
--- a/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
@@ -25,7 +25,6 @@ return {
   dependencies = {
     { "zbirenbaum/copilot.lua" },
     { "nvim-lua/plenary.nvim" },
-    { "nvim-telescope/telescope.nvim" },
     {
       "AstroNvim/astrocore",
       ---@param opts AstroCoreOpts
@@ -71,7 +70,10 @@ return {
         -- Helper function to create mappings
         local function create_mapping(action_type, selection_type)
           return function()
-            require("CopilotChat.integrations.telescope").pick(require("CopilotChat.actions")[action_type] {
+            local fzf_ok = pcall(require, "fzf-lua")
+            local snacks_ok = pcall(require, "snacks")
+
+            require("CopilotChat.integrations." .. (fzf_ok and "fzflua" or snacks_ok and "snacks" or "telescope")).pick(require("CopilotChat.actions")[action_type] {
               selection = require("CopilotChat.select")[selection_type],
             })
           end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
This removes mandatory dependency on telescope and selects the picker based on which one is installed instead with a default to the telescope.
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
Can see different integrations here:
https://github.com/CopilotC-Nvim/CopilotChat.nvim/tree/main/lua/CopilotChat/integrations
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
