### PR TITLE
fix(copilot-cmp): add symbol_map initialization in mini.icons configuration

### DIFF
--- a/lua/astrocommunity/completion/copilot-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-cmp/init.lua
@@ -56,6 +56,7 @@ return {
       -- Adds icon for copilot using mini.icons
       opts = function(_, opts)
         if not opts.lsp then opts.lsp = {} end
+        if not opts.symbol_map then opts.symbol_map = {} end
         opts.symbol_map.copilot = { glyph = "", hl = "MiniIconsAzure" }
       end,
     },


### PR DESCRIPTION
## 📑 Description

Without the change from this PR, loading `astrocommunity/completion/copilot-cmp` leads to the following error message at startup:

> ```
> Failed to run `config` for mini.icons
> 
> ...unity/lua/astrocommunity/completion/copilot-cmp/init.lua:59: attempt to index field 'symbol_map' (a nil value)
> 
> # stacktrace:
>   - /astrocommunity/lua/astrocommunity/completion/copilot-cmp/init.lua:59 _in_ **values**
>   - /astroui/lua/astroui/status/utils.lua:155 _in_ **icon_provider**
>   - /astroui/lua/astroui/status/hl.lua:41 _in_ **hl**
>   - /heirline.nvim/lua/heirline/statusline.lua:355 _in_ **_eval**
>   - /heirline.nvim/lua/heirline/statusline.lua:398 _in_ **_eval**
>   - /heirline.nvim/lua/heirline/statusline.lua:398 _in_ **_eval**
>   - /heirline.nvim/lua/heirline/statusline.lua:398 _in_ **_eval**
>   - /heirline.nvim/lua/heirline/statusline.lua:398 _in_ **_eval**
>   - /heirline.nvim/lua/heirline/statusline.lua:398 _in_ **_eval**
>   - /heirline.nvim/lua/heirline/statusline.lua:473 _in_ **eval**
>   - /heirline.nvim/lua/heirline/init.lua:114
> ```

## ℹ Additional Information

The same change is also included in #1434 for the codeium completion.