### PR TITLE
fix(yanky-nvim): Fix typo in command

### DIFF
--- a/lua/astrocommunity/editing-support/yanky-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/yanky-nvim/init.lua
@@ -8,7 +8,7 @@ return {
       opts = {
         mappings = {
           n = {
-            ["<Leader>fy"] = { "<Cmd>YankRingHistory<CR>", desc = "Find yanks" },
+            ["<Leader>fy"] = { "<Cmd>YankyRingHistory<CR>", desc = "Find yanks" },
             ["y"] = { "<Plug>(YankyYank)", desc = "Yank text" },
             ["p"] = { "<Plug>(YankyPutAfter)", desc = "Put yanked text after cursor" },
             ["P"] = { "<Plug>(YankyPutBefore)", desc = "Put yanked text before cursor" },


### PR DESCRIPTION
Fixes bug reported in https://github.com/AstroNvim/astrocommunity/issues/1405#issuecomment-2764361961