### PR TITLE
fix(avante-nvim): add missing mapping override

### DIFF
--- a/lua/astrocommunity/completion/avante-nvim/init.lua
+++ b/lua/astrocommunity/completion/avante-nvim/init.lua
@@ -46,6 +46,7 @@ return {
       },
       files = {
         add_current = prefix .. ".",
+        add_all_buffers = prefix .. "B",
       },
     },
   },


### PR DESCRIPTION
## 📑 Description

Adds an Avante mapping for the [recently added](https://github.com/yetone/avante.nvim/commit/78d6c389b4f94b2040c87c82558ea6cd9328ef95) `add_all_buffers`.

## ℹ Additional Information

I'm not sure if there's any Astro precedent for switching from `B` to something else...