### PR TITLE
fix(editing-support): disable nvim-treesitter-sexp for neovim 0.11

### DIFF
--- a/lua/astrocommunity/editing-support/nvim-treesitter-sexp/README.md
+++ b/lua/astrocommunity/editing-support/nvim-treesitter-sexp/README.md
@@ -5,3 +5,5 @@ A plugin for Neovim for editing code by manipulating the Treesitter AST. Basical
 Supported Languages: Clojure, Fennel, Janet, Query
 
 **Repository:** <https://github.com/PaterJason/nvim-treesitter-sexp>
+
+> NOTE: Disabled for Neovim 0.11 (treesitter breaking changes)

--- a/lua/astrocommunity/editing-support/nvim-treesitter-sexp/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-treesitter-sexp/init.lua
@@ -1,6 +1,7 @@
 return {
   "PaterJason/nvim-treesitter-sexp",
   dependencies = { "nvim-treesitter/nvim-treesitter" },
+  enabled = vim.fn.has "nvim-0.11" == 0,
   ft = { "clojure", "fennel", "janet", "query" },
   cmd = "TSSexp",
   opts = {},

--- a/lua/astrocommunity/pack/clojure/README.md
+++ b/lua/astrocommunity/pack/clojure/README.md
@@ -20,6 +20,9 @@ The Clojure language pack includes:
 
 > NOTE: Conjure is available as a [code-runner](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/code-runner) plugin config. nvim-treesitter-sexp and nvim-parinfer are available as [editing-support plugin configurations](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/editing-support)
 
+> NOTE: nvim-treesitter-sexp plugin disabled for Neovim 0.11 (treesitter breaking changes)
+
+
 ## Clojure Guides
 
 `:ConjureSchool` in a Clojure buffer runs an interactive tutorial for Conjure


### PR DESCRIPTION
## 📑 Description

Disable nvim-treesitter-sexp plugin when running neovim 0.11 (errors due to treesitter breaking changes)

- [x] Add condition to lazy config for plugin on 
- [x] Update nvim-treesitter-readme with note regarding neovim 0.11
- [x] Update clojure pack readme with note regarding nvim-treesitter-sexp 

> If there is a preferred approach to managing breaking changes in plugins (that arent fixed yet), feel free to change this PR or help me know what I should change it too.  Thanks.

## ℹ️  Additional Information

An [issue has been raised with the maintainer](https://github.com/PaterJason/nvim-treesitter-sexp/issues/12) of the package.

nvim-treesitter-sexp fails when using its commands for neovim 0.11 and AstroNvim v5

This plugin is failing due to breaking changes in treesitter since neovim 0.11