### PR TITLE
feat(fzf-lua): add key mappings similar to telescope

### DIFF
--- a/lua/astrocommunity/fuzzy-finder/fzf-lua/init.lua
+++ b/lua/astrocommunity/fuzzy-finder/fzf-lua/init.lua
@@ -63,5 +63,20 @@ return {
       end,
     },
   },
-  opts = { "default-title" },
+  opts = {
+    "default-title",
+    keymap = {
+      builtin = {
+        true,
+        ["<C-d>"] = "preview-page-down",
+        ["<C-u>"] = "preview-page-up",
+      },
+      fzf = {
+        true,
+        ["ctrl-d"] = "preview-page-down",
+        ["ctrl-u"] = "preview-page-up",
+        ["ctrl-q"] = "select-all+accept",
+      },
+    },
+  },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
I’ve added some key mappings to make all pickers more or less the same way. So, telescope, snacks-picker, and fzf-lua would have the same behavior.
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
I've copied the configuration from https://github.com/ibhagwan/fzf-lua/blob/8af88e542d70ed397f297a81168be0dd3394b0d4/lua/fzf-lua/profiles/telescope.lua#L60-L71
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
