### PR TITLE
fix(magazine-nvim): not disabling blink

### DIFF
--- a/lua/astrocommunity/completion/magazine-nvim/init.lua
+++ b/lua/astrocommunity/completion/magazine-nvim/init.lua
@@ -2,5 +2,9 @@ return {
   "iguanacucumber/magazine.nvim",
   lazy = true,
   config = function() vim.opt.rtp:remove(require("astrocore").get_plugin("nvim-cmp").dir) end,
-  specs = { "hrsh7th/nvim-cmp", dependencies = { "iguanacucumber/magazine.nvim" } },
+  specs = {
+    { "hrsh7th/nvim-cmp", dependencies = { "iguanacucumber/magazine.nvim" } },
+    { "Saghen/blink.cmp", enabled = false },
+    { "Saghen/blink.compat", enabled = false },
+  },
 }

--- a/lua/astrocommunity/utility/noice-nvim/init.lua
+++ b/lua/astrocommunity/utility/noice-nvim/init.lua
@@ -41,11 +41,15 @@ return {
       opts = function(_, opts)
         local noice_opts = require("astrocore").plugin_opts "noice.nvim"
         -- disable the necessary handlers in AstroLSP
+        if not opts.defaults then opts.defaults = {} end
+        -- TODO: remove lsp_handlers when dropping support for AstroNvim v4
         if not opts.lsp_handlers then opts.lsp_handlers = {} end
         if vim.tbl_get(noice_opts, "lsp", "hover", "enabled") ~= false then
+          opts.defaults.hover = nil
           opts.lsp_handlers["textDocument/hover"] = false
         end
         if vim.tbl_get(noice_opts, "lsp", "signature", "enabled") ~= false then
+          opts.defaults.signature_help = nil
           opts.lsp_handlers["textDocument/signatureHelp"] = false
           if not opts.features then opts.features = {} end
           opts.features.signature_help = false


### PR DESCRIPTION
Closes #1403

## 📑 Description
With the plugin enabled you'll have both blink and nvim-cmp enable, I've just disabled blink

