### PR TITLE
fix(lazydev-nvim): add deprecation notice as it was added upstream

### DIFF
--- a/lua/astrocommunity/neovim-lua-development/lazydev-nvim/README.md
+++ b/lua/astrocommunity/neovim-lua-development/lazydev-nvim/README.md
@@ -7,3 +7,5 @@ Requires:
 - [Neovim v0.10+](https://github.com/neovim/neovim/releases)
 
 **Repository:** <https://github.com/folke/lazydev.nvim>
+
+Note: This plugins is part of AstroNvim core as of [v4.22.0](https://github.com/AstroNvim/AstroNvim/releases/tag/v4.22.0)

--- a/lua/astrocommunity/neovim-lua-development/lazydev-nvim/init.lua
+++ b/lua/astrocommunity/neovim-lua-development/lazydev-nvim/init.lua
@@ -2,34 +2,10 @@ return {
   "folke/lazydev.nvim",
   ft = "lua",
   cmd = "LazyDev",
-  opts = function(_, opts)
-    if not opts.library then
-      opts.library = {
-        { path = "luvit-meta/library", words = { "vim%.uv" } },
-        { path = "astrocore", words = { "AstroCore" } },
-        { path = "astrolsp", words = { "AstroLSP" } },
-        { path = "astroui", words = { "AstroUI" } },
-        { path = "astrotheme", words = { "AstroTheme" } },
-        { path = "lazy.nvim", words = { "Lazy" } },
-      }
-    end
+  init = function()
+    require("astrocore").notify(
+      "`lazydev.nvim` has been included upstream!\nPlease remove from your community plugins.",
+      vim.log.levels.WARN
+    )
   end,
-  specs = {
-    { "folke/neodev.nvim", optional = true, enabled = false },
-    { "Bilal2453/luvit-meta", lazy = true },
-    {
-      "hrsh7th/nvim-cmp",
-      optional = true,
-      opts = function(_, opts)
-        local lazydev_inserted
-        for _, source in ipairs(opts.sources or {}) do
-          if (type(source) == "table" and source.name or source) == "lazydev" then
-            lazydev_inserted = true
-            break
-          end
-        end
-        if not lazydev_inserted then table.insert(opts.sources, { name = "lazydev", group_index = 0 }) end
-      end,
-    },
-  },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
Deprecate the plugin, since it's been part of the core since v4.22.0
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
Deprecation setup copied from https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/project/neoconf-nvim
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
