### PR TITLE
feat!: astronvim v5 compatibility

### DIFF
--- a/lua/astrocommunity/color/ccc-nvim/init.lua
+++ b/lua/astrocommunity/color/ccc-nvim/init.lua
@@ -3,7 +3,8 @@ return {
   event = { "User AstroFile", "InsertEnter" },
   cmd = { "CccPick", "CccConvert", "CccHighlighterEnable", "CccHighlighterDisable", "CccHighlighterToggle" },
   specs = {
-    { "NvChad/nvim-colorizer.lua", optional = true, enabled = false },
+    { "brenoprata10/nvim-highlight-colors", enabled = false },
+    { "NvChad/nvim-colorizer.lua", enabled = false },
   },
   dependencies = {
     {

--- a/lua/astrocommunity/comment/ts-comments-nvim/init.lua
+++ b/lua/astrocommunity/comment/ts-comments-nvim/init.lua
@@ -2,7 +2,6 @@ return {
   "folke/ts-comments.nvim",
   opts = {},
   event = "VeryLazy",
-  enabled = vim.fn.has "nvim-0.10.0" == 1,
   specs = {
     { "numToStr/Comment.nvim", optional = true, enabled = false },
     { "JoosepAlviste/nvim-ts-context-commentstring", optional = true, enabled = false },

--- a/lua/astrocommunity/completion/avante-nvim/init.lua
+++ b/lua/astrocommunity/completion/avante-nvim/init.lua
@@ -15,7 +15,7 @@ return {
     "AvanteClear",
   },
   dependencies = {
-    "stevearc/dressing.nvim",
+    { "stevearc/dressing.nvim", optional = true },
     "nvim-lua/plenary.nvim",
     "MunifTanjim/nui.nvim",
     { "AstroNvim/astrocore", opts = function(_, opts) opts.mappings.n[prefix] = { desc = " Avante" } end },

--- a/lua/astrocommunity/completion/cmp-calc/init.lua
+++ b/lua/astrocommunity/completion/cmp-calc/init.lua
@@ -1,9 +1,29 @@
 return {
-  "hrsh7th/nvim-cmp",
-  optional = true,
-  dependencies = { "hrsh7th/cmp-calc", lazy = true },
-  opts = function(_, opts)
-    opts.sources = opts.sources or {}
-    table.insert(opts.sources, { name = "calc" })
-  end,
+  "hrsh7th/cmp-calc",
+  lazy = true,
+  specs = {
+    {
+      "hrsh7th/nvim-cmp",
+      optional = true,
+      dependencies = { "hrsh7th/cmp-calc", lazy = true },
+      opts = function(_, opts)
+        opts.sources = opts.sources or {}
+        table.insert(opts.sources, { name = "calc" })
+      end,
+    },
+    {
+      "Saghen/blink.cmp",
+      optional = true,
+      dependencies = "hrsh7th/cmp-calc",
+      specs = { "Saghen/blink.compat", version = "*", lazy = true, opts = {} },
+      opts = {
+        sources = {
+          default = { "calc" },
+          providers = {
+            calc = { name = "calc", module = "blink.compat.source", score_offset = -1 },
+          },
+        },
+      },
+    },
+  },
 }

--- a/lua/astrocommunity/completion/cmp-emoji/init.lua
+++ b/lua/astrocommunity/completion/cmp-emoji/init.lua
@@ -1,9 +1,29 @@
 return {
-  "hrsh7th/nvim-cmp",
-  optional = true,
-  dependencies = { "hrsh7th/cmp-emoji" },
-  opts = function(_, opts)
-    if not opts.sources then opts.sources = {} end
-    table.insert(opts.sources, { name = "emoji", priority = 700 })
-  end,
+  "hrsh7th/cmp-emoji",
+  lazy = true,
+  specs = {
+    {
+      "hrsh7th/nvim-cmp",
+      optional = true,
+      dependencies = { "hrsh7th/cmp-emoji" },
+      opts = function(_, opts)
+        if not opts.sources then opts.sources = {} end
+        table.insert(opts.sources, { name = "emoji", priority = 700 })
+      end,
+    },
+    {
+      "Saghen/blink.cmp",
+      optional = true,
+      dependencies = "hrsh7th/cmp-emoji",
+      specs = { "Saghen/blink.compat", version = "*", lazy = true, opts = {} },
+      opts = {
+        sources = {
+          default = { "emoji" },
+          providers = {
+            emoji = { name = "emoji", module = "blink.compat.source", score_offset = -1 },
+          },
+        },
+      },
+    },
+  },
 }

--- a/lua/astrocommunity/completion/cmp-latex-symbols/init.lua
+++ b/lua/astrocommunity/completion/cmp-latex-symbols/init.lua
@@ -1,9 +1,29 @@
 return {
-  "hrsh7th/nvim-cmp",
-  optional = true,
-  dependencies = { "kdheepak/cmp-latex-symbols" },
-  opts = function(_, opts)
-    if not opts.sources then opts.sources = {} end
-    table.insert(opts.sources, { name = "latex_symbols", priority = 700 })
-  end,
+  "kdheepak/cmp-latex-symbols",
+  lazy = true,
+  specs = {
+    {
+      "hrsh7th/nvim-cmp",
+      optional = true,
+      dependencies = { "kdheepak/cmp-latex-symbols" },
+      opts = function(_, opts)
+        if not opts.sources then opts.sources = {} end
+        table.insert(opts.sources, { name = "latex_symbols", priority = 700 })
+      end,
+    },
+    {
+      "Saghen/blink.cmp",
+      optional = true,
+      dependencies = "kdheepak/cmp-latex-symbols",
+      specs = { "Saghen/blink.compat", version = "*", lazy = true, opts = {} },
+      opts = {
+        sources = {
+          default = { "latex" },
+          providers = {
+            latex = { name = "latex_symbols", module = "blink.compat.source", score_offset = -1 },
+          },
+        },
+      },
+    },
+  },
 }

--- a/lua/astrocommunity/completion/cmp-nerdfont/init.lua
+++ b/lua/astrocommunity/completion/cmp-nerdfont/init.lua
@@ -1,9 +1,29 @@
 return {
-  "hrsh7th/nvim-cmp",
-  optional = true,
-  dependencies = { "chrisgrieser/cmp-nerdfont" },
-  opts = function(_, opts)
-    if not opts.sources then opts.sources = {} end
-    table.insert(opts.sources, { name = "nerdfont", priority = 700 })
-  end,
+  "chrisgrieser/cmp-nerdfont",
+  lazy = true,
+  specs = {
+    {
+      "hrsh7th/nvim-cmp",
+      optional = true,
+      dependencies = { "chrisgrieser/cmp-nerdfont" },
+      opts = function(_, opts)
+        if not opts.sources then opts.sources = {} end
+        table.insert(opts.sources, { name = "nerdfont", priority = 700 })
+      end,
+    },
+    {
+      "Saghen/blink.cmp",
+      optional = true,
+      dependencies = "chrisgrieser/cmp-nerdfont",
+      specs = { "Saghen/blink.compat", version = "*", lazy = true, opts = {} },
+      opts = {
+        sources = {
+          default = { "nerdfont" },
+          providers = {
+            nerdfont = { name = "nerdfont", module = "blink.compat.source", score_offset = -1 },
+          },
+        },
+      },
+    },
+  },
 }

--- a/lua/astrocommunity/completion/cmp-nvim-lua/init.lua
+++ b/lua/astrocommunity/completion/cmp-nvim-lua/init.lua
@@ -1,9 +1,29 @@
 return {
-  "hrsh7th/nvim-cmp",
-  optional = true,
-  dependencies = { "hrsh7th/cmp-nvim-lua", lazy = true },
-  opts = function(_, opts)
-    if not opts.sources then opts.sources = {} end
-    table.insert(opts.sources, { name = "nvim_lua" })
-  end,
+  "hrsh7th/cmp-nvim-lua",
+  lazy = true,
+  specs = {
+    {
+      "hrsh7th/nvim-cmp",
+      optional = true,
+      dependencies = { "hrsh7th/cmp-nvim-lua", lazy = true },
+      opts = function(_, opts)
+        if not opts.sources then opts.sources = {} end
+        table.insert(opts.sources, { name = "nvim_lua" })
+      end,
+    },
+    {
+      "Saghen/blink.cmp",
+      optional = true,
+      dependencies = "hrsh7th/cmp-nvim-lua",
+      specs = { "Saghen/blink.compat", version = "*", lazy = true, opts = {} },
+      opts = {
+        sources = {
+          default = { "nvim_lua" },
+          providers = {
+            nvim_lua = { name = "nvim_lua", module = "blink.compat.source" },
+          },
+        },
+      },
+    },
+  },
 }

--- a/lua/astrocommunity/completion/cmp-spell/init.lua
+++ b/lua/astrocommunity/completion/cmp-spell/init.lua
@@ -1,9 +1,29 @@
 return {
-  "hrsh7th/nvim-cmp",
-  optional = true,
-  dependencies = { "f3fora/cmp-spell", lazy = true },
-  opts = function(_, opts)
-    opts.sources = opts.sources or {}
-    table.insert(opts.sources, { name = "spell" })
-  end,
+  "f3fora/cmp-spell",
+  lazy = true,
+  specs = {
+    {
+      "hrsh7th/nvim-cmp",
+      optional = true,
+      dependencies = { "f3fora/cmp-spell", lazy = true },
+      opts = function(_, opts)
+        opts.sources = opts.sources or {}
+        table.insert(opts.sources, { name = "spell" })
+      end,
+    },
+    {
+      "Saghen/blink.cmp",
+      optional = true,
+      dependencies = "f3fora/cmp-spell",
+      specs = { "Saghen/blink.compat", version = "*", lazy = true, opts = {} },
+      opts = {
+        sources = {
+          default = { "spell" },
+          providers = {
+            spell = { name = "spell", module = "blink.compat.source" },
+          },
+        },
+      },
+    },
+  },
 }

--- a/lua/astrocommunity/completion/cmp-tmux/init.lua
+++ b/lua/astrocommunity/completion/cmp-tmux/init.lua
@@ -1,9 +1,29 @@
 return {
-  "hrsh7th/nvim-cmp",
-  optional = true,
-  dependencies = { "andersevenrud/cmp-tmux", lazy = true },
-  opts = function(_, opts)
-    opts.sources = opts.sources or {}
-    table.insert(opts.sources, { name = "tmux" })
-  end,
+  "andersevenrud/cmp-tmux",
+  lazy = true,
+  specs = {
+    {
+      "hrsh7th/nvim-cmp",
+      optional = true,
+      dependencies = { "andersevenrud/cmp-tmux", lazy = true },
+      opts = function(_, opts)
+        opts.sources = opts.sources or {}
+        table.insert(opts.sources, { name = "tmux" })
+      end,
+    },
+    {
+      "Saghen/blink.cmp",
+      optional = true,
+      dependencies = "andersevenrud/cmp-tmux",
+      specs = { "Saghen/blink.compat", version = "*", lazy = true, opts = {} },
+      opts = {
+        sources = {
+          default = { "tmux" },
+          providers = {
+            tmux = { name = "tmux", module = "blink.compat.source", score_offset = -1 },
+          },
+        },
+      },
+    },
+  },
 }

--- a/lua/astrocommunity/completion/codeium-nvim/init.lua
+++ b/lua/astrocommunity/completion/codeium-nvim/init.lua
@@ -57,5 +57,14 @@ return {
         opts.symbol_map.Codeium = require("astroui").get_icon("Codeium", 1, true)
       end,
     },
+    {
+      "echasnovski/mini.icons",
+      optional = true,
+      -- Adds icon for codeium using mini.icons
+      opts = function(_, opts)
+        if not opts.lsp then opts.lsp = {} end
+        opts.symbol_map.codeium = { glyph = require("astroui").get_icon("Codeium", 1, true), hl = "MiniIconsCyan" }
+      end,
+    },
   },
 }

--- a/lua/astrocommunity/completion/codeium-nvim/init.lua
+++ b/lua/astrocommunity/completion/codeium-nvim/init.lua
@@ -2,9 +2,10 @@ return {
   "Exafunction/codeium.nvim",
   event = "User AstroFile",
   cmd = "Codeium",
-  opts = {
-    enable_chat = true,
-  },
+  opts = function(_, opts)
+    opts.enable_chat = true
+    opts.enable_cmp_source = require("astrocore").is_available "nvim-cmp"
+  end,
   dependencies = {
     {
       "AstroNvim/astroui",

--- a/lua/astrocommunity/completion/copilot-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-cmp/init.lua
@@ -31,7 +31,19 @@ return {
       "onsails/lspkind.nvim",
       optional = true,
       -- Adds icon for copilot using lspkind
-      opts = function(_, opts) opts.symbol_map.Copilot = "" end,
+      opts = function(_, opts)
+        if not opts.symbol_map then opts.symbol_map = {} end
+        opts.symbol_map.Copilot = ""
+      end,
+    },
+    {
+      "echasnovski/mini.icons",
+      optional = true,
+      -- Adds icon for copilot using mini.icons
+      opts = function(_, opts)
+        if not opts.lsp then opts.lsp = {} end
+        opts.symbol_map.copilot = { glyph = "", hl = "MiniIconsAzure" }
+      end,
     },
   },
 }

--- a/lua/astrocommunity/completion/copilot-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-cmp/init.lua
@@ -28,6 +28,20 @@ return {
       end,
     },
     {
+      "Saghen/blink.cmp",
+      optional = true,
+      dependencies = "zbirenbaum/copilot-cmp",
+      specs = { "Saghen/blink.compat", version = "*", lazy = true, opts = {} },
+      opts = {
+        sources = {
+          default = { "copilot" },
+          providers = {
+            copilot = { name = "copilot", module = "blink.compat.source" },
+          },
+        },
+      },
+    },
+    {
       "onsails/lspkind.nvim",
       optional = true,
       -- Adds icon for copilot using lspkind

--- a/lua/astrocommunity/completion/coq_nvim/init.lua
+++ b/lua/astrocommunity/completion/coq_nvim/init.lua
@@ -5,6 +5,7 @@ return {
   build = ":COQdeps",
   cmd = { "COQnow", "COQhelp", "COQstats", "COQdeps" },
   specs = {
+    { "Saghen/blink.cmp", optional = true, enabled = false },
     { "hrsh7th/nvim-cmp", optional = true, enabled = false },
     { "hrsh7th/cmp-buffer", optional = true, enabled = false },
     { "hrsh7th/cmp-nvim-lsp", optional = true, enabled = false },

--- a/lua/astrocommunity/completion/magazine-nvim/init.lua
+++ b/lua/astrocommunity/completion/magazine-nvim/init.lua
@@ -3,6 +3,7 @@ return {
   lazy = true,
   config = function() vim.opt.rtp:remove(require("astrocore").get_plugin("nvim-cmp").dir) end,
   specs = {
+    { import = "astrocommunity.completion.nvim-cmp" },
     { "hrsh7th/nvim-cmp", dependencies = { "iguanacucumber/magazine.nvim" } },
     { "Saghen/blink.cmp", enabled = false },
     { "Saghen/blink.compat", enabled = false },

--- a/lua/astrocommunity/completion/mini-completion/init.lua
+++ b/lua/astrocommunity/completion/mini-completion/init.lua
@@ -3,6 +3,7 @@ return {
   lazy = false,
   opts = {},
   specs = {
+    { "Saghen/blink.cmp", enabled = false },
     { "hrsh7th/nvim-cmp", optional = true, enabled = false },
     { "hrsh7th/cmp-buffer", optional = true, enabled = false },
     { "hrsh7th/cmp-nvim-lsp", optional = true, enabled = false },

--- a/lua/astrocommunity/completion/nvim-cmp-buffer-lines/init.lua
+++ b/lua/astrocommunity/completion/nvim-cmp-buffer-lines/init.lua
@@ -5,6 +5,7 @@ return {
   specs = {
     {
       "hrsh7th/nvim-cmp",
+      optional = true,
       dependencies = { "amarakon/nvim-cmp-buffer-lines" },
       opts = function(_, opts)
         local cmp = require "cmp"

--- a/lua/astrocommunity/completion/nvim-cmp/init.lua
+++ b/lua/astrocommunity/completion/nvim-cmp/init.lua
@@ -239,5 +239,6 @@ return {
         })
       end,
     },
+    { "Saghen/blink.cmp", enabled = false },
   },
 }

--- a/lua/astrocommunity/editing-support/conform-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/conform-nvim/init.lua
@@ -1,7 +1,6 @@
 return {
   "stevearc/conform.nvim",
   event = "User AstroFile",
-  version = vim.fn.has "nvim-0.10" ~= 1 and "7",
   cmd = "ConformInfo",
   specs = {
     { "AstroNvim/astrolsp", optional = true, opts = { formatting = { disabled = true } } },

--- a/lua/astrocommunity/editing-support/zen-mode-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/zen-mode-nvim/init.lua
@@ -29,6 +29,7 @@ return {
         vim.g.diagnostics_enabled_old = not vim.diagnostic.is_disabled()
       end
       if vim.g.diagnostics_enabled_old then
+        -- TODO: Remove this when astronvim drops 0.10 support
         if vim.fn.has "nvim-0.10" == 0 then
           vim.diagnostic.disable()
         else

--- a/lua/astrocommunity/file-explorer/mini-files/init.lua
+++ b/lua/astrocommunity/file-explorer/mini-files/init.lua
@@ -22,7 +22,6 @@ end
 return {
   "echasnovski/mini.files",
   dependencies = {
-    "nvim-tree/nvim-web-devicons",
     {
       "AstroNvim/astrocore",
       opts = {

--- a/lua/astrocommunity/fuzzy-finder/snacks-picker/init.lua
+++ b/lua/astrocommunity/fuzzy-finder/snacks-picker/init.lua
@@ -112,7 +112,7 @@ return {
         window = { mappings = { F = "find_in_dir" } },
       },
     },
+    { "stevearc/dressing.nvim", optional = true, opts = { select = { enabled = false } } },
     { "nvim-telescope/telescope.nvim", enabled = false },
-    { "stevearc/dressing.nvim", opts = { select = { enabled = false } } },
   },
 }

--- a/lua/astrocommunity/game/leetcode-nvim/init.lua
+++ b/lua/astrocommunity/game/leetcode-nvim/init.lua
@@ -9,7 +9,6 @@ return {
 
     -- optional
     { "rcarriga/nvim-notify", optional = true },
-    { "nvim-tree/nvim-web-devicons", optional = true },
     {
       "nvim-treesitter/nvim-treesitter",
       optional = true,

--- a/lua/astrocommunity/git/fugit2-nvim/init.lua
+++ b/lua/astrocommunity/git/fugit2-nvim/init.lua
@@ -7,7 +7,6 @@ return {
   },
   dependencies = {
     "MunifTanjim/nui.nvim",
-    "nvim-tree/nvim-web-devicons",
     "nvim-lua/plenary.nvim",
     {
       "AstroNvim/astrocore",

--- a/lua/astrocommunity/git/neogit/init.lua
+++ b/lua/astrocommunity/git/neogit/init.lua
@@ -44,7 +44,12 @@ return {
           return require("telescope").extensions.fzf.native_fzf_sorter()
         end
       end,
-      integrations = { telescope = utils.is_available "telescope.nvim" },
+      integrations = {
+        telescope = utils.is_available "telescope.nvim",
+        diffview = utils.is_available "diffview.nvim",
+        fzf_lua = utils.is_available "fzf-lua",
+        mini_pick = utils.is_available "mini.pick",
+      },
     })
   end,
 }

--- a/lua/astrocommunity/git/neogit/init.lua
+++ b/lua/astrocommunity/git/neogit/init.lua
@@ -29,6 +29,12 @@ return {
   opts = function(_, opts)
     local utils = require "astrocore"
     local disable_builtin_notifications = utils.is_available "nvim-notify" or utils.is_available "noice.nvim"
+    if utils.is_available "snacks.nvim" then
+      local snacks_notifier = utils.plugin_opts("snacks.nvim").notifier
+      if snacks_notifier and vim.tbl_get(snacks_notifier, "enabled") ~= false then
+        disable_builtin_notifications = true
+      end
+    end
 
     return utils.extend_tbl(opts, {
       disable_builtin_notifications = disable_builtin_notifications,

--- a/lua/astrocommunity/git/nvim-tinygit/init.lua
+++ b/lua/astrocommunity/git/nvim-tinygit/init.lua
@@ -3,6 +3,7 @@ return {
   ft = { "git_rebase", "gitcommit" }, -- so ftplugins are loaded
   dependencies = {
     "nvim-telescope/telescope.nvim",
+    { "stevearc/dressing.nvim", optional = true },
     {
       "AstroNvim/astrocore",
       opts = {

--- a/lua/astrocommunity/git/octo-nvim/init.lua
+++ b/lua/astrocommunity/git/octo-nvim/init.lua
@@ -3,7 +3,6 @@ return {
   dependencies = {
     "nvim-lua/plenary.nvim",
     "nvim-telescope/telescope.nvim",
-    "nvim-tree/nvim-web-devicons",
     { "AstroNvim/astroui", opts = { icons = { Octo = "" } } },
     {
       "AstroNvim/astrocore",

--- a/lua/astrocommunity/git/octo-nvim/init.lua
+++ b/lua/astrocommunity/git/octo-nvim/init.lua
@@ -2,7 +2,6 @@ return {
   "pwntester/octo.nvim",
   dependencies = {
     "nvim-lua/plenary.nvim",
-    "nvim-telescope/telescope.nvim",
     { "AstroNvim/astroui", opts = { icons = { Octo = "" } } },
     {
       "AstroNvim/astrocore",
@@ -81,8 +80,12 @@ return {
     },
   },
   cmd = { "Octo" },
-  opts = {
-    use_diagnostic_signs = true,
-    mappings = {},
-  },
+  opts = function(_, opts)
+    local is_available = require("astrocore").is_available
+    opts.use_diagnostic_signs = true
+    opts.mappings = {}
+    opts.picker = (is_available "telescope.nvim" and "telescope")
+      or (is_available "fzf-lua" and "fzf-lua")
+      or (is_available "snacks.nvim" and "snacks")
+  end,
 }

--- a/lua/astrocommunity/lsp/actions-preview-nvim/init.lua
+++ b/lua/astrocommunity/lsp/actions-preview-nvim/init.lua
@@ -3,7 +3,6 @@ return {
   "aznhe21/actions-preview.nvim",
   lazy = true,
   dependencies = {
-    "nvim-telescope/telescope.nvim",
     {
       "AstroNvim/astrolsp",
       optional = true,
@@ -28,4 +27,11 @@ return {
       },
     },
   },
+  opts = function(_, opts)
+    local is_available = require("astrocore").is_available
+    opts.backend.provider = (is_available "telescope.nvim" and "telescope")
+      or (is_available "mini.pick" and "minipick")
+      or (is_available "snacks.nvim" and "snacks")
+      or (is_available "nui.nvim" and "nui")
+  end,
 }

--- a/lua/astrocommunity/lsp/coc-nvim/init.lua
+++ b/lua/astrocommunity/lsp/coc-nvim/init.lua
@@ -162,5 +162,7 @@ return {
     -- luaship
     { "L3MON4D3/LuaSnip", optional = true, enabled = false },
     { "rafamadriz/friendly-snippets", optional = true, enabled = false },
+    -- blink
+    { "Saghen/blink.cmp", optional = true, enabled = false },
   },
 }

--- a/lua/astrocommunity/motion/grapple-nvim/init.lua
+++ b/lua/astrocommunity/motion/grapple-nvim/init.lua
@@ -19,7 +19,6 @@ return {
         maps.n["<C-p>"] = { "<Cmd>Grapple cycle backward<CR>", desc = "Select previous tag" }
       end,
     },
-    { "nvim-tree/nvim-web-devicons", lazy = true },
   },
   cmd = { "Grapple" },
 }

--- a/lua/astrocommunity/motion/harpoon/init.lua
+++ b/lua/astrocommunity/motion/harpoon/init.lua
@@ -3,7 +3,7 @@ return {
   branch = "harpoon2",
   dependencies = {
     "nvim-lua/plenary.nvim",
-    "nvim-telescope/telescope.nvim",
+    { "nvim-telescope/telescope.nvim", optional = true },
     { "AstroNvim/astroui", opts = { icons = { Harpoon = "󱡀" } } },
     {
       "AstroNvim/astrocore",
@@ -29,7 +29,9 @@ return {
         }
         maps.n["<C-p>"] = { function() require("harpoon"):list():prev() end, desc = "Goto previous mark" }
         maps.n["<C-n>"] = { function() require("harpoon"):list():next() end, desc = "Goto next mark" }
-        maps.n[prefix .. "m"] = { "<Cmd>Telescope harpoon marks<CR>", desc = "Show marks in Telescope" }
+        if require("astrocore").is_available "telescope.nvim" then
+          maps.n[prefix .. "m"] = { "<Cmd>Telescope harpoon marks<CR>", desc = "Show marks in Telescope" }
+        end
         maps.n[prefix .. "t"] = {
           function()
             vim.ui.input({ prompt = term_string .. " window number: " }, function(input)

--- a/lua/astrocommunity/motion/tabout-nvim/init.lua
+++ b/lua/astrocommunity/motion/tabout-nvim/init.lua
@@ -28,6 +28,24 @@ return {
         end, { "i", "s" })
       end,
     },
+    {
+      "Saghen/blink.cmp",
+      optional = true,
+      opts = {
+        keymap = {
+          ["<Tab>"] = {
+            "select_next",
+            "snippet_forward",
+            "fallback",
+          },
+          ["<S-Tab>"] = {
+            "select_prev",
+            "snippet_backward",
+            "fallback",
+          },
+        },
+      },
+    },
   },
   opts = {},
 }

--- a/lua/astrocommunity/note-taking/neorg/init.lua
+++ b/lua/astrocommunity/note-taking/neorg/init.lua
@@ -3,25 +3,30 @@ return {
   version = "^8",
   event = "VeryLazy",
   dependencies = { "nvim-treesitter/nvim-treesitter" },
-  opts = {
-    load = {
-      ["core.defaults"] = {}, -- Loads default behaviour
-      ["core.concealer"] = {}, -- Adds pretty icons to your documents
-      ["core.keybinds"] = {}, -- Adds default keybindings
-      ["core.completion"] = {
-        config = {
-          engine = "nvim-cmp",
-        },
-      }, -- Enables support for completion plugins
-      ["core.journal"] = {}, -- Enables support for the journal module
-      ["core.dirman"] = { -- Manages Neorg workspaces
-        config = {
-          workspaces = {
-            notes = "~/projects/notes",
+  opts = function(_, opts)
+    local astrocore = require "astrocore"
+    return astrocore.extend_tbl(opts, {
+      load = {
+        ["core.defaults"] = {}, -- Loads default behaviour
+        ["core.concealer"] = {}, -- Adds pretty icons to your documents
+        ["core.keybinds"] = {}, -- Adds default keybindings
+        ["core.completion"] = {
+          config = {
+            engine = (astrocore.is_available "nvim-cmp" and "nvim-cmp")
+              or (astrocore.is_available "coq_nvim" and "coq_nvim")
+              or (astrocore.is_available "nvim-compe" and "nvim-compe"),
           },
-          default_workspace = "notes",
+        }, -- Enables support for completion plugins
+        ["core.journal"] = {}, -- Enables support for the journal module
+        ["core.dirman"] = { -- Manages Neorg workspaces
+          config = {
+            workspaces = {
+              notes = "~/projects/notes",
+            },
+            default_workspace = "notes",
+          },
         },
       },
-    },
-  },
+    })
+  end,
 }

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -7,7 +7,6 @@ return {
   dependencies = {
     "nvim-lua/plenary.nvim",
     { "hrsh7th/nvim-cmp", optional = true },
-    "nvim-telescope/telescope.nvim",
     {
       "AstroNvim/astrocore",
       opts = {
@@ -33,7 +32,9 @@ return {
     return astrocore.extend_tbl(opts, {
       dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
       use_advanced_uri = true,
-      finder = "telescope.nvim",
+      finder = (astrocore.is_available "telescope.nvim" and "telescope.nvim")
+        or (astrocore.is_available "fzf-lua" and "fzf-lua")
+        or (astrocore.is_available "mini.pick" and "mini.pick"),
 
       templates = {
         subdir = "templates",
@@ -60,7 +61,7 @@ return {
 
       -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
       -- URL it will be ignored but you can customize this behavior here.
-      follow_url_func = vim.ui.open or function(url) require("astrocore").system_open(url) end,
+      follow_url_func = vim.ui.open,
     })
   end,
 }

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -6,7 +6,7 @@ return {
   event = { "BufReadPre  */obsidian-vault/*.md" },
   dependencies = {
     "nvim-lua/plenary.nvim",
-    "hrsh7th/nvim-cmp",
+    { "hrsh7th/nvim-cmp", optional = true },
     "nvim-telescope/telescope.nvim",
     {
       "AstroNvim/astrocore",
@@ -28,32 +28,39 @@ return {
       },
     },
   },
-  opts = {
-    dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
-    use_advanced_uri = true,
-    finder = "telescope.nvim",
+  opts = function(_, opts)
+    local astrocore = require "astrocore"
+    return astrocore.extend_tbl(opts, {
+      dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
+      use_advanced_uri = true,
+      finder = "telescope.nvim",
 
-    templates = {
-      subdir = "templates",
-      date_format = "%Y-%m-%d-%a",
-      time_format = "%H:%M",
-    },
+      templates = {
+        subdir = "templates",
+        date_format = "%Y-%m-%d-%a",
+        time_format = "%H:%M",
+      },
 
-    note_frontmatter_func = function(note)
-      -- This is equivalent to the default frontmatter function.
-      local out = { id = note.id, aliases = note.aliases, tags = note.tags }
-      -- `note.metadata` contains any manually added fields in the frontmatter.
-      -- So here we just make sure those fields are kept in the frontmatter.
-      if note.metadata ~= nil and require("obsidian").util.table_length(note.metadata) > 0 then
-        for k, v in pairs(note.metadata) do
-          out[k] = v
+      completion = {
+        nvim_cmp = astrocore.is_available "nvim-cmp",
+      },
+
+      note_frontmatter_func = function(note)
+        -- This is equivalent to the default frontmatter function.
+        local out = { id = note.id, aliases = note.aliases, tags = note.tags }
+        -- `note.metadata` contains any manually added fields in the frontmatter.
+        -- So here we just make sure those fields are kept in the frontmatter.
+        if note.metadata ~= nil and require("obsidian").util.table_length(note.metadata) > 0 then
+          for k, v in pairs(note.metadata) do
+            out[k] = v
+          end
         end
-      end
-      return out
-    end,
+        return out
+      end,
 
-    -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
-    -- URL it will be ignored but you can customize this behavior here.
-    follow_url_func = vim.ui.open or function(url) require("astrocore").system_open(url) end,
-  },
+      -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
+      -- URL it will be ignored but you can customize this behavior here.
+      follow_url_func = vim.ui.open or function(url) require("astrocore").system_open(url) end,
+    })
+  end,
 }

--- a/lua/astrocommunity/pack/full-dadbod/init.lua
+++ b/lua/astrocommunity/pack/full-dadbod/init.lua
@@ -24,23 +24,43 @@ return {
       },
     },
     {
-      "hrsh7th/nvim-cmp",
-      optional = true,
-      dependencies = {
+      "kristijanhusak/vim-dadbod-completion",
+      lazy = true,
+      specs = {
         {
-          "kristijanhusak/vim-dadbod-completion",
+          "hrsh7th/nvim-cmp",
+          optional = true,
           dependencies = {
-            "AstroNvim/astrocore",
-            opts = {
-              autocmds = {
-                dadbod_cmp = {
-                  {
-                    event = "FileType",
-                    desc = "dadbod completion",
-                    pattern = { "sql", "mysql", "plsql" },
-                    callback = function()
-                      require("cmp").setup.buffer { sources = { { name = "vim-dadbod-completion" } } }
-                    end,
+            {
+              "kristijanhusak/vim-dadbod-completion",
+              dependencies = {
+                "AstroNvim/astrocore",
+                opts = {
+                  autocmds = {
+                    dadbod_cmp = {
+                      {
+                        event = "FileType",
+                        desc = "dadbod completion",
+                        pattern = { "sql", "mysql", "plsql" },
+                        callback = function()
+                          require("cmp").setup.buffer { sources = { { name = "vim-dadbod-completion" } } }
+                        end,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            {
+              "saghen/blink.cmp",
+              opts = {
+                sources = {
+                  per_filetype = {
+                    sql = { "snippets", "dadbod", "buffer" },
+                  },
+                  -- add vim-dadbod-completion to your completion providers
+                  providers = {
+                    dadbod = { name = "Dadbod", module = "vim_dadbod_completion.blink" },
                   },
                 },
               },

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -76,7 +76,6 @@ return {
     "mrcjkb/haskell-tools.nvim",
     ft = haskell_ft,
     dependencies = {
-      { "nvim-lua/plenary.nvim", optional = true },
       { "nvim-telescope/telescope.nvim", optional = true },
       { "mfussenegger/nvim-dap", optional = true },
       {

--- a/lua/astrocommunity/pack/haskell/init.lua
+++ b/lua/astrocommunity/pack/haskell/init.lua
@@ -4,7 +4,7 @@ local is_available = function(plugin)
 end
 local haskell_ft = { "haskell", "lhaskell", "cabal", "cabalproject" }
 
-local pack = {
+return {
   { import = "astrocommunity.pack.yaml" }, -- stack.yaml
   { import = "astrocommunity.pack.json" }, -- hls.json
   { import = "astrocommunity.test.neotest" }, -- neotest-haskell
@@ -72,16 +72,11 @@ local pack = {
       table.insert(opts.adapters, require "neotest-haskell"(require("astrocore").plugin_opts "neotest-haskell"))
     end,
   },
-}
-
-if vim.fn.has "nvim-0.10" == 1 then
-  -- haskell-tools v4 supports neovim v0.10+
-  table.insert(pack, {
+  {
     "mrcjkb/haskell-tools.nvim",
     ft = haskell_ft,
     dependencies = {
-      -- vim.fn.has >= nvim 0.9 removes plenary dependency
-      { "nvim-lua/plenary.nvim", optional = vim.fn.has "nvim-0.9" == 1 },
+      { "nvim-lua/plenary.nvim", optional = true },
       { "nvim-telescope/telescope.nvim", optional = true },
       { "mfussenegger/nvim-dap", optional = true },
       {
@@ -100,37 +95,5 @@ if vim.fn.has "nvim-0.10" == 1 then
         hls = astrolsp_avail and { capabilities = astrolsp.config.capabilities, on_attach = astrolsp.on_attach } or {},
       }, vim.g.haskell_tools)
     end,
-  })
-else
-  -- TODO: Remove this with AstroNvim v5 when dropping Neovim v0.9 support
-  -- haskell-tools v3 is the last version that supports neovim v0.9
-  -- This is simply a copy/paste of the v3 configuration to be left alone just in case
-  -- the setup gets breaking changes and diverges.
-  table.insert(pack, {
-    "mrcjkb/haskell-tools.nvim",
-    ft = haskell_ft,
-    dependencies = {
-      -- vim.fn.has >= nvim 0.9 removes plenary dependency
-      { "nvim-lua/plenary.nvim", optional = vim.fn.has "nvim-0.9" == 1 },
-      { "nvim-telescope/telescope.nvim", optional = true },
-      { "mfussenegger/nvim-dap", optional = true },
-      {
-        "AstroNvim/astrolsp",
-        ---@type AstroLSPOpts
-        opts = {
-          ---@diagnostic disable: missing-fields
-          handlers = { hls = false },
-        },
-      },
-    },
-    version = "^3",
-    init = function()
-      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
-      vim.g.haskell_tools = require("astrocore").extend_tbl({
-        hls = astrolsp_avail and { capabilities = astrolsp.config.capabilities, on_attach = astrolsp.on_attach } or {},
-      }, vim.g.haskell_tools)
-    end,
-  })
-end
-
-return pack
+  },
+}

--- a/lua/astrocommunity/pack/laravel/init.lua
+++ b/lua/astrocommunity/pack/laravel/init.lua
@@ -7,7 +7,6 @@ return {
     cmd = { "Sail", "Artisan", "Composer", "Npm", "Yarn", "Laravel" },
     dependencies = {
       "tpope/vim-dotenv",
-      "nvim-telescope/telescope.nvim",
       "MunifTanjim/nui.nvim",
       "kevinhwang91/promise-async",
       {
@@ -28,7 +27,14 @@ return {
       { "AstroNvim/astroui", opts = { icons = { Laravel = "󰫐" } } },
     },
     event = { "VeryLazy" },
-    config = true,
+    opts = function(_, opts)
+      local is_available = require("astrocore").is_available
+      opts.pickers = { enable = true }
+      opts.pickers.provider = (is_available "telescope.nvim" and "telescope")
+        or (is_available "fzf-lua" and "fzf-lua")
+        or (is_available "snacks.nvim" and "snacks")
+        or "ui.select"
+    end,
   },
   {
     "Bleksak/laravel-ide-helper.nvim",

--- a/lua/astrocommunity/pack/laravel/init.lua
+++ b/lua/astrocommunity/pack/laravel/init.lua
@@ -57,7 +57,7 @@ return {
   {
     "ricardoramirezr/blade-nav.nvim",
     dependencies = {
-      "hrsh7th/nvim-cmp",
+      { "hrsh7th/nvim-cmp", optional = true },
     },
     ft = { "blade", "php" },
   },

--- a/lua/astrocommunity/pack/nvchad-ui/init.lua
+++ b/lua/astrocommunity/pack/nvchad-ui/init.lua
@@ -99,7 +99,12 @@ return {
     -- Disable unnecessary plugins
     { import = "astrocommunity.recipes.disable-tabline" },
     { "rebelot/heirline.nvim", opts = { statusline = false } },
-    { "goolord/alpha-nvim", enabled = false },
+    {
+      "folke/snacks.nvim",
+      optional = true,
+      ---@type snacks.Config
+      opts = { dashboard = { enabled = false } },
+    },
     { "brenoprata10/nvim-highlight-colors", enabled = false },
     { "NvChad/nvim-colorizer.lua", enabled = false },
     -- add lazy loaded dependencies

--- a/lua/astrocommunity/pack/nvchad-ui/init.lua
+++ b/lua/astrocommunity/pack/nvchad-ui/init.lua
@@ -99,6 +99,7 @@ return {
     -- Disable unnecessary plugins
     { import = "astrocommunity.recipes.disable-tabline" },
     { "rebelot/heirline.nvim", opts = { statusline = false } },
+    { "goolord/alpha-nvim", enabled = false },
     {
       "folke/snacks.nvim",
       optional = true,

--- a/lua/astrocommunity/pack/quarto/init.lua
+++ b/lua/astrocommunity/pack/quarto/init.lua
@@ -4,7 +4,6 @@ return {
     ft = { "quarto", "qmd" },
     opts = {},
     dependencies = {
-      { "hrsh7th/nvim-cmp" },
       { "jmbuhr/otter.nvim" },
     },
   },

--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -1,4 +1,4 @@
-local pack = {
+return {
   { import = "astrocommunity.pack.toml" },
   {
     "nvim-treesitter/nvim-treesitter",
@@ -78,11 +78,7 @@ local pack = {
       if rustaceanvim_avail then table.insert(opts.adapters, rustaceanvim) end
     end,
   },
-}
-
-if vim.fn.has "nvim-0.10" == 1 then
-  -- Rustaceanvim v5 supports neovim v0.10+
-  table.insert(pack, {
+  {
     "mrcjkb/rustaceanvim",
     version = "^5",
     ft = "rust",
@@ -143,74 +139,5 @@ if vim.fn.has "nvim-0.10" == 1 then
       }
     end,
     config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
-  })
-else
-  -- TODO: Remove this with AstroNvim v5 when dropping Neovim v0.9 support
-  -- Rustaceanvim v4 is the last version that supports neovim v0.9
-  -- This is simply a copy/paste of the v4 configuration to be left alone just in case
-  -- the setup gets breaking changes and diverges.
-  table.insert(pack, {
-    "mrcjkb/rustaceanvim",
-    version = "^4",
-    ft = "rust",
-    specs = {
-      {
-        "AstroNvim/astrolsp",
-        optional = true,
-        ---@type AstroLSPOpts
-        opts = {
-          handlers = { rust_analyzer = false }, -- disable setup of `rust_analyzer`
-        },
-      },
-    },
-    opts = function()
-      local adapter
-      local success, package = pcall(function() return require("mason-registry").get_package "codelldb" end)
-      local cfg = require "rustaceanvim.config"
-      if success then
-        local package_path = vim.fn.expand "$MASON/packages/codelldb"
-        local codelldb_path = package_path .. "/codelldb"
-        local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
-        local this_os = vim.loop.os_uname().sysname
-
-        -- The path in windows is different
-        if this_os:find "Windows" then
-          codelldb_path = package_path .. "\\extension\\adapter\\codelldb.exe"
-          liblldb_path = package_path .. "\\extension\\lldb\\bin\\liblldb.dll"
-        else
-          -- The liblldb extension is .so for linux and .dylib for macOS
-          liblldb_path = liblldb_path .. (this_os == "Linux" and ".so" or ".dylib")
-        end
-        adapter = cfg.get_codelldb_adapter(codelldb_path, liblldb_path)
-      else
-        adapter = cfg.get_codelldb_adapter()
-      end
-
-      local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
-      local astrolsp_opts = (astrolsp_avail and astrolsp.lsp_opts "rust_analyzer") or {}
-      local server = {
-        ---@type table | (fun(project_root:string|nil, default_settings: table|nil):table) -- The rust-analyzer settings or a function that creates them.
-        settings = function(project_root, default_settings)
-          local astrolsp_settings = astrolsp_opts.settings or {}
-
-          local merge_table = require("astrocore").extend_tbl(default_settings or {}, astrolsp_settings)
-          local ra = require "rustaceanvim.config.server"
-          -- load_rust_analyzer_settings merges any found settings with the passed in default settings table and then returns that table
-          return ra.load_rust_analyzer_settings(project_root, {
-            settings_file_pattern = "rust-analyzer.json",
-            default_settings = merge_table,
-          })
-        end,
-      }
-      local final_server = require("astrocore").extend_tbl(astrolsp_opts, server)
-      return {
-        server = final_server,
-        dap = { adapter = adapter, load_rust_types = true },
-        tools = { enable_clippy = false },
-      }
-    end,
-    config = function(_, opts) vim.g.rustaceanvim = require("astrocore").extend_tbl(opts, vim.g.rustaceanvim) end,
-  })
-end
-
-return pack
+  },
+}

--- a/lua/astrocommunity/pack/tailwindcss/init.lua
+++ b/lua/astrocommunity/pack/tailwindcss/init.lua
@@ -73,24 +73,6 @@ return {
     end,
   },
   {
-    "hrsh7th/nvim-cmp",
-    optional = true,
-    dependencies = {
-      { "js-everts/cmp-tailwind-colors", opts = {} },
-    },
-    opts = function(_, opts)
-      local format_kinds = opts.formatting.format
-      opts.formatting.format = function(entry, item)
-        if item.kind == "Color" then
-          item = require("cmp-tailwind-colors").format(entry, item)
-          if item.kind == "Color" then return format_kinds(entry, item) end
-          return item
-        end
-        return format_kinds(entry, item)
-      end
-    end,
-  },
-  {
     "NvChad/nvim-colorizer.lua",
     optional = true,
     opts = {

--- a/lua/astrocommunity/programming-language-support/xbase/init.lua
+++ b/lua/astrocommunity/programming-language-support/xbase/init.lua
@@ -1,5 +1,5 @@
 return {
-  "xbase-lab/xbase",
+  "kkharji/xbase",
   ft = { "swift", "objcpp", "objc" },
   run = "make install",
   dependencies = {

--- a/lua/astrocommunity/project/linear-nvim/init.lua
+++ b/lua/astrocommunity/project/linear-nvim/init.lua
@@ -3,7 +3,6 @@ return {
   dependencies = {
     "nvim-lua/plenary.nvim",
     "nvim-telescope/telescope.nvim",
-    "stevearc/dressing.nvim",
     {
       "AstroNvim/astrocore",
       opts = function(_, opts)

--- a/lua/astrocommunity/recipes/auto-session-restore/init.lua
+++ b/lua/astrocommunity/recipes/auto-session-restore/init.lua
@@ -34,9 +34,18 @@ return {
               if should_skip then return end
               -- if possible, load session
               if not pcall(function() require("resession").load(vim.fn.getcwd(), { dir = "dirsession" }) end) then
-                -- if session was not loaded, if possible, load Snacks dashboard
-                if pcall(function() Snacks.dashboard.start() end) then
-                  vim.schedule(function() vim.cmd.doautocmd "FileType" end)
+                local is_available = require("astrocore").is_available
+                if is_available "alpha-nvim" then
+                  -- if session was not loaded, if possible, load alpha
+                  require("lazy").load { plugins = { "alpha-nvim" } }
+                  if pcall(function() require("alpha").start(true) end) then
+                    vim.schedule(function() vim.cmd.doautocmd "FileType" end)
+                  end
+                elseif is_available "snacks.nvim" then
+                  -- if session was not loaded, if possible, load Snacks dashboard
+                  if pcall(function() require("snacks").dashboard() end) then
+                    vim.schedule(function() vim.cmd.doautocmd "FileType" end)
+                  end
                 end
               end
             end,

--- a/lua/astrocommunity/recipes/auto-session-restore/init.lua
+++ b/lua/astrocommunity/recipes/auto-session-restore/init.lua
@@ -34,9 +34,8 @@ return {
               if should_skip then return end
               -- if possible, load session
               if not pcall(function() require("resession").load(vim.fn.getcwd(), { dir = "dirsession" }) end) then
-                -- if session was not loaded, if possible, load alpha
-                require("lazy").load { plugins = { "alpha-nvim" } }
-                if pcall(function() require("alpha").start(true) end) then
+                -- if session was not loaded, if possible, load Snacks dashboard
+                if pcall(function() Snacks.dashboard.start() end) then
                   vim.schedule(function() vim.cmd.doautocmd "FileType" end)
                 end
               end

--- a/lua/astrocommunity/snippet/nvim-snippets/init.lua
+++ b/lua/astrocommunity/snippet/nvim-snippets/init.lua
@@ -7,6 +7,7 @@ return {
     { "L3MON4D3/LuaSnip", optional = true, enabled = false },
     {
       "hrsh7th/nvim-cmp",
+      optional = true,
       dependencies = { "garymjr/nvim-snippets" },
       opts = function(_, opts)
         if not opts.sources then opts.sources = {} end

--- a/lua/astrocommunity/startup/fsplash-nvim/init.lua
+++ b/lua/astrocommunity/startup/fsplash-nvim/init.lua
@@ -28,7 +28,9 @@ return {
     },
   },
   specs = {
-    { "goolord/alpha-nvim", optional = true, enabled = false },
+    { "folke/snacks.nvim", optional = true, opts = {
+      dashboard = { enabled = false },
+    } },
     { "stevearc/resession.nvim", optional = true, opts = { extensions = { fsplash = {} } } },
   },
   opts = {

--- a/lua/astrocommunity/startup/fsplash-nvim/init.lua
+++ b/lua/astrocommunity/startup/fsplash-nvim/init.lua
@@ -28,6 +28,7 @@ return {
     },
   },
   specs = {
+    { "goolord/alpha-nvim", optional = true, enabled = false },
     { "folke/snacks.nvim", optional = true, opts = {
       dashboard = { enabled = false },
     } },

--- a/lua/astrocommunity/startup/mini-starter/init.lua
+++ b/lua/astrocommunity/startup/mini-starter/init.lua
@@ -3,7 +3,9 @@ return {
   version = "*", -- stable version
   config = function() require("mini.starter").setup() end,
   specs = {
-    { "goolord/alpha-nvim", optional = true, enabled = false },
+    { "folke/snacks.nvim", optional = true, opts = {
+      dashboard = { enabled = false },
+    } },
     {
       "AstroNvim/astrocore",
       optional = true,

--- a/lua/astrocommunity/startup/mini-starter/init.lua
+++ b/lua/astrocommunity/startup/mini-starter/init.lua
@@ -3,6 +3,7 @@ return {
   version = "*", -- stable version
   config = function() require("mini.starter").setup() end,
   specs = {
+    { "goolord/alpha-nvim", optional = true, enabled = false },
     { "folke/snacks.nvim", optional = true, opts = {
       dashboard = { enabled = false },
     } },


### PR DESCRIPTION
TODO list:
- [x] Drop support for neovim 0.9
- [x] Alpha-nvim -> snacks.nvim
- [x] dressing.nvim -> snacks.nvim
- [x] indent-blankline.nvim	-> snacks.nvim
- [x] lspkind.nvim -> mini.icons
- [x] mini.bufremove -> snacks.nvim
- [x] nvim-cmp -> blink.cmp
- [x] nvim-colorizer.lua -> nvim-highlight-colors
- [x] nvim-notify -> snacks.nvim
- [x] nvim-web-devicons -> mini.icons
- [x] telescope.nvim -> snacks.nvim
- [x] mason-tool-installer integration 
	From release notes:
	> AstroNvim is now relying on mason-tool-installer.nvim rather than mason-lspconfig/mason-nvim-dap/mason-null-ls. This makes configuration of installed packages easier rather than managing several ensure_installed tables and also adds support for installing packages automatically that are not part of any of those usecase specific plugins. mason-tool-installer.nvim also allows the user to specify specific package versions and other options. Check out the [mason-tool-installer.nvim Documentation](https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim) for details on it’s configuration.
For migration, anywhere in your configuration where you are configuring ensure_installed for mason-lspconfig/mason-nvim-dap/mason-null-ls, you should move those to an ensure_installed table in mason-tool-installer.nvim. You must also change the name of the package where necessary to properly reflect the name of the package in Mason. For instance, if you have lua_ls specified for mason-lspconfig, this would be lua-language-server in mason-tool-installer.nvim.
