### PR TITLE
feat(completion): add copilot-vim-cmp

### DIFF
--- a/lua/astrocommunity/completion/copilot-vim-cmp/README.md
+++ b/lua/astrocommunity/completion/copilot-vim-cmp/README.md
@@ -1,0 +1,20 @@
+# copilot.vim + CMP
+
+Integration of GitHub's official Copilot plugin with completion engines
+
+**Repository:** <https://github.com/github/copilot.vim>
+
+## Key Features
+
+- Seamless integration with nvim-cmp or blink.cmp
+- Enhanced keybindings for Copilot suggestions:
+  - `<Tab>` - Accept suggestion/Navigate completion menu
+  - `<M-[>` / `<M-]>` - Previous/Next suggestion
+  - `<M-\>` - Suggest completions
+  - `<M-Right>` - Accept word
+  - `<M-C-Right>` - Accept line
+  - `<C-]>` - Dismiss suggestion
+
+_Note_: This plugin will also reconfigure `<Tab>` in AstroNvim to work with both auto completion in `cmp` and `copilot`.
+
+The configuration includes support for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) and [blink.cmp](https://github.com/Saghen/blink.cmp) for improved completion behavior.

--- a/lua/astrocommunity/completion/copilot-vim-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-vim-cmp/init.lua
@@ -6,18 +6,11 @@ end
 ---@type LazySpec
 return {
   "github/copilot.vim",
-  cmd = "Copilot",
-  event = "User AstroFile",
-  init = function()
-    vim.g.copilot_filetypes = {
-      markdown = true,
-    }
-  end,
-  dependencies = {
+  specs = {
+    { import = "astrocommunity.completion.copilot-vim" },
     {
       "hrsh7th/nvim-cmp",
       optional = true,
-      dependencies = { "github/copilot.vim" },
       opts = function(_, opts)
         local cmp = require "cmp"
         local snip_status_ok, luasnip = pcall(require, "luasnip")
@@ -59,7 +52,6 @@ return {
     {
       "Saghen/blink.cmp",
       optional = true,
-      dependencies = { "github/copilot.vim" },
       ---@param opts blink.cmp.Config
       opts = function(_, opts)
         if not opts.keymap then opts.keymap = {} end

--- a/lua/astrocommunity/completion/copilot-vim-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-vim-cmp/init.lua
@@ -1,0 +1,113 @@
+local function has_words_before()
+  local line, col = unpack(vim.api.nvim_win_get_cursor(0))
+  return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match "%s" == nil
+end
+
+---@type LazySpec
+return {
+  "github/copilot.vim",
+  cmd = "Copilot",
+  event = "User AstroFile",
+  init = function()
+    vim.g.copilot_filetypes = {
+      markdown = true,
+    }
+  end,
+  dependencies = {
+    {
+      "hrsh7th/nvim-cmp",
+      optional = true,
+      dependencies = { "github/copilot.vim" },
+      opts = function(_, opts)
+        local cmp = require "cmp"
+        local snip_status_ok, luasnip = pcall(require, "luasnip")
+        if not snip_status_ok then return end
+
+        if not opts.mapping then opts.mapping = {} end
+        opts.mapping["<Tab>"] = cmp.mapping(function(fallback)
+          if vim.fn["copilot#GetDisplayedSuggestion"]().text ~= "" then
+            vim.api.nvim_feedkeys(vim.fn["copilot#Accept"](), "n", true)
+          elseif cmp.visible() then
+            cmp.select_next_item()
+          elseif luasnip.expand_or_jumpable() then
+            luasnip.expand_or_jump()
+          elseif has_words_before() then
+            cmp.complete()
+          else
+            fallback()
+          end
+        end, { "i", "s" })
+
+        opts.mapping["<M-]>"] = cmp.mapping(function() vim.fn["copilot#Next"]() end)
+        opts.mapping["<M-[>"] = cmp.mapping(function() vim.fn["copilot#Previous"]() end)
+        opts.mapping["<M-\\>"] = cmp.mapping(function() vim.fn["copilot#Suggest"]() end)
+        opts.mapping["<M-Right>"] = cmp.mapping(function()
+          local copilot_keys = vim.fn["copilot#AcceptWord"]()
+          if copilot_keys ~= "" and type(copilot_keys) == "string" then
+            vim.api.nvim_feedkeys(copilot_keys, "i", true)
+          end
+        end)
+        opts.mapping["<M-C-Right>"] = cmp.mapping(function()
+          local copilot_keys = vim.fn["copilot#AcceptLine"]()
+          if copilot_keys ~= "" and type(copilot_keys) == "string" then
+            vim.api.nvim_feedkeys(copilot_keys, "i", true)
+          end
+        end)
+        opts.mapping["<C-]>"] = cmp.mapping(function() vim.fn["copilot#Dismiss"]() end)
+      end,
+    },
+    {
+      "Saghen/blink.cmp",
+      optional = true,
+      dependencies = { "github/copilot.vim" },
+      ---@param opts blink.cmp.Config
+      opts = function(_, opts)
+        if not opts.keymap then opts.keymap = {} end
+        opts.keymap["<Tab>"] = {
+          function()
+            if vim.fn["copilot#GetDisplayedSuggestion"]().text ~= "" then
+              vim.api.nvim_feedkeys(vim.fn["copilot#Accept"](), "n", true)
+              return true
+            else
+              return false
+            end
+          end,
+          "select_next",
+          "snippet_forward",
+          function(cmp)
+            if has_words_before() or vim.api.nvim_get_mode().mode == "c" then return cmp.show() end
+          end,
+          "fallback",
+        }
+        opts.keymap["<M-]>"] = {
+          function() vim.fn["copilot#Next"]() end,
+        }
+        opts.keymap["<M-[>"] = {
+          function() vim.fn["copilot#Previous"]() end,
+        }
+        opts.keymap["<M-\\>"] = {
+          function() vim.fn["copilot#Suggest"]() end,
+        }
+        opts.keymap["<M-Right>"] = {
+          function()
+            local copilot_keys = vim.fn["copilot#AcceptWord"]()
+            if copilot_keys ~= "" and type(copilot_keys) == "string" then
+              vim.api.nvim_feedkeys(copilot_keys, "i", true)
+            end
+          end,
+        }
+        opts.keymap["<M-C-Right>"] = {
+          function()
+            local copilot_keys = vim.fn["copilot#AcceptLine"]()
+            if copilot_keys ~= "" and type(copilot_keys) == "string" then
+              vim.api.nvim_feedkeys(copilot_keys, "i", true)
+            end
+          end,
+        }
+        opts.keymap["<C-]>"] = {
+          function() vim.fn["copilot#Dismiss"]() end,
+        }
+      end,
+    },
+  },
+}

--- a/lua/astrocommunity/completion/copilot-vim/README.md
+++ b/lua/astrocommunity/completion/copilot-vim/README.md
@@ -4,4 +4,22 @@ Neovim plugin for GitHub Copilot
 
 Check out the [documentation](https://github.com/github/copilot.vim/blob/release/doc/copilot.txt) for usage and key mappings.
 
+It is possible to update `vim.g` copilot settings through AstroCore:
+
+```lua
+{
+  "AstroNvim/astrocore",
+  opts = {
+    options = {
+      g = {
+        copilot_workspace_folders = { vim.fn.getcwd() },
+        copilot_filetypes = {
+          markdown = true,
+        },
+      },
+    },
+  },
+}
+```
+
 **Repository:** <https://github.com/github/copilot.vim>

--- a/lua/astrocommunity/completion/copilot-vim/README.md
+++ b/lua/astrocommunity/completion/copilot-vim/README.md
@@ -1,6 +1,6 @@
 # copilot.vim
 
-The official Vim/Neovim plugin for GitHub Copilot.
+Neovim plugin for GitHub Copilot
 
 Check out the [documentation](https://github.com/github/copilot.vim/blob/release/doc/copilot.txt) for usage and key mappings.
 

--- a/lua/astrocommunity/completion/copilot-vim/README.md
+++ b/lua/astrocommunity/completion/copilot-vim/README.md
@@ -1,0 +1,7 @@
+# copilot.vim
+
+The official Vim/Neovim plugin for GitHub Copilot.
+
+Check out the [documentation](https://github.com/github/copilot.vim/blob/release/doc/copilot.txt) for usage and key mappings.
+
+**Repository:** <https://github.com/github/copilot.vim>

--- a/lua/astrocommunity/completion/copilot-vim/init.lua
+++ b/lua/astrocommunity/completion/copilot-vim/init.lua
@@ -1,0 +1,5 @@
+return {
+  "github/copilot.vim",
+  cmd = "Copilot",
+  event = "User AstroFile",
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
This will add the official GitHub Copilot vim plugin (from tpope) and cmp support. The main reason is because copilot.vim gets updated immediately to any Copilot changes.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
There might be breaking changes or any other slowdowns in the copilot-lua similar to https://github.com/zbirenbaum/copilot.lua/pull/368 and it would be nice to have an alternative that's official and immediately updated by GitHub itself.
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
