### PR TITLE
fix(tailwindcss): add support for v4 by using tailwind.css rooter scan

### DIFF
--- a/lua/astrocommunity/pack/tailwindcss/README.md
+++ b/lua/astrocommunity/pack/tailwindcss/README.md
@@ -4,5 +4,11 @@ This plugin pack does the following:
 
 - Adds `css` Treesitter parser
 - Adds `tailwindcss` and `cssls` language servers
+  - tailwindcss server activates when it detects any of these files:
+    - `tailwind.config.{mjs,cjs,js,ts}`
+    - `postcss.config.js`
+    - `config/tailwind.config.js`
+    - `assets/tailwind.config.js`
+    - `tailwind.css`
 - Adds `prettierd` formatter
 - Adds [`tailwindcss-colorizer-cmp.nvim`](https://github.com/js-everts/cmp-tailwind-colors) to cmp completion sources

--- a/lua/astrocommunity/pack/tailwindcss/init.lua
+++ b/lua/astrocommunity/pack/tailwindcss/init.lua
@@ -22,7 +22,8 @@ return {
                   "tailwind.config.ts",
                   "postcss.config.js",
                   "config/tailwind.config.js",
-                  "assets/tailwind.config.js"
+                  "assets/tailwind.config.js",
+                  "tailwind.css"
                 )
                 return root_pattern(fname)
               end,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #1328 
-->

## 📑 Description

<!-- Add a brief description of the pr -->
This should hopefully allow working with tailwind v4
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
Proper solution would require scanning all `.css` files for `@import "tailwindcss";` which I imagine would be quite intensive.
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
