### PR TITLE
feat(avante-nvim): integrate Avante with Mcphub

### DIFF
--- a/lua/astrocommunity/completion/avante-nvim/init.lua
+++ b/lua/astrocommunity/completion/avante-nvim/init.lua
@@ -47,6 +47,27 @@ return {
   },
   specs = { -- configure optional plugins
     { "AstroNvim/astroui", opts = { icons = { Avante = "" } } },
+    {
+        "ravitemer/mcphub.nvim",
+        optional = true,
+        specs = {
+          {
+            "yetone/avante.nvim",
+            opts = {
+              system_prompt = function()
+                local hub = require("mcphub").get_hub_instance()
+                return hub:get_active_servers_prompt()
+              end,
+              -- The custom_tools type supports both a list and a function that returns a list. Using a function here prevents requiring mcphub before it's loaded
+              custom_tools = function()
+                return {
+                  require("mcphub.extensions.avante").mcp_tool(),
+                }
+              end,
+            },
+          },
+        },
+      },
     { -- if copilot.lua is available, default to copilot provider
       "zbirenbaum/copilot.lua",
       optional = true,

--- a/lua/astrocommunity/completion/avante-nvim/init.lua
+++ b/lua/astrocommunity/completion/avante-nvim/init.lua
@@ -7,12 +7,16 @@ return {
   cmd = {
     "AvanteAsk",
     "AvanteBuild",
-    "AvanteEdit",
-    "AvanteRefresh",
-    "AvanteSwitchProvider",
-    "AvanteChat",
-    "AvanteToggle",
+    "AvanteChat",  
     "AvanteClear",
+    "AvanteEdit",
+    "AvanteFocus",
+    "AvanteRefresh",
+    "AvanteStop",
+    "AvanteSwitchProvider",
+    "AvanteShowRepoMap",
+    "AvanteToggle",
+    "AvanteModels"
   },
   dependencies = {
     "stevearc/dressing.nvim",


### PR DESCRIPTION
- Add ravitemer/mcphub.nvim as optional plugin dependency
- Add additional cmd 