### PR TITLE
feat(fzf-lua): directly go to definition when only a single result

### DIFF
--- a/lua/astrocommunity/fuzzy-finder/fzf-lua/init.lua
+++ b/lua/astrocommunity/fuzzy-finder/fzf-lua/init.lua
@@ -13,7 +13,9 @@ return {
           local maps = opts.mappings
           maps.n["<Leader>lD"] =
             { function() require("fzf-lua").diagnostics_document() end, desc = "Search diagnostics" }
-          if maps.n.gd then maps.n.gd[1] = function() require("fzf-lua").lsp_definitions() end end
+          if maps.n.gd then
+            maps.n.gd[1] = function() require("fzf-lua").lsp_definitions { jump_to_single_result = true } end
+          end
           if maps.n.gI then maps.n.gI[1] = function() require("fzf-lua").lsp_implementations() end end
           if maps.n["<Leader>lR"] then maps.n["<Leader>lR"][1] = function() require("fzf-lua").lsp_references() end end
           if maps.n.gy then maps.n.gy[1] = function() require("fzf-lua").lsp_typedefs() end end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
This will add behavior similar to telescope and snacks-picker, where if there is a single result then it directly goes there instead of opening the picker window.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
https://github.com/ibhagwan/fzf-lua/wiki#lsp-jump-to-location-for-single-result
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
