### PR TITLE
feat(avante-nvim): consolidate keybinds under existing prefix

### DIFF
--- a/lua/astrocommunity/completion/avante-nvim/init.lua
+++ b/lua/astrocommunity/completion/avante-nvim/init.lua
@@ -26,6 +26,9 @@ return {
       edit = prefix .. "e",
       refresh = prefix .. "r",
       focus = prefix .. "f",
+      select_model = prefix .. "?",
+      stop = prefix .. "S",
+      select_history = prefix .. "h",
       toggle = {
         default = prefix .. "t",
         debug = prefix .. "d",


### PR DESCRIPTION
- Ensure all avante keybinds use the same prefix 