### PR TITLE
fix(grug-far-nvim): re-enable `which-key` for `ft=grug-far`

### DIFF
--- a/lua/astrocommunity/search/grug-far-nvim/init.lua
+++ b/lua/astrocommunity/search/grug-far-nvim/init.lua
@@ -105,14 +105,6 @@ return {
       opts = { integrations = { grug_far = true } },
     },
     {
-      "folke/which-key.nvim",
-      optional = true,
-      opts = function(_, opts)
-        if not opts.disable then opts.disable = {} end
-        opts.disable.ft = require("astrocore").list_insert_unique(opts.disable.ft, { "grug-far" })
-      end,
-    },
-    {
       "nvim-neo-tree/neo-tree.nvim",
       optional = true,
       opts = {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This PR works around the following plugin conflict...

- https://github.com/MagicDuck/grug-far.nvim/issues/419#issuecomment-2727111902

... by re-enabling `which-key` for `ft=grug-far` in `grug-far-nvim/init.lua`, as proposed by @magicduck (the project owner himself) in https://github.com/MagicDuck/grug-far.nvim/issues/419#issuecomment-2727111902:

> the config that @rami3l mentions is likely a hold over from "olden times" when which-key caused folds not to work correctly in grug-far, but that issue has been resolved for some time.
> [..]
> ```lua
>         if not opts.disable then opts.disable = {} end
>         opts.disable.ft = require("astrocore").list_insert_unique(opts.disable.ft, { "grug-far" })
> ```