### PR TITLE
fix(docker): use dockerfile ft for hadolint

### DIFF
--- a/lua/astrocommunity/pack/docker/init.lua
+++ b/lua/astrocommunity/pack/docker/init.lua
@@ -66,7 +66,7 @@ return {
     optional = true,
     opts = {
       linters_by_ft = {
-        ["docker-compose"] = { "hadolint" },
+        ["dockerfile"] = { "hadolint" },
       },
     },
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
Hadolint doesn't work with docker compose, only dockerfile.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
Use same ft as in none-ls: https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTINS.md#defaults-44

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
