### PR TITLE
feat(picker-lsp-mappings): Add standard `gO` binding for LSP symbols

### DIFF
--- a/lua/astrocommunity/recipes/picker-lsp-mappings/init.lua
+++ b/lua/astrocommunity/recipes/picker-lsp-mappings/init.lua
@@ -40,6 +40,10 @@ return {
         desc = "LSP Implementations",
         cond = "textDocument/implementation",
       }
+      opts.mappings.n.gO = {
+        function() require("snacks.picker").lsp_symbols() end,
+        desc = "LSP Document Symbols",
+      }
 
       if opts.mappings.n.gd then opts.mappings.n.gd[1] = function() require("snacks.picker").lsp_definitions() end end
       if opts.mappings.n.gI then


### PR DESCRIPTION
## 📑 Description

There is a new standard binding in NeoVim 0.11, `gO` for the symbol outline (if there is an LSP, it goes to `vim.lsp.buf.document_symbol()`. This PR hooks this up to use the snacks equivalentl.
