### PR TITLE
fix(picker-lsp-mappings): picker-lsp-mappings in recipers to work with telescope and picker

### DIFF
--- a/lua/astrocommunity/recipes/picker-lsp-mappings/init.lua
+++ b/lua/astrocommunity/recipes/picker-lsp-mappings/init.lua
@@ -29,7 +29,8 @@ return {
       if opts.mappings.n["<Leader>lR"] then
         opts.mappings.n["<Leader>lR"][1] = function() require("telescope.builtin").lsp_references() end
       end
-    elseif require("astrocore").is_available "snacks.nvim" then
+    end
+    if require("astrocore").is_available "snacks.nvim" then
       opts.mappings.n.grr = {
         function() require("snacks.picker").lsp_references() end,
         desc = "LSP References",


### PR DESCRIPTION

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
- previously, lsp mapping would not be applied to use snack.picker when telescope is installed due the use of following plugin: 

  ```lua
  { import = "astrocommunity.debugging.telescope-dap-nvim" },
  ```
