### PR TITLE
feat!: astronvim v5 compatibility

### DIFF
--- a/lua/astrocommunity/comment/ts-comments-nvim/init.lua
+++ b/lua/astrocommunity/comment/ts-comments-nvim/init.lua
@@ -2,7 +2,7 @@ return {
   "folke/ts-comments.nvim",
   opts = {},
   event = "VeryLazy",
-  enabled = vim.fn.has "nvim-0.10.0" == 1,
+  enabled = true,
   specs = {
     { "numToStr/Comment.nvim", optional = true, enabled = false },
     { "JoosepAlviste/nvim-ts-context-commentstring", optional = true, enabled = false },

--- a/lua/astrocommunity/completion/nvim-cmp/README.md
+++ b/lua/astrocommunity/completion/nvim-cmp/README.md
@@ -1,0 +1,5 @@
+# nvim-cmp
+
+A completion plugin for neovim coded in Lua.
+
+**Repository:** <https://github.com/hrsh7th/nvim-cmp>

--- a/lua/astrocommunity/completion/nvim-cmp/init.lua
+++ b/lua/astrocommunity/completion/nvim-cmp/init.lua
@@ -1,0 +1,243 @@
+local function has_words_before()
+  local line, col = (unpack or table.unpack)(vim.api.nvim_win_get_cursor(0))
+  return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match "%s" == nil
+end
+local function is_visible(cmp) return cmp.core.view:visible() or vim.fn.pumvisible() == 1 end
+
+return {
+  "hrsh7th/nvim-cmp",
+  dependencies = {
+    { "hrsh7th/cmp-buffer", lazy = true },
+    { "hrsh7th/cmp-path", lazy = true },
+    { "hrsh7th/cmp-nvim-lsp", lazy = true },
+  },
+  event = "InsertEnter",
+  opts_extend = { "sources" },
+  opts = function(_, opts)
+    local cmp, astro = require "cmp", require "astrocore"
+
+    local sources = {}
+    for source_plugin, source in pairs {
+      ["cmp-buffer"] = { name = "buffer", priority = 500, group_index = 2 },
+      ["cmp-nvim-lsp"] = { name = "nvim_lsp", priority = 1000 },
+      ["cmp-path"] = { name = "path", priority = 250 },
+    } do
+      if astro.is_available(source_plugin) then table.insert(sources, source) end
+    end
+
+    local function get_icon_provider()
+      local _, mini_icons = pcall(require, "mini.icons")
+      if _G.MiniIcons then
+        return function(kind) return mini_icons.get("lsp", kind or "") end
+      end
+      local lspkind_avail, lspkind = pcall(require, "lspkind")
+      if lspkind_avail then
+        return function(kind) return lspkind.symbolic(kind, { mode = "symbol" }) end
+      end
+    end
+    local icon_provider = get_icon_provider()
+
+    local function format(entry, item)
+      local highlight_colors_avail, highlight_colors = pcall(require, "nvim-highlight-colors")
+      local color_item = highlight_colors_avail and highlight_colors.format(entry, { kind = item.kind })
+      if icon_provider then
+        local icon = icon_provider(item.kind)
+        if icon then item.kind = icon end
+      end
+      if color_item and color_item.abbr and color_item.abbr_hl_group then
+        item.kind, item.kind_hl_group = color_item.abbr, color_item.abbr_hl_group
+      end
+      return item
+    end
+
+    return astro.extend_tbl(opts, {
+      enabled = function()
+        -- Disable completion when recording macros
+        if vim.fn.reg_recording() ~= "" or vim.fn.reg_executing() ~= "" then return false end
+        -- Disable completion for prompt windows that are not `nvim-dap` prompts
+        local dap_prompt = astro.is_available "cmp-dap" -- add interoperability with cmp-dap
+          and vim.tbl_contains({ "dap-repl", "dapui_watches", "dapui_hover" }, vim.bo.filetype)
+        if vim.bo.buftype == "prompt" and not dap_prompt then return false end
+        -- Disable completion when disabled in AstroNvim
+        return vim.F.if_nil(vim.b.completion, astro.config.features.cmp)
+      end,
+      preselect = cmp.PreselectMode.None,
+      formatting = { fields = { "kind", "abbr", "menu" }, format = format },
+      confirm_opts = {
+        behavior = cmp.ConfirmBehavior.Replace,
+        select = false,
+      },
+      window = {
+        completion = cmp.config.window.bordered {
+          col_offset = -2,
+          side_padding = 0,
+          border = "rounded",
+          winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:PmenuSel,Search:None",
+        },
+        documentation = cmp.config.window.bordered {
+          border = "rounded",
+          winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:PmenuSel,Search:None",
+        },
+      },
+      mapping = {
+        ["<Up>"] = cmp.mapping.select_prev_item { behavior = cmp.SelectBehavior.Select },
+        ["<Down>"] = cmp.mapping.select_next_item { behavior = cmp.SelectBehavior.Select },
+        ["<C-P>"] = cmp.mapping(function()
+          if is_visible(cmp) then
+            cmp.select_prev_item()
+          else
+            cmp.complete()
+          end
+        end),
+        ["<C-N>"] = cmp.mapping(function()
+          if is_visible(cmp) then
+            cmp.select_next_item()
+          else
+            cmp.complete()
+          end
+        end),
+        ["<C-K>"] = cmp.mapping(cmp.mapping.select_prev_item(), { "i", "c" }),
+        ["<C-J>"] = cmp.mapping(cmp.mapping.select_next_item(), { "i", "c" }),
+        ["<C-U>"] = cmp.mapping(cmp.mapping.scroll_docs(-4), { "i", "c" }),
+        ["<C-D>"] = cmp.mapping(cmp.mapping.scroll_docs(4), { "i", "c" }),
+        ["<C-Space>"] = cmp.mapping(cmp.mapping.complete(), { "i", "c" }),
+        ["<C-Y>"] = cmp.config.disable,
+        ["<C-E>"] = cmp.mapping(cmp.mapping.abort(), { "i", "c" }),
+        ["<CR>"] = cmp.mapping(cmp.mapping.confirm { select = false }, { "i", "c" }),
+        ["<Tab>"] = cmp.mapping(function(fallback)
+          if is_visible(cmp) then
+            cmp.select_next_item()
+          elseif vim.api.nvim_get_mode().mode ~= "c" and vim.snippet and vim.snippet.active { direction = 1 } then
+            vim.schedule(function() vim.snippet.jump(1) end)
+          elseif has_words_before() then
+            cmp.complete()
+          else
+            fallback()
+          end
+        end, { "i", "s" }),
+        ["<S-Tab>"] = cmp.mapping(function(fallback)
+          if is_visible(cmp) then
+            cmp.select_prev_item()
+          elseif vim.api.nvim_get_mode().mode ~= "c" and vim.snippet and vim.snippet.active { direction = -1 } then
+            vim.schedule(function() vim.snippet.jump(-1) end)
+          else
+            fallback()
+          end
+        end, { "i", "s" }),
+      },
+      sources = sources,
+    })
+  end,
+  config = function(_, opts)
+    for _, source in ipairs(opts.sources or {}) do
+      if not source.group_index then source.group_index = 1 end
+    end
+    local cmp = require "cmp"
+    cmp.setup(opts)
+
+    local autopairs_avail, autopairs = pcall(require, "nvim-autopairs.completion.cmp")
+    if autopairs_avail then cmp.event:on("confirm_done", autopairs.on_confirm_done { tex = false }) end
+  end,
+  specs = {
+    {
+      "AstroNvim/astrolsp",
+      optional = true,
+      opts = function(_, opts)
+        local astrocore = require "astrocore"
+        if astrocore.is_available "cmp-nvim-lsp" then
+          opts.capabilities = astrocore.extend_tbl(opts.capabilities, {
+            textDocument = {
+              completion = {
+                completionItem = {
+                  documentationFormat = { "markdown", "plaintext" },
+                  snippetSupport = true,
+                  preselectSupport = true,
+                  insertReplaceSupport = true,
+                  labelDetailsSupport = true,
+                  deprecatedSupport = true,
+                  commitCharactersSupport = true,
+                  tagSupport = { valueSet = { 1 } },
+                  resolveSupport = { properties = { "documentation", "detail", "additionalTextEdits" } },
+                },
+              },
+            },
+          })
+        end
+      end,
+    },
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        maps.n["<Leader>uc"] =
+          { function() require("astrocore.toggles").buffer_cmp() end, desc = "Toggle autocompletion (buffer)" }
+        maps.n["<Leader>uC"] =
+          { function() require("astrocore.toggles").cmp() end, desc = "Toggle autocompletion (global)" }
+      end,
+    },
+    {
+      "L3MON4D3/LuaSnip",
+      optional = true,
+      specs = {
+        {
+          "hrsh7th/nvim-cmp",
+          dependencies = { { "saadparwaiz1/cmp_luasnip", lazy = true } },
+          opts = function(_, opts)
+            local luasnip, cmp = require "luasnip", require "cmp"
+
+            if not opts.snippet then opts.snippet = {} end
+            opts.snippet.expand = function(args) luasnip.lsp_expand(args.body) end
+
+            if not opts.sources then opts.sources = {} end
+            table.insert(opts.sources, { name = "luasnip", priority = 750 })
+
+            if not opts.mappings then opts.mappings = {} end
+            opts.mapping["<Tab>"] = cmp.mapping(function(fallback)
+              if is_visible(cmp) then
+                cmp.select_next_item()
+              elseif vim.api.nvim_get_mode().mode ~= "c" and luasnip.expand_or_locally_jumpable() then
+                luasnip.expand_or_jump()
+              elseif has_words_before() then
+                cmp.complete()
+              else
+                fallback()
+              end
+            end, { "i", "s" })
+            opts.mapping["<S-Tab>"] = cmp.mapping(function(fallback)
+              if is_visible(cmp) then
+                cmp.select_prev_item()
+              elseif vim.api.nvim_get_mode().mode ~= "c" and luasnip.jumpable(-1) then
+                luasnip.jump(-1)
+              else
+                fallback()
+              end
+            end, { "i", "s" })
+          end,
+        },
+      },
+    },
+    {
+      "folke/lazydev.nvim",
+      optional = true,
+      specs = {
+        {
+          "hrsh7th/nvim-cmp",
+          opts = function(_, opts) table.insert(opts.sources, { name = "lazydev", group_index = 0 }) end,
+        },
+      },
+    },
+    {
+      "rcarriga/cmp-dap",
+      optional = true,
+      dependencies = { "hrsh7th/nvim-cmp" },
+      config = function(...)
+        require "astronvim.plugins.configs.cmp-dap"(...)
+        require("cmp").setup.filetype({ "dap-repl", "dapui_watches", "dapui_hover" }, {
+          sources = {
+            { name = "dap" },
+          },
+        })
+      end,
+    },
+  },
+}

--- a/lua/astrocommunity/editing-support/conform-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/conform-nvim/init.lua
@@ -1,7 +1,6 @@
 return {
   "stevearc/conform.nvim",
   event = "User AstroFile",
-  version = vim.fn.has "nvim-0.10" ~= 1 and "7",
   cmd = "ConformInfo",
   specs = {
     { "AstroNvim/astrolsp", optional = true, opts = { formatting = { disabled = true } } },

--- a/lua/astrocommunity/editing-support/mcphub-nvim/README.md
+++ b/lua/astrocommunity/editing-support/mcphub-nvim/README.md
@@ -1,0 +1,7 @@
+# Mcphub.nvim
+
+A powerful Neovim plugin for managing MCP (Model Context Protocol) servers
+
+_Note_: This plugin requires [mcp-hub](https://www.npmjs.com/package/mcp-hub) to be installed. This can be done with `npm`, `bun`, `yarn`, or `pnpm`. 
+
+**Repository:** <https://github.com/ravitemer/mcphub.nvim/tree/main>

--- a/lua/astrocommunity/editing-support/mcphub-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/mcphub-nvim/init.lua
@@ -1,0 +1,36 @@
+return {
+  "ravitemer/mcphub.nvim",
+  dependencies = {
+    "nvim-lua/plenary.nvim", -- Required for Job and HTTP requests
+  },
+  event = "User AstroFile",
+  cmd = "MCPHub",
+  opts = {
+    port = 3000,
+    config = vim.fn.expand "~/mcpservers.json",
+    log = {
+      level = vim.log.levels.WARN,
+      to_file = false,
+      file_path = nil,
+      prefix = "MCPHub",
+    },
+  },
+  specs = {
+    {
+      "yetone/avante.nvim",
+      optional = true,
+      opts = {
+        system_prompt = function()
+          local hub = require("mcphub").get_hub_instance()
+          return hub:get_active_servers_prompt()
+        end,
+        -- The custom_tools type supports both a list and a function that returns a list. Using a function here prevents requiring mcphub before it's loaded
+        custom_tools = function()
+          return {
+            require("mcphub.extensions.avante").mcp_tool(),
+          }
+        end,
+      },
+    },
+  },
+}

--- a/lua/astrocommunity/editing-support/yanky-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/yanky-nvim/init.lua
@@ -1,13 +1,14 @@
+local is_windows = jit.os:find "Windows"
 return {
   "gbprod/yanky.nvim",
   dependencies = {
-    { "kkharji/sqlite.lua", enabled = not jit.os:find "Windows" },
+    { "kkharji/sqlite.lua", enabled = not is_windows },
     {
       "AstroNvim/astrocore",
       opts = {
         mappings = {
           n = {
-            ["<Leader>fy"] = { "<Cmd>Telescope yank_history<CR>", desc = "Find yanks" },
+            ["<Leader>fy"] = { "<Cmd>YankRingHistory<CR>", desc = "Find yanks" },
             ["y"] = { "<Plug>(YankyYank)", desc = "Yank text" },
             ["p"] = { "<Plug>(YankyPutAfter)", desc = "Put yanked text after cursor" },
             ["P"] = { "<Plug>(YankyPutBefore)", desc = "Put yanked text before cursor" },
@@ -37,19 +38,41 @@ return {
       },
     },
   },
-  opts = function()
-    local mapping = require "yanky.telescope.mapping"
-    local mappings = mapping.get_defaults()
-    mappings.i["<c-p>"] = nil
-    return {
+  opts = function(_, opts)
+    local astrocore = require "astrocore"
+    opts = astrocore.extend_tbl(opts, {
       highlight = { timer = 200 },
-      ring = { storage = jit.os:find "Windows" and "shada" or "sqlite" },
-      picker = {
+      ring = { storage = is_windows and "shada" or "sqlite" },
+    })
+    if require("astrocore").is_available "telescope.nvim" then
+      local mapping = require "yanky.telescope.mapping"
+      local mappings = mapping.get_defaults()
+      mappings.i["<c-p>"] = nil
+      opts.picker = astrocore.extend_tbl(opts.picker, {
         telescope = {
           use_default_mappings = false,
           mappings = mappings,
         },
-      },
-    }
+      })
+    end
+    return opts
   end,
+  specs = {
+    {
+      "nvim-telescope/telescope.nvim",
+      optional = true,
+      specs = {
+        {
+          "AstroNvim/astrocore",
+          opts = {
+            mappings = {
+              n = {
+                ["<Leader>fy"] = { "<Cmd>Telescope yank_history<CR>", desc = "Find yanks" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 }

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -4,7 +4,7 @@ local is_available = function(plugin)
 end
 local haskell_ft = { "haskell", "lhaskell", "cabal", "cabalproject" }
 
-local pack = {
+return {
   { import = "astrocommunity.pack.yaml" }, -- stack.yaml
   { import = "astrocommunity.pack.json" }, -- hls.json
   { import = "astrocommunity.test.neotest" }, -- neotest-haskell
@@ -72,16 +72,11 @@ local pack = {
       table.insert(opts.adapters, require "neotest-haskell"(require("astrocore").plugin_opts "neotest-haskell"))
     end,
   },
-}
-
-if vim.fn.has "nvim-0.10" == 1 then
-  -- haskell-tools v4 supports neovim v0.10+
-  table.insert(pack, {
+  {
     "mrcjkb/haskell-tools.nvim",
     ft = haskell_ft,
     dependencies = {
-      -- vim.fn.has >= nvim 0.9 removes plenary dependency
-      { "nvim-lua/plenary.nvim", optional = vim.fn.has "nvim-0.9" == 1 },
+      { "nvim-lua/plenary.nvim", optional = true },
       { "nvim-telescope/telescope.nvim", optional = true },
       { "mfussenegger/nvim-dap", optional = true },
       {
@@ -100,37 +95,5 @@ if vim.fn.has "nvim-0.10" == 1 then
         hls = astrolsp_avail and { capabilities = astrolsp.config.capabilities, on_attach = astrolsp.on_attach } or {},
       }, vim.g.haskell_tools)
     end,
-  })
-else
-  -- TODO: Remove this with AstroNvim v5 when dropping Neovim v0.9 support
-  -- haskell-tools v3 is the last version that supports neovim v0.9
-  -- This is simply a copy/paste of the v3 configuration to be left alone just in case
-  -- the setup gets breaking changes and diverges.
-  table.insert(pack, {
-    "mrcjkb/haskell-tools.nvim",
-    ft = haskell_ft,
-    dependencies = {
-      -- vim.fn.has >= nvim 0.9 removes plenary dependency
-      { "nvim-lua/plenary.nvim", optional = vim.fn.has "nvim-0.9" == 1 },
-      { "nvim-telescope/telescope.nvim", optional = true },
-      { "mfussenegger/nvim-dap", optional = true },
-      {
-        "AstroNvim/astrolsp",
-        ---@type AstroLSPOpts
-        opts = {
-          ---@diagnostic disable: missing-fields
-          handlers = { hls = false },
-        },
-      },
-    },
-    version = "^3",
-    init = function()
-      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
-      vim.g.haskell_tools = require("astrocore").extend_tbl({
-        hls = astrolsp_avail and { capabilities = astrolsp.config.capabilities, on_attach = astrolsp.on_attach } or {},
-      }, vim.g.haskell_tools)
-    end,
-  })
-end
-
-return pack
+  },
+}

--- a/lua/astrocommunity/pack/nvchad-ui/init.lua
+++ b/lua/astrocommunity/pack/nvchad-ui/init.lua
@@ -99,7 +99,7 @@ return {
     -- Disable unnecessary plugins
     { import = "astrocommunity.recipes.disable-tabline" },
     { "rebelot/heirline.nvim", opts = { statusline = false } },
-    { "goolord/alpha-nvim", enabled = false },
+    { "folke/snacks.nvim", enabled = false },
     { "brenoprata10/nvim-highlight-colors", enabled = false },
     { "NvChad/nvim-colorizer.lua", enabled = false },
     -- add lazy loaded dependencies

--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -1,4 +1,4 @@
-local pack = {
+return {
   { import = "astrocommunity.pack.toml" },
   {
     "nvim-treesitter/nvim-treesitter",
@@ -78,11 +78,7 @@ local pack = {
       if rustaceanvim_avail then table.insert(opts.adapters, rustaceanvim) end
     end,
   },
-}
-
-if vim.fn.has "nvim-0.10" == 1 then
-  -- Rustaceanvim v5 supports neovim v0.10+
-  table.insert(pack, {
+  {
     "mrcjkb/rustaceanvim",
     version = "^5",
     ft = "rust",
@@ -143,74 +139,5 @@ if vim.fn.has "nvim-0.10" == 1 then
       }
     end,
     config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
-  })
-else
-  -- TODO: Remove this with AstroNvim v5 when dropping Neovim v0.9 support
-  -- Rustaceanvim v4 is the last version that supports neovim v0.9
-  -- This is simply a copy/paste of the v4 configuration to be left alone just in case
-  -- the setup gets breaking changes and diverges.
-  table.insert(pack, {
-    "mrcjkb/rustaceanvim",
-    version = "^4",
-    ft = "rust",
-    specs = {
-      {
-        "AstroNvim/astrolsp",
-        optional = true,
-        ---@type AstroLSPOpts
-        opts = {
-          handlers = { rust_analyzer = false }, -- disable setup of `rust_analyzer`
-        },
-      },
-    },
-    opts = function()
-      local adapter
-      local success, package = pcall(function() return require("mason-registry").get_package "codelldb" end)
-      local cfg = require "rustaceanvim.config"
-      if success then
-        local package_path = vim.fn.expand "$MASON/packages/codelldb"
-        local codelldb_path = package_path .. "/codelldb"
-        local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
-        local this_os = vim.loop.os_uname().sysname
-
-        -- The path in windows is different
-        if this_os:find "Windows" then
-          codelldb_path = package_path .. "\\extension\\adapter\\codelldb.exe"
-          liblldb_path = package_path .. "\\extension\\lldb\\bin\\liblldb.dll"
-        else
-          -- The liblldb extension is .so for linux and .dylib for macOS
-          liblldb_path = liblldb_path .. (this_os == "Linux" and ".so" or ".dylib")
-        end
-        adapter = cfg.get_codelldb_adapter(codelldb_path, liblldb_path)
-      else
-        adapter = cfg.get_codelldb_adapter()
-      end
-
-      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
-      local astrolsp_opts = (astrolsp_avail and astrolsp.lsp_opts "rust_analyzer") or {}
-      local server = {
-        ---@type table | (fun(project_root:string|nil, default_settings: table|nil):table) -- The rust-analyzer settings or a function that creates them.
-        settings = function(project_root, default_settings)
-          local astrolsp_settings = astrolsp_opts.settings or {}
-
-          local merge_table = require("astrocore").extend_tbl(default_settings or {}, astrolsp_settings)
-          local ra = require "rustaceanvim.config.server"
-          -- load_rust_analyzer_settings merges any found settings with the passed in default settings table and then returns that table
-          return ra.load_rust_analyzer_settings(project_root, {
-            settings_file_pattern = "rust-analyzer.json",
-            default_settings = merge_table,
-          })
-        end,
-      }
-      local final_server = require("astrocore").extend_tbl(astrolsp_opts, server)
-      return {
-        server = final_server,
-        dap = { adapter = adapter, load_rust_types = true },
-        tools = { enable_clippy = false },
-      }
-    end,
-    config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
-  })
-end
-
-return pack
+  },
+}

--- a/lua/astrocommunity/startup/fsplash-nvim/init.lua
+++ b/lua/astrocommunity/startup/fsplash-nvim/init.lua
@@ -28,7 +28,7 @@ return {
     },
   },
   specs = {
-    { "goolord/alpha-nvim", optional = true, enabled = false },
+    { "folke/snacks.nvim", optional = true, enabled = false },
     { "stevearc/resession.nvim", optional = true, opts = { extensions = { fsplash = {} } } },
   },
   opts = {

--- a/lua/astrocommunity/startup/mini-starter/init.lua
+++ b/lua/astrocommunity/startup/mini-starter/init.lua
@@ -3,7 +3,7 @@ return {
   version = "*", -- stable version
   config = function() require("mini.starter").setup() end,
   specs = {
-    { "goolord/alpha-nvim", optional = true, enabled = false },
+    { "folke/snacks.nvim", optional = true, enabled = false },
     {
       "AstroNvim/astrocore",
       optional = true,

--- a/lua/astrocommunity/utility/noice-nvim/init.lua
+++ b/lua/astrocommunity/utility/noice-nvim/init.lua
@@ -41,11 +41,15 @@ return {
       opts = function(_, opts)
         local noice_opts = require("astrocore").plugin_opts "noice.nvim"
         -- disable the necessary handlers in AstroLSP
+        if not opts.defaults then opts.defaults = {} end
+        -- TODO: remove lsp_handlers when dropping support for AstroNvim v4
         if not opts.lsp_handlers then opts.lsp_handlers = {} end
         if vim.tbl_get(noice_opts, "lsp", "hover", "enabled") ~= false then
+          opts.defaults.hover = false
           opts.lsp_handlers["textDocument/hover"] = false
         end
         if vim.tbl_get(noice_opts, "lsp", "signature", "enabled") ~= false then
+          opts.defaults.signature_help = false
           opts.lsp_handlers["textDocument/signatureHelp"] = false
           if not opts.features then opts.features = {} end
           opts.features.signature_help = false


### PR DESCRIPTION
TODO list:
- [ ] Drop support for neovim 0.9
- [ ] Alpha-nvim -> snacks.nvim
- [ ] dressing.nvim -> snacks.nvim
- [ ] indent-blankline.nvim	snacks.nvim
- [ ] lspkind.nvim -> mini.icons
- [ ] mini.bufremove -> snacks.nvim
- [ ] nvim-cmp -> blink.cmp
- [ ] nvim-colorizer.lua -> nvim-highlight-colors
- [ ] nvim-notify -> snacks.nvim
- [ ] nvim-web-devicons -> mini.icons
- [ ] telescope.nvim -> snacks.nvim
- [ ] mason-tool-installer integration 
	From release notes:
	> AstroNvim is now relying on mason-tool-installer.nvim rather than mason-lspconfig/mason-nvim-dap/mason-null-ls. This makes configuration of installed packages easier rather than managing several ensure_installed tables and also adds support for installing packages automatically that are not part of any of those usecase specific plugins. mason-tool-installer.nvim also allows the user to specify specific package versions and other options. Check out the [mason-tool-installer.nvim Documentation](https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim) for details on it’s configuration.
For migration, anywhere in your configuration where you are configuring ensure_installed for mason-lspconfig/mason-nvim-dap/mason-null-ls, you should move those to an ensure_installed table in mason-tool-installer.nvim. You must also change the name of the package where necessary to properly reflect the name of the package in Mason. For instance, if you have lua_ls specified for mason-lspconfig, this would be lua-language-server in mason-tool-installer.nvim.
