### PR TITLE
chore(cord-nvim): pin version to v1

### DIFF
--- a/lua/astrocommunity/media/cord-nvim/init.lua
+++ b/lua/astrocommunity/media/cord-nvim/init.lua
@@ -1,5 +1,6 @@
 return {
   "vyfor/cord.nvim",
+  version = "^1",
   build = vim.fn.has "win32" == 0 and "./build" or ".\\build",
   event = "VeryLazy",
   opts = {


### PR DESCRIPTION
## 📑 Description

Pins `cord.nvim` to version `1.0.0` or newer.  
This is a precautionary measure in case Cord v2 is merged into the master branch *while* #1322 is not yet merged into astrocommunity, potentially causing unexpected errors.