### PR TITLE
feat(neogit): add mappings to open Neogit in floating window, horizontal and vertical splits

### DIFF
--- a/lua/astrocommunity/git/neogit/init.lua
+++ b/lua/astrocommunity/git/neogit/init.lua
@@ -14,6 +14,9 @@ return {
         maps.n[prefix .. "nc"] = { "<Cmd>Neogit commit<CR>", desc = "Open Neogit Commit Page" }
         maps.n[prefix .. "nd"] = { ":Neogit cwd=", desc = "Open Neogit Override CWD" }
         maps.n[prefix .. "nk"] = { ":Neogit kind=", desc = "Open Neogit Override Kind" }
+        maps.n[prefix .. "nf"] = { "<Cmd>Neogit kind=floating<CR>", desc = "Open Neogit Float" }
+        maps.n[prefix .. "nh"] = { "<Cmd>Neogit kind=split<CR>", desc = "Open Neogit Horizontal Split" }
+        maps.n[prefix .. "nv"] = { "<Cmd>Neogit kind=vsplit<CR>", desc = "Open Neogit Vertical Split" }
       end,
     },
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

![image](https://github.com/user-attachments/assets/02210745-3f3d-45ba-ab31-42478fdc29b7)

Added `<Leader>gnh`, `<Leader>gnv` and `<Leader>gnf` mappings for Neogit to open windows with different `kind` options values: `split`, `vsplit`, `float`.

Mappings are inspired by toggleterm mappings `<Leader>th`, `<Ledaer>tv` and `<Leader>tf`
