### PR TITLE
feat(grug-far-nvim): add support for GrugFarWithin

### DIFF
--- a/lua/astrocommunity/search/grug-far-nvim/init.lua
+++ b/lua/astrocommunity/search/grug-far-nvim/init.lua
@@ -17,7 +17,7 @@ end
 ---@type LazySpec
 return {
   "MagicDuck/grug-far.nvim",
-  cmd = "GrugFar",
+  cmd = { "GrugFar", "GrugFarWithin" },
   specs = {
     {
       "AstroNvim/astroui",
@@ -75,6 +75,26 @@ return {
         filetypes = {
           ["grug-far"] = false,
           ["grug-far-history"] = false,
+        },
+      },
+    },
+    {
+      "github/copilot.vim",
+      optional = true,
+      specs = {
+        {
+          "AstroNvim/astrocore",
+          ---@type AstroCoreOpts
+          opts = {
+            options = {
+              g = {
+                copilot_filetypes = {
+                  ["grug-far"] = false,
+                  ["grug-far-history"] = false,
+                },
+              },
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
This should add support for the new GrugFarWithin cmd and also add the missing copilot.vim options to disable it inside grug-far buffer.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
Thanks to https://github.com/LazyVim/LazyVim/pull/5772
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
