### PR TITLE
feat(pack)!: update rust pack to use v6 rustaceanvim when using 0.11 nvim

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -80,7 +80,7 @@ return {
   },
   {
     "mrcjkb/rustaceanvim",
-    version = "^5",
+    version = vim.version().minor < 11 and "^5" or "^6",
     ft = "rust",
     specs = {
       {


### PR DESCRIPTION
## 📑 Description

Update to use v6 when 0.11 nvim is installed, I don't believe the other breaking changes effect us.

https://github.com/mrcjkb/rustaceanvim/releases/tag/v6.0.0