### PR TITLE
fix(noice-nvim): don't override the lsp_progress component

### DIFF
--- a/lua/astrocommunity/utility/noice-nvim/init.lua
+++ b/lua/astrocommunity/utility/noice-nvim/init.lua
@@ -57,16 +57,6 @@ return {
       end,
     },
     {
-      "rebelot/heirline.nvim",
-      optional = true,
-      opts = function(_, opts)
-        local noice_opts = require("astrocore").plugin_opts "noice.nvim"
-        if vim.tbl_get(noice_opts, "lsp", "progress", "enabled") ~= false then -- check if lsp progress is enabled
-          opts.statusline[9] = require("astroui.status").component.lsp { lsp_progress = false }
-        end
-      end,
-    },
-    {
       "folke/edgy.nvim",
       optional = true,
       opts = function(_, opts)


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Since disabling lsp_progress in the statusline is hardcoded, it interferes with user-configured statuslines and is difficult to debug. We'll disable it temporarily.
