### PR TITLE
refactor(copilotchat-nvim): improve picker selection logic and error handling

### DIFF
--- a/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
@@ -69,16 +69,20 @@ return {
 
         -- Determine the currently active picker
         local function get_active_picker()
-          -- Snacks integration check
-          -- this is tricky because we can't just assume that if snacks.nvim is
-          -- installed, it's being used as the picker, too
-          local snacks = require "snacks.picker"
-          if snacks.config and snacks.config.ui_select then return "snacks" end
-
-          -- Check other CopilotChat compatibel pickers
+          -- Check CopilotChat compatibel pickers
           -- this is also a mapping between picker module names and their
           -- counterparts in the CopilotChat integrations
-          if require("astrocore").is_available "fzf-lua" then
+          -- snacks.picker is tricky because we can't just assume that if snacks.nvim is
+          -- installed, it's being used as the picker, too
+          if
+            require("astrocore").is_available "snacks.nvim"
+            and (function()
+              local snacks = require "snacks.picker"
+              return snacks.config and snacks.config.ui_select
+            end)()
+          then
+            return "snacks"
+          elseif require("astrocore").is_available "fzf-lua" then
             return "fzflua"
           elseif require("astrocore").is_available "telescope.nvim" then
             return "telescope"

--- a/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
@@ -67,17 +67,62 @@ return {
           desc = "Load Chat",
         }
 
+        -- Determine the currently active picker
+        local function get_active_picker()
+          -- Snacks integration check
+          -- this is tricky because we can't just assume that if snacks.nvim is
+          -- installed, it's being used as the picker, too
+          local snacks = require "snacks.picker"
+          if snacks.config and snacks.config.ui_select then return "snacks" end
+
+          -- Check other CopilotChat compatibel pickers
+          -- this is also a mapping between picker module names and their
+          -- counterparts in the CopilotChat integrations
+          if require("astrocore").is_available "fzf-lua" then
+            return "fzflua"
+          elseif require("astrocore").is_available "telescope.nvim" then
+            return "telescope"
+          end
+
+          -- Default fallback
+          return nil
+        end
+
         -- Helper function to create mappings
         local function create_mapping(action_type, selection_type)
           return function()
-            local fzf_ok = pcall(require, "fzf-lua")
-            local snacks_ok = pcall(require, "snacks")
+            local actions = require "CopilotChat.actions"
+            local items = actions[action_type] { selection = require("CopilotChat.select")[selection_type] }
+            if not items then
+              vim.notify("No " .. action_type:gsub("_", " ") .. " found for the current selection", vim.log.levels.WARN)
+              return
+            end
 
-            require("CopilotChat.integrations." .. (fzf_ok and "fzflua" or snacks_ok and "snacks" or "telescope")).pick(
-              require("CopilotChat.actions")[action_type] {
-                selection = require("CopilotChat.select")[selection_type],
-              }
-            )
+            -- Determine the active picker
+            local picker = get_active_picker()
+            if not picker then
+              vim.notify(
+                "No valid picker is enabled. Please enable one of telescope, fzf-lua, or snacks.",
+                vim.log.levels.ERROR
+              )
+              return
+            end
+
+            -- Attempt to load the picker module
+            local ok, picker_module = pcall(require, "CopilotChat.integrations." .. picker)
+            if not ok then
+              vim.notify(
+                ("Integration module '%s' for picker '%s' is not available. Ensure it is installed and enabled."):format(
+                  picker,
+                  picker
+                ),
+                vim.log.levels.WARN
+              )
+              return
+            end
+
+            -- Use the selected picker module
+            picker_module.pick(items)
           end
         end
 


### PR DESCRIPTION
This is an attempt to further improve on https://github.com/AstroNvim/astrocommunity/pull/1333.

First, a separate function to check for the currently active pickers name or `nil` if it has no CopilotChat.integrations module. Since I did not find a better solution to check if snacks.nvim picker is actually used as the picker (solely checking for snacks.nvim availability does not mean that it's picker is actually configured and used, contrary to telescope or fzf-lua), I tried finding something to find out, which is up for debate. Second, the `create_mapping()` function now checks for availability and compatibility of the active picker with CopilotChat integrations and gracefully warn users if it's not.
