### PR TITLE
Avante: Neotree shortcut

### DIFF
--- a/lua/astrocommunity/completion/avante-nvim/init.lua
+++ b/lua/astrocommunity/completion/avante-nvim/init.lua
@@ -75,5 +75,43 @@ return {
         opts.filetypes = require("astrocore").list_insert_unique(opts.filetypes, { "Avante" })
       end,
     },
+    {
+      "nvim-neo-tree/neo-tree.nvim",
+      optional = true,
+      opts = function (_, opts)
+        local ok, _ = pcall(require, "neo-tree")
+        if not ok then return opts end
+        return require("astrocore").extend_tbl(opts, {
+          filesystem = {
+            commands = {
+              avante_add_files = function(state)
+                local node = state.tree:get_node()
+                local filepath = node:get_id()
+                local relative_path = require("avante.utils").relative_path(filepath)
+                
+                local sidebar = require("avante").get()
+
+                local open = sidebar:is_open()
+                -- ensure avante sidebar is open
+                if not open then
+                  require("avante.api").ask()
+                  sidebar = require("avante").get()
+                end
+
+                sidebar.file_selector:add_selected_file(relative_path)
+
+                -- remove neo tree buffer
+                if not open then sidebar.file_selector:remove_selected_file "neo-tree filesystem [1]" end
+              end,
+            },
+            window = {
+              mappings = {
+                ["oa"] = "avante_add_files",
+              },
+            },
+          },
+        })
+      end,
+    },
   },
 }


### PR DESCRIPTION
fix: The configuration in the README for Avante.nvim overrides the original shortcuts for neotree

