### PR TITLE
docs(main): fix string interpolation

### DIFF
--- a/docs/assets/template.html5
+++ b/docs/assets/template.html5
@@ -115,7 +115,7 @@
           const target = document.querySelector(hash);
           if (target) {
             target.scrollIntoView();
-            const activeLink = toc.querySelector(`a[href="${hash}"]`);
+            const activeLink = toc.querySelector('a[href="' + hash + '"]');
             if (activeLink) {
               activeLink.scrollIntoView({ behavior: 'auto', block: "nearest" });
             }
@@ -127,7 +127,7 @@
           entries.forEach(entry => {
             if (entry.isIntersecting) {
               const id = entry.target.id;
-              const activeLink = toc.querySelector(`a[href="#${id}"]`);
+              const activeLink = toc.querySelector('a[href="#' + id + '"]');
               if (activeLink) {
                 tocLinks.forEach(link => link.classList.remove('active'));
                 activeLink.classList.add('active');


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
There seems to be an issue when compiling the templates which doesn't like the new `${}` string interpolation syntax. Should work now with normal concatenation.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
