### PR TITLE
fix(actions-preview-nvim): fix incorrect picker backend configuration

### DIFF
--- a/lua/astrocommunity/lsp/actions-preview-nvim/init.lua
+++ b/lua/astrocommunity/lsp/actions-preview-nvim/init.lua
@@ -29,9 +29,11 @@ return {
   },
   opts = function(_, opts)
     local is_available = require("astrocore").is_available
-    opts.backend.provider = (is_available "telescope.nvim" and "telescope")
-      or (is_available "mini.pick" and "minipick")
-      or (is_available "snacks.nvim" and "snacks")
-      or (is_available "nui.nvim" and "nui")
+    opts.backend = {
+      (is_available "telescope.nvim" and "telescope")
+        or (is_available "mini.pick" and "minipick")
+        or (is_available "snacks.nvim" and "snacks")
+        or (is_available "nui.nvim" and "nui"),
+    }
   end,
 }

--- a/lua/astrocommunity/lsp/actions-preview-nvim/init.lua
+++ b/lua/astrocommunity/lsp/actions-preview-nvim/init.lua
@@ -30,9 +30,9 @@ return {
   opts = function(_, opts)
     local is_available = require("astrocore").is_available
     opts.backend = {
-      (is_available "telescope.nvim" and "telescope")
+      (is_available "snacks.nvim" and "snacks")
+        or (is_available "telescope.nvim" and "telescope")
         or (is_available "mini.pick" and "minipick")
-        or (is_available "snacks.nvim" and "snacks")
         or (is_available "nui.nvim" and "nui"),
     }
   end,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The backend config option for `actions-preview.nvim` expects a table with a priority list of backends to attempt to use. This PR fixes the configuration