### PR TITLE
fix(copilotchat-nvim): disable blink in copilotchat buffer

### DIFF
--- a/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
@@ -1,110 +1,129 @@
 ---@type LazySpec
 return {
-  "CopilotC-Nvim/CopilotChat.nvim",
-  version = "^3",
-  cmd = {
-    "CopilotChat",
-    "CopilotChatOpen",
-    "CopilotChatClose",
-    "CopilotChatToggle",
-    "CopilotChatStop",
-    "CopilotChatReset",
-    "CopilotChatSave",
-    "CopilotChatLoad",
-    "CopilotChatDebugInfo",
-    "CopilotChatModels",
-    "CopilotChatAgents",
-    "CopilotChatExplain",
-    "CopilotChatReview",
-    "CopilotChatFix",
-    "CopilotChatOptimize",
-    "CopilotChatDocs",
-    "CopilotChatFixTests",
-    "CopilotChatCommit",
-  },
-  dependencies = {
-    { "zbirenbaum/copilot.lua" },
-    { "nvim-lua/plenary.nvim" },
-    {
-      "AstroNvim/astrocore",
-      ---@param opts AstroCoreOpts
-      opts = function(_, opts)
-        local maps = assert(opts.mappings)
-        local prefix = opts.options.g.copilot_chat_prefix or "<Leader>P"
-        local astroui = require "astroui"
-
-        maps.n[prefix] = { desc = astroui.get_icon("CopilotChat", 1, true) .. "CopilotChat" }
-        maps.v[prefix] = { desc = astroui.get_icon("CopilotChat", 1, true) .. "CopilotChat" }
-
-        maps.n[prefix .. "o"] = { ":CopilotChatOpen<CR>", desc = "Open Chat" }
-        maps.n[prefix .. "c"] = { ":CopilotChatClose<CR>", desc = "Close Chat" }
-        maps.n[prefix .. "t"] = { ":CopilotChatToggle<CR>", desc = "Toggle Chat" }
-        maps.n[prefix .. "r"] = { ":CopilotChatReset<CR>", desc = "Reset Chat" }
-        maps.n[prefix .. "s"] = { ":CopilotChatStop<CR>", desc = "Stop Chat" }
-
-        maps.n[prefix .. "S"] = {
-          function()
-            vim.ui.input({ prompt = "Save Chat: " }, function(input)
-              if input ~= nil and input ~= "" then require("CopilotChat").save(input) end
-            end)
-          end,
-          desc = "Save Chat",
-        }
-
-        maps.n[prefix .. "L"] = {
-          function()
-            local copilot_chat = require "CopilotChat"
-            local path = copilot_chat.config.history_path
-            local chats = require("plenary.scandir").scan_dir(path, { depth = 1, hidden = true })
-            -- Remove the path from the chat names and .json
-            for i, chat in ipairs(chats) do
-              chats[i] = chat:sub(#path + 2, -6)
-            end
-            vim.ui.select(chats, { prompt = "Load Chat: " }, function(selected)
-              if selected ~= nil and selected ~= "" then copilot_chat.load(selected) end
-            end)
-          end,
-          desc = "Load Chat",
-        }
-
-        local function select_action(selection_type)
-          return function()
-            require("CopilotChat").select_prompt { selection = require("CopilotChat.select")[selection_type] }
-          end
-        end
-
-        maps.n[prefix .. "p"] = {
-          select_action "buffer",
-          desc = "Prompt actions",
-        }
-
-        maps.v[prefix .. "p"] = {
-          select_action "visual",
-          desc = "Prompt actions",
-        }
-
-        local function quick_chat(selection_type)
-          return function()
-            vim.ui.input({ prompt = "Quick Chat: " }, function(input)
-              if input ~= nil and input ~= "" then
-                require("CopilotChat").ask(input, { selection = require("CopilotChat.select")[selection_type] })
-              end
-            end)
-          end
-        end
-
-        maps.n[prefix .. "q"] = {
-          quick_chat "buffer",
-          desc = "Quick Chat",
-        }
-
-        maps.v[prefix .. "q"] = {
-          quick_chat "visual",
-          desc = "Quick Chat",
-        }
-      end,
+  {
+    "CopilotC-Nvim/CopilotChat.nvim",
+    version = "^3",
+    cmd = {
+      "CopilotChat",
+      "CopilotChatOpen",
+      "CopilotChatClose",
+      "CopilotChatToggle",
+      "CopilotChatStop",
+      "CopilotChatReset",
+      "CopilotChatSave",
+      "CopilotChatLoad",
+      "CopilotChatDebugInfo",
+      "CopilotChatModels",
+      "CopilotChatAgents",
+      "CopilotChatExplain",
+      "CopilotChatReview",
+      "CopilotChatFix",
+      "CopilotChatOptimize",
+      "CopilotChatDocs",
+      "CopilotChatFixTests",
+      "CopilotChatCommit",
     },
-    { "AstroNvim/astroui", opts = { icons = { CopilotChat = "" } } },
+    dependencies = {
+      { "zbirenbaum/copilot.lua" },
+      { "nvim-lua/plenary.nvim" },
+      {
+        "AstroNvim/astrocore",
+        ---@param opts AstroCoreOpts
+        opts = function(_, opts)
+          local maps = assert(opts.mappings)
+          local prefix = opts.options.g.copilot_chat_prefix or "<Leader>P"
+          local astroui = require "astroui"
+
+          maps.n[prefix] = { desc = astroui.get_icon("CopilotChat", 1, true) .. "CopilotChat" }
+          maps.v[prefix] = { desc = astroui.get_icon("CopilotChat", 1, true) .. "CopilotChat" }
+
+          maps.n[prefix .. "o"] = { ":CopilotChatOpen<CR>", desc = "Open Chat" }
+          maps.n[prefix .. "c"] = { ":CopilotChatClose<CR>", desc = "Close Chat" }
+          maps.n[prefix .. "t"] = { ":CopilotChatToggle<CR>", desc = "Toggle Chat" }
+          maps.n[prefix .. "r"] = { ":CopilotChatReset<CR>", desc = "Reset Chat" }
+          maps.n[prefix .. "s"] = { ":CopilotChatStop<CR>", desc = "Stop Chat" }
+
+          maps.n[prefix .. "S"] = {
+            function()
+              vim.ui.input({ prompt = "Save Chat: " }, function(input)
+                if input ~= nil and input ~= "" then require("CopilotChat").save(input) end
+              end)
+            end,
+            desc = "Save Chat",
+          }
+
+          maps.n[prefix .. "L"] = {
+            function()
+              local copilot_chat = require "CopilotChat"
+              local path = copilot_chat.config.history_path
+              local chats = require("plenary.scandir").scan_dir(path, { depth = 1, hidden = true })
+              -- Remove the path from the chat names and .json
+              for i, chat in ipairs(chats) do
+                chats[i] = chat:sub(#path + 2, -6)
+              end
+              vim.ui.select(chats, { prompt = "Load Chat: " }, function(selected)
+                if selected ~= nil and selected ~= "" then copilot_chat.load(selected) end
+              end)
+            end,
+            desc = "Load Chat",
+          }
+
+          local function select_action(selection_type)
+            return function()
+              require("CopilotChat").select_prompt { selection = require("CopilotChat.select")[selection_type] }
+            end
+          end
+
+          maps.n[prefix .. "p"] = {
+            select_action "buffer",
+            desc = "Prompt actions",
+          }
+
+          maps.v[prefix .. "p"] = {
+            select_action "visual",
+            desc = "Prompt actions",
+          }
+
+          local function quick_chat(selection_type)
+            return function()
+              vim.ui.input({ prompt = "Quick Chat: " }, function(input)
+                if input ~= nil and input ~= "" then
+                  require("CopilotChat").ask(input, { selection = require("CopilotChat.select")[selection_type] })
+                end
+              end)
+            end
+          end
+
+          maps.n[prefix .. "q"] = {
+            quick_chat "buffer",
+            desc = "Quick Chat",
+          }
+
+          maps.v[prefix .. "q"] = {
+            quick_chat "visual",
+            desc = "Quick Chat",
+          }
+        end,
+      },
+      { "AstroNvim/astroui", opts = { icons = { CopilotChat = "" } } },
+    },
+    opts = {},
   },
-  opts = {},
+  -- Blink integration
+  {
+    "saghen/blink.cmp",
+    optional = true,
+    ---@module 'blink.cmp'
+    ---@type blink.cmp.Config
+    opts = {
+      sources = {
+        providers = {
+          path = {
+            -- Path sources triggered by "/" interfere with CopilotChat commands
+            enabled = function() return vim.bo.filetype ~= "copilot-chat" end,
+          },
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
I had an issue where both autocomplete menus would open at the same time. https://github.com/CopilotC-Nvim/CopilotChat.nvim/discussions/969#discussioncomment-12507278
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
Thanks to https://github.com/LazyVim/LazyVim/pull/5754 for the solution.
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
