### PR TITLE
fix(markview-nvim): adapted config to consider breaking changes in version v25.1.

### DIFF
--- a/lua/astrocommunity/markdown-and-latex/markview-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/markview-nvim/init.lua
@@ -15,7 +15,9 @@ return {
     end,
   },
   opts = {
-    hybrid_modes = { "n" },
-    headings = { shift_width = 0 },
+    preview = {
+      hybrid_modes = { "n" },
+      headings = { shift_width = 0 },
+    },
   },
 }


### PR DESCRIPTION
## 📑 Description

Adapted config to consider breaking changes introduced in `markview.nvim` v25.1.

## ℹ Additional Information

This fix works for `markview.nvim` v25.1 and later.
