### PR TITLE
feat(code-runner): Add mf-runner.nvim

### DIFF
--- a/lua/astrocommunity/code-runner/mf-runner-nvim/README.md
+++ b/lua/astrocommunity/code-runner/mf-runner-nvim/README.md
@@ -1,5 +1,5 @@
 # mf-runner.nvim
 
-Makefile task runner
+code runner based off of Makefiles because it's the easiest and one of the most common formats.
 
 **Repository:** <https://github.com/burgr033/mf-runner.nvim>

--- a/lua/astrocommunity/code-runner/mf-runner-nvim/README.md
+++ b/lua/astrocommunity/code-runner/mf-runner-nvim/README.md
@@ -1,0 +1,5 @@
+# mf-runner.nvim
+
+Makefile task runner
+
+**Repository:** <https://github.com/burgr033/mf-runner.nvim>

--- a/lua/astrocommunity/code-runner/mf-runner-nvim/init.lua
+++ b/lua/astrocommunity/code-runner/mf-runner-nvim/init.lua
@@ -1,0 +1,19 @@
+return {
+  "burgr033/mf-runner.nvim",
+  cmd = { "MFROpen", "MFRRun", "MFREdit" },
+  dependencies = {
+    { "folke/snacks.nvim" },
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        mappings = {
+          n = {
+            ["<Leader>Rr"] = { "<Cmd>MFROpen<CR>", desc = "mf-runner: open" },
+            ["<Leader>Re"] = { "<Cmd>MFREdit<CR>", desc = "mf-runner: edit Makefile" },
+          },
+        },
+      },
+    },
+  },
+  opts = {},
+}


### PR DESCRIPTION
## 📑 Description

This PR introduces [mf-runner.nvim](https://github.com/burgr033/mf-runner.nvim). A lightweight code runner plugin that uses good old Makefiles as a base.