### PR TITLE
fix(bash): add nvim-lint and add shellcheck to conform

### DIFF
--- a/lua/astrocommunity/pack/bash/init.lua
+++ b/lua/astrocommunity/pack/bash/init.lua
@@ -45,7 +45,16 @@ return {
     optional = true,
     opts = {
       formatters_by_ft = {
-        sh = { "shfmt" },
+        sh = { "shfmt", "shellcheck" },
+      },
+    },
+  },
+  {
+    "mfussenegger/nvim-lint",
+    optional = true,
+    opts = {
+      linters_by_ft = {
+        sh = { "shellcheck" },
       },
     },
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
Not sure if this is correct, but nvim-lint seemed to have been missing, and also shellcheck wasn't set in conform, as it was for none-ls.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
