### PR TITLE
fix(fzf-lua): show diagnostics for whole workspace

### DIFF
--- a/lua/astrocommunity/fuzzy-finder/fzf-lua/init.lua
+++ b/lua/astrocommunity/fuzzy-finder/fzf-lua/init.lua
@@ -12,7 +12,7 @@ return {
         if require("astrocore").is_available "fzf-lua" then
           local maps = opts.mappings
           maps.n["<Leader>lD"] =
-            { function() require("fzf-lua").diagnostics_document() end, desc = "Search diagnostics" }
+            { function() require("fzf-lua").diagnostics_workspace() end, desc = "Search diagnostics" }
           if maps.n.gd then
             maps.n.gd[1] = function() require("fzf-lua").lsp_definitions { jump_to_single_result = true } end
           end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
This change should match what the telescope and snacks-picker do: search for diagnostics for the whole workspace instead of the current buffer.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
