### PR TITLE
feat(conform-nvim): add mapping for ConformInfo

### DIFF
--- a/lua/astrocommunity/editing-support/conform-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/conform-nvim/init.lua
@@ -33,6 +33,7 @@ return {
         mappings = {
           n = {
             ["<Leader>lf"] = { function() vim.cmd.Format() end, desc = "Format buffer" },
+            ["<Leader>lc"] = { function() vim.cmd.ConformInfo() end, desc = "Conform information" },
             ["<Leader>uf"] = {
               function()
                 if vim.b.autoformat == nil then


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->
Closes https://github.com/AstroNvim/astrocommunity/issues/1335

## 📑 Description
Adds a mapping `<Leader>lc` for ConformInfo, similar to nonels info.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
Can't use same `<Leader>lI` since it's still occupied.
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
