### PR TITLE
feat(bash): add zsh support

### DIFF
--- a/lua/astrocommunity/pack/bash/README.md
+++ b/lua/astrocommunity/pack/bash/README.md
@@ -7,3 +7,5 @@ This plugin pack does the following:
 - Adds `shfmt` formatter
 - Adds `shellcheck` linter
 - Adds `bash` debugger
+
+> :warning: Also attaches to zsh files with experimental support.

--- a/lua/astrocommunity/pack/bash/init.lua
+++ b/lua/astrocommunity/pack/bash/init.lua
@@ -1,5 +1,15 @@
 return {
   {
+    "AstroNvim/astrolsp",
+    opts = {
+      config = {
+        bashls = {
+          filetypes = { "sh", "bash", "zsh" },
+        },
+      },
+    },
+  },
+  {
     "nvim-treesitter/nvim-treesitter",
     optional = true,
     opts = function(_, opts)
@@ -46,6 +56,7 @@ return {
     opts = {
       formatters_by_ft = {
         sh = { "shfmt", "shellcheck" },
+        zsh = { "shfmt", "shellcheck" },
       },
     },
   },
@@ -55,6 +66,7 @@ return {
     opts = {
       linters_by_ft = {
         sh = { "shellcheck" },
+        zsh = { "shellcheck" },
       },
     },
   },


### PR DESCRIPTION
## 📑 Description

While bashls doesn't officially support zsh, the syntax is almost the same and will get you most of the way there to make dealing with zsh files much better.