### PR TITLE
fix(leap-nvim): Fix cursor invisible bug on nvim 0.10+

### DIFF
--- a/lua/astrocommunity/motion/leap-nvim/init.lua
+++ b/lua/astrocommunity/motion/leap-nvim/init.lua
@@ -5,28 +5,6 @@ return {
     {
       "AstroNvim/astrocore",
       opts = {
-        autocmds = vim.fn.has "nvim-0.10" == 0
-            and {
-              leap_cursor = { -- https://github.com/ggandor/leap.nvim/issues/70#issuecomment-1521177534
-                {
-                  event = "User",
-                  pattern = "LeapEnter",
-                  callback = function()
-                    vim.cmd.hi("Cursor", "blend=100")
-                    vim.opt.guicursor:append { "a:Cursor/lCursor" }
-                  end,
-                },
-                {
-                  event = "User",
-                  pattern = "LeapLeave",
-                  callback = function()
-                    vim.cmd.hi("Cursor", "blend=0")
-                    vim.opt.guicursor:remove { "a:Cursor/lCursor" }
-                  end,
-                },
-              },
-            }
-          or {},
         mappings = {
           n = {
             ["s"] = { "<Plug>(leap-forward)", desc = "Leap forward" },


### PR DESCRIPTION
We added this autocmd to fix the cursor issue in nvim 0.9 and having around around broke 0,10, since we no longer support 0.9, I think we can safely remove it

Related Issue: https://github.com/AstroNvim/astrocommunity/issues/1219
