### PR TITLE
fix(rust): use a stable path for `codelldb` in Mason

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -94,21 +94,19 @@ return {
     },
     opts = function()
       local adapter
-      local success, package = pcall(function() return require("mason-registry").get_package "codelldb" end)
+      local codelldb_installed = pcall(function() return require("mason-registry").get_package "codelldb" end)
       local cfg = require "rustaceanvim.config"
-      if success then
-        local package_path = vim.fn.expand "$MASON/packages/codelldb"
-        local codelldb_path = package_path .. "/codelldb"
-        local liblldb_path = package_path .. "/extension/lldb/lib/liblldb"
-        local this_os = vim.loop.os_uname().sysname
+      if codelldb_installed then
+        local codelldb_path = vim.fn.exepath "codelldb"
+        local this_os = vim.uv.os_uname().sysname
 
+        local liblldb_path = vim.fn.expand "$MASON/share/lldb"
         -- The path in windows is different
         if this_os:find "Windows" then
-          codelldb_path = package_path .. "\\extension\\adapter\\codelldb.exe"
-          liblldb_path = package_path .. "\\extension\\lldb\\bin\\liblldb.dll"
+          liblldb_path = liblldb_path .. "\\bin\\lldb.dll"
         else
           -- The liblldb extension is .so for linux and .dylib for macOS
-          liblldb_path = liblldb_path .. (this_os == "Linux" and ".so" or ".dylib")
+          liblldb_path = liblldb_path .. "/lib/liblldb" .. (this_os == "Linux" and ".so" or ".dylib")
         end
         adapter = cfg.get_codelldb_adapter(codelldb_path, liblldb_path)
       else


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Mason paths within a package are not really considered stable, so we should rely on stable paths if available. I have a PR open to resolve this stable path and then we can merge this in

Relies on https://github.com/mason-org/mason-registry/pull/9565

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
