### PR TITLE
feat(editing-support): Add `quick-scope`

### DIFF
--- a/lua/astrocommunity/editing-support/quick-scope/README.md
+++ b/lua/astrocommunity/editing-support/quick-scope/README.md
@@ -1,0 +1,5 @@
+# quick-scope
+
+Visual guides on current line for f and t motions.
+
+**Repository:** <https://github.com/unblevable/quick-scope>

--- a/lua/astrocommunity/editing-support/quick-scope/init.lua
+++ b/lua/astrocommunity/editing-support/quick-scope/init.lua
@@ -1,0 +1,15 @@
+return {
+  {
+    "unblevable/quick-scope",
+    keys = { "f", "F", "t", "T" },
+    dependencies = {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        if not opts.options then opts.options = {} end
+        opts.options.g["qs_highlight_on_keys"] = { "f", "F", "t", "T" }
+        if not opts.mappings then opts.mappings = {} end
+        opts.mappings.n["<Leader>uq"] = { "<Cmd>QuickScopeToggle<CR>", desc = "Toggle quick-scope" }
+      end,
+    },
+  },
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This pr adds the unblevable/quick-scope vim plugin to astrocommunity.

It offers a visual enhancement to f and t motions. I quite like it as I find it less intrusive than plugins like sneak or flash and just improves on a default vim workflow.

## ℹ Additional Information

I configured it to my liking to add a bit of value to its addition to astrocommunity.
