### PR TITLE
feat(neovim-lua-development): add lua-console.nvim

### DIFF
--- a/lua/astrocommunity/neovim-lua-development/lua-console-nvim/README.md
+++ b/lua/astrocommunity/neovim-lua-development/lua-console-nvim/README.md
@@ -1,7 +1,5 @@
 # Lua-console.nvim
 
-A handy scratch pad / REPL / debug console for Lua development and Neovim exploration and configuration.  
-Acts as a user friendly replacement of command mode - messages loop and as a handy scratch pad to store and test your code gists.
-Focuses on Lua and Neovim development, but can be used for any other language.
+A handy scratch pad / REPL / debug console for Lua development and Neovim exploration
 
 **Repository**: <https://github.com/yarospace/lua-console.nvim>

--- a/lua/astrocommunity/neovim-lua-development/lua-console-nvim/README.md
+++ b/lua/astrocommunity/neovim-lua-development/lua-console-nvim/README.md
@@ -1,0 +1,7 @@
+# Lua-console.nvim
+
+A handy scratch pad / REPL / debug console for Lua development and Neovim exploration and configuration.  
+Acts as a user friendly replacement of command mode - messages loop and as a handy scratch pad to store and test your code gists.
+Focuses on Lua and Neovim development, but can be used for any other language.
+
+**Repository**: <https://github.com/yarospace/lua-console.nvim>

--- a/lua/astrocommunity/neovim-lua-development/lua-console-nvim/init.lua
+++ b/lua/astrocommunity/neovim-lua-development/lua-console-nvim/init.lua
@@ -1,0 +1,26 @@
+return {
+  "yarospace/lua-console.nvim",
+  lazy = true,
+  specs = {
+    {
+      "AstroNvim/astrocore",
+      ---@type AstroCoreOpts
+      opts = {
+        mappings = {
+          n = {
+            ["`"] = { function() require("lua-console").toggle_console() end, desc = "Lua-console - toggle" },
+            ["<Leader>`"] = {
+              function() require("lua-console.utils").attach_toggle() end,
+              desc = "Lua-console - attach to buffer",
+            },
+          },
+        },
+      },
+    },
+  },
+  keys = {
+    { "`", desc = "Lua-console - toggle" },
+    { "<Leader>`", desc = "Lua-console - attach to buffer" },
+  },
+  opts = {},
+}


### PR DESCRIPTION
## 📑 Description

[Lua-console.nvim](https://github.com/YaroSpace/lua-console.nvim) handy scratch pad / REPL / debug console for Lua development and Neovim exploration and configuration. 