### PR TITLE
fix(nvim-dap-repl-highlights): nvim-dap in dependencies breaks lazy loading

### DIFF
--- a/lua/astrocommunity/debugging/nvim-dap-repl-highlights/init.lua
+++ b/lua/astrocommunity/debugging/nvim-dap-repl-highlights/init.lua
@@ -4,11 +4,7 @@ return {
   specs = {
     {
       "nvim-treesitter/nvim-treesitter",
-      dependencies = {
-        "LiadOz/nvim-dap-repl-highlights",
-        dependencies = { "mfussenegger/nvim-dap" },
-        opts = {},
-      },
+      dependencies = { "LiadOz/nvim-dap-repl-highlights", opts = {} },
       opts = function(_, opts)
         if opts.ensure_installed ~= "all" then
           opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "dap_repl" })


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
nvim-dap in dependencies breaks lazy loading of the nvim-dap plugin and all related plugins
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
before this patch dap* plugins loaded on nvim open:
![image](https://github.com/user-attachments/assets/6a46b0a4-925c-47b3-9f86-001c6a3438dc)
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
