### PR TITLE
feat(docs): add auto scrollable TOC

### DIFF
--- a/docs/assets/template.html5
+++ b/docs/assets/template.html5
@@ -104,6 +104,45 @@
           });
         });
       })();
+      document.addEventListener('DOMContentLoaded', function () {
+        const toc = document.querySelector('nav[role="doc-toc"]');
+        const tocLinks = toc.querySelectorAll('a');
+        const sections = Array.from(tocLinks).map(link => document.querySelector(link.getAttribute('href')));
+
+        // Scroll to specific entry on page load
+        const hash = window.location.hash;
+        if (hash) {
+          const target = document.querySelector(hash);
+          if (target) {
+            target.scrollIntoView();
+            const activeLink = toc.querySelector(`a[href="${hash}"]`);
+            if (activeLink) {
+              activeLink.scrollIntoView({ behavior: 'auto', block: "nearest" });
+            }
+          }
+        }
+
+        // Observe each section
+        const observer = new IntersectionObserver(entries => {
+          entries.forEach(entry => {
+            if (entry.isIntersecting) {
+              const id = entry.target.id;
+              const activeLink = toc.querySelector(`a[href="#${id}"]`);
+              if (activeLink) {
+                tocLinks.forEach(link => link.classList.remove('active'));
+                activeLink.classList.add('active');
+                activeLink.scrollIntoView({ behavior: 'auto', block: "nearest" });
+              }
+            }
+          });
+        }, {rootMargin: '0px 0px -60% 0px', threshold: 0.5 } );
+
+        sections.forEach(section => {
+          if (section) {
+            observer.observe(section);
+          }
+        });
+      });
     </script>
     $for(include-after)$ $include-after$ $endfor$
   </body>

--- a/docs/assets/theme.css
+++ b/docs/assets/theme.css
@@ -318,6 +318,10 @@ sup {
   top: var(--side-note-sup-offset);
 }
 
+#TOC .active {
+  border-bottom: 1px solid var(--color-link);
+}
+
 sup {
   font-weight: inherit;
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
This should make the docs website a little easier to use, since the TOC will be scrolling alongside the main content. And it should also scroll the TOC when a URL with an ID is opened, e.g., `https://astronvim.github.io/astrocommunity/#bigfile-nvim`.


[Screencast_20250302_181703.webm](https://github.com/user-attachments/assets/533feec6-9f8c-4dae-a3cf-34a3e6748fad)

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
Might need some more testing, but seems to be working alright.
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
