### PR TITLE
feat(sql): disable sqls formatter and add sqlfluff

### DIFF
--- a/lua/astrocommunity/pack/sql/init.lua
+++ b/lua/astrocommunity/pack/sql/init.lua
@@ -26,15 +26,56 @@ return {
     end,
   },
   {
-    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "sqls" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "sqlfluff" })
+      opts.handlers = {
+        sqlfluff = function()
+          local null_ls = require "null-ls"
+          null_ls.register(null_ls.builtins.diagnostics.sqlfluff.with {
+            extra_args = { "--dialect", "ansi" },
+          })
+          null_ls.register(null_ls.builtins.formatting.sqlfluff.with {
+            extra_args = { "--dialect", "ansi" },
+          })
+        end,
+      }
     end,
   },
   {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "sqlfluff", "sqls" })
+    end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        sql = { "sqlfluff" },
+      },
+      formatters = {
+        sqlfluff = {
+          args = { "fix", "--dialect=ansi", "-" },
+          require_cwd = false,
+        },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        sql = { "sqlfluff" },
+      },
+    },
+  },
+  {
     "nanotee/sqls.nvim",
-    lazy = true,
     dependencies = {
       "AstroNvim/astrocore",
       opts = {
@@ -45,7 +86,11 @@ return {
               desc = "Load sqls.nvim with sqls",
               callback = function(args)
                 local client = assert(vim.lsp.get_client_by_id(args.data.client_id))
-                if client.name == "sqls" then require("sqls").on_attach(client, args.buf) end
+                if client.name == "sqls" then
+                  -- Disable formatting due to bugs: https://github.com/sqls-server/sqls/issues/149
+                  client.server_capabilities.documentFormattingProvider = false
+                  require("sqls").on_attach(client, args.buf)
+                end
               end,
             },
           },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #1323
-->

## 📑 Description

<!-- Add a brief description of the pr -->
This should disable the sqls lsp formatter and use sqlfluff instead. Might as well use sqlfluff diagnostics also, I see them beneficial.

This is the issue with sqls at the moment: https://github.com/sqls-server/sqls/issues/149
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
This needs thorough testing, since I'm not sure if all works as expected and I lack knowledge to verify on my own due to being new to neovim ecosystem. Especially different combinations of null-ls/conform/nvim-lint/lspconfig community packs.

I disabled cwd in conform due to default settings requiring a config file to be present for the formatter to work. I didn't notice this behavior in null-ls.
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
