### PR TITLE
feat(mini-files): add mappings for open in splits

### DIFF
--- a/lua/astrocommunity/file-explorer/mini-files/init.lua
+++ b/lua/astrocommunity/file-explorer/mini-files/init.lua
@@ -16,7 +16,7 @@ local function map_split(buf_id, lhs, direction, close_on_file)
   end
 
   -- Adding `desc` will result into `show_help` entries
-  local desc = "Split " .. direction
+  local desc = "Open in " .. direction .. " split"
   if should_close then desc = desc .. " and close" end
   vim.keymap.set("n", lhs, rhs, { buffer = buf_id, desc = desc })
 end

--- a/lua/astrocommunity/file-explorer/mini-files/init.lua
+++ b/lua/astrocommunity/file-explorer/mini-files/init.lua
@@ -4,7 +4,6 @@ local function map_split(buf_id, lhs, direction, close_on_file)
   local should_close = close_on_file == nil and true or close_on_file
 
   local rhs = function()
-    -- Make new window and set it as target
     local cur_target = files.get_explorer_state().target_window
     local new_target = vim.api.nvim_win_call(cur_target, function()
       vim.cmd(direction .. " split")

--- a/lua/astrocommunity/file-explorer/mini-files/init.lua
+++ b/lua/astrocommunity/file-explorer/mini-files/init.lua
@@ -15,7 +15,6 @@ local function map_split(buf_id, lhs, direction, close_on_file)
     files.go_in { close_on_file = should_close }
   end
 
-  -- Adding `desc` will result into `show_help` entries
   local desc = "Open in " .. direction .. " split"
   if should_close then desc = desc .. " and close" end
   vim.keymap.set("n", lhs, rhs, { buffer = buf_id, desc = desc })

--- a/lua/astrocommunity/file-explorer/mini-files/init.lua
+++ b/lua/astrocommunity/file-explorer/mini-files/init.lua
@@ -1,3 +1,4 @@
+-- This function is taken from LazyVim: https://github.com/LazyVim/LazyVim/blob/cb223553ff73eb2f37ffb5dc0bb75b76a4677faf/lua/lazyvim/plugins/extras/editor/mini-files.lua
 local function map_split(buf_id, lhs, direction, close_on_file)
   local files = require "mini.files"
   local should_close = close_on_file == nil and true or close_on_file


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
Hello, I regularly use `mini.files` and I've noticed, in the default configuration provided by astrocommunity, we don't include keybindings for opening files in splits.
This PR addresses that.

NOTE: The code for `map_split` function was copied from [LazyVim's mini-files](https://github.com/LazyVim/LazyVim/blob/cb223553ff73eb2f37ffb5dc0bb75b76a4677faf/lua/lazyvim/plugins/extras/editor/mini-files.lua#L48)
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
