### PR TITLE
fix(codeium-nvim): add symbol_map initialization in mini.icons configuration

### DIFF
--- a/lua/astrocommunity/completion/codeium-nvim/init.lua
+++ b/lua/astrocommunity/completion/codeium-nvim/init.lua
@@ -64,6 +64,7 @@ return {
       -- Adds icon for codeium using mini.icons
       opts = function(_, opts)
         if not opts.lsp then opts.lsp = {} end
+        if not opts.symbol_map then opts.symbol_map = {} end
         opts.symbol_map.codeium = { glyph = require("astroui").get_icon("Codeium", 1, true), hl = "MiniIconsCyan" }
       end,
     },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

This PR fixes an issue in the Codeium plugin's mini.icons configuration where it was trying to access `opts.symbol_map.codeium` without first checking if `opts.symbol_map` exists.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

- [x] Add `if not opts.symbol_map then opts.symbol_map = {} end` check before setting codeium icon in mini.icons configuration

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

This fix prevents an error that would occur when `opts.symbol_map` is nil, similar to how it's already checked in the lspkind configuration above it.