### PR TITLE
fix(copilot-lua-cmp): make nvim-cmp optional

### DIFF
--- a/lua/astrocommunity/completion/copilot-lua-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-lua-cmp/init.lua
@@ -19,6 +19,7 @@ return {
     { import = "astrocommunity.completion.copilot-lua" },
     {
       "hrsh7th/nvim-cmp",
+      optional = true,
       dependencies = { "zbirenbaum/copilot.lua" },
       opts = function(_, opts)
         local cmp, copilot = require "cmp", require "copilot.suggestion"


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
After migration to v5, when using this plugin, nvim-cmp is installed automatically, which does not necessarily need to happen if blink.cmp is installed

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Old behavior after v5: plugin is enabled, nvim-cmp is installed automatically despite a valid completion engine (blink.cmp) being present
New behavior after v5: plugin is enabled, nvim-cmp is not set up unless already installed