### PR TITLE
fix(rust): rust types load in lldb

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -136,7 +136,11 @@ if vim.fn.has "nvim-0.10" == 1 then
         end,
       }
       local final_server = require("astrocore").extend_tbl(astrolsp_opts, server)
-      return { server = final_server, dap = { adapter = adapter }, tools = { enable_clippy = false } }
+      return {
+        server = final_server,
+        dap = { adapter = adapter, load_rust_types = true },
+        tools = { enable_clippy = false },
+      }
     end,
     config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
   })
@@ -199,7 +203,11 @@ else
         end,
       }
       local final_server = require("astrocore").extend_tbl(astrolsp_opts, server)
-      return { server = final_server, dap = { adapter = adapter }, tools = { enable_clippy = false } }
+      return {
+        server = final_server,
+        dap = { adapter = adapter, load_rust_types = true },
+        tools = { enable_clippy = false },
+      }
     end,
     config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
   })


### PR DESCRIPTION
## 📑 Description

Added a `rustaceanvim` opt (`load_rust_types`) to make sure rust types are loaded into lldb.

Recently codelldb dropped support for rust types to be passed to LLDB. This is okay as the rust toolchain supports feature of loading rust types into lldb.

## ℹ Additional Information

Tested on ubuntu and MacOS.

Before:
![image](https://github.com/user-attachments/assets/b5f227ad-1e22-4c91-9ae9-bd0cc3f17e4c)

After:
![image](https://github.com/user-attachments/assets/7d26faa8-906c-4f49-9a54-5239a7d55fd9)

Reference: https://github.com/mrcjkb/rustaceanvim/issues/552#issuecomment-2455033130
