### PR TITLE
feat(multiple-cursors-nvim): Add icon for mappings prefix

### DIFF
--- a/lua/astrocommunity/editing-support/multiple-cursors-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/multiple-cursors-nvim/init.lua
@@ -11,29 +11,36 @@ return {
     "MultipleCursorsLock",
   },
   dependencies = {
-    "AstroNvim/astrocore",
-    opts = function(_, opts)
-      local maps = opts.mappings
-      for lhs, map in pairs {
-        ["<C-Down>"] = { "<Cmd>MultipleCursorsAddDown<CR>", desc = "Add cursor down" },
-        ["<C-Up>"] = { "<Cmd>MultipleCursorsAddUp<CR>", desc = "Add cursor up" },
-        ["<C-LeftMouse>"] = { "<Cmd>MultipleCursorsMouseAddDelete<CR>", desc = "Add cursor with mouse" },
-      } do
-        maps.n[lhs] = map
-        maps.i[lhs] = map
-      end
-      local prefix = "<Leader>m"
-      for lhs, map in pairs {
-        [prefix .. "a"] = { "<Cmd>MultipleCursorsAddMatches<CR>", desc = "Add cursor matches" },
-        [prefix .. "A"] = { "<Cmd>MultipleCursorsAddMatchesV<CR>", desc = "Add cursor matches in previous visual area" },
-        [prefix .. "j"] = { "<Cmd>MultipleCursorsAddJumpNextMatch<CR>", desc = "Add cursor and jump to next match" },
-        [prefix .. "J"] = { "<Cmd>MultipleCursorsJumpNextMatch<CR>", desc = "Move cursor to next match" },
-        [prefix .. "l"] = { "<Cmd>MultipleCursorsLock<CR>", desc = "Lock virtual cursors" },
-      } do
-        maps.n[lhs] = map
-        maps.x[lhs] = map
-      end
-    end,
+    { "AstroNvim/astroui", opts = { icons = { MultipleCursors = "󰗧" } } },
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        for lhs, map in pairs {
+          ["<C-Down>"] = { "<Cmd>MultipleCursorsAddDown<CR>", desc = "Add cursor down" },
+          ["<C-Up>"] = { "<Cmd>MultipleCursorsAddUp<CR>", desc = "Add cursor up" },
+          ["<C-LeftMouse>"] = { "<Cmd>MultipleCursorsMouseAddDelete<CR>", desc = "Add cursor with mouse" },
+        } do
+          maps.n[lhs] = map
+          maps.i[lhs] = map
+        end
+        local prefix = "<Leader>m"
+        for lhs, map in pairs {
+          [prefix] = { desc = require("astroui").get_icon("MultipleCursors", 1, true) .. "MultipleCursors" },
+          [prefix .. "a"] = { "<Cmd>MultipleCursorsAddMatches<CR>", desc = "Add cursor matches" },
+          [prefix .. "A"] = {
+            "<Cmd>MultipleCursorsAddMatchesV<CR>",
+            desc = "Add cursor matches in previous visual area",
+          },
+          [prefix .. "j"] = { "<Cmd>MultipleCursorsAddJumpNextMatch<CR>", desc = "Add cursor and jump to next match" },
+          [prefix .. "J"] = { "<Cmd>MultipleCursorsJumpNextMatch<CR>", desc = "Move cursor to next match" },
+          [prefix .. "l"] = { "<Cmd>MultipleCursorsLock<CR>", desc = "Lock virtual cursors" },
+        } do
+          maps.n[lhs] = map
+          maps.x[lhs] = map
+        end
+      end,
+    },
   },
   opts = {},
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

Added icon for group `<leader>m` of mappings provided by this plugin.
![image](https://github.com/user-attachments/assets/0948c0f5-5dc0-43d6-9bd1-7c28ef4bddac)
