### PR TITLE
feat(completion): Add in codex.nvim

### DIFF
--- a/lua/astrocommunity/completion/codex-nvim/README.md
+++ b/lua/astrocommunity/completion/codex-nvim/README.md
@@ -1,0 +1,7 @@
+# Codex.nvim
+
+OpenAI Codex plugin for Neovim
+
+For more information, please refer to:
+
+Repository: <https://github.com/johnseth97/codex.nvim>

--- a/lua/astrocommunity/completion/codex-nvim/init.lua
+++ b/lua/astrocommunity/completion/codex-nvim/init.lua
@@ -1,0 +1,22 @@
+return {
+  "johnseth97/codex.nvim",
+  specs = {
+    {
+      "AstroNvim/astrocore",
+      opts = {
+        mappings = {
+          n = {
+            ["<Leader>O"] = { function() require("codex").toggle() end, desc = "Toggle Codex popup" },
+          },
+        },
+      },
+    },
+  },
+  cmd = {
+    "Codex",
+    "CodexToggle",
+  },
+  opts = {
+    keymaps = {}, -- Disable internal mapping
+  },
+}

--- a/lua/astrocommunity/completion/codex-nvim/init.lua
+++ b/lua/astrocommunity/completion/codex-nvim/init.lua
@@ -6,7 +6,7 @@ return {
       opts = {
         mappings = {
           n = {
-            ["<Leader>O"] = { function() require("codex").toggle() end, desc = "Toggle Codex popup" },
+            ["<Leader>Oc"] = { function() require("codex").toggle() end, desc = "Toggle Codex popup" },
           },
         },
       },


### PR DESCRIPTION
This might be one of the case where we need to prefix the author to the name, since I recon it could be a flood of codex.nvim plugins. WDYT? @AstroNvim/astrocommunity-maintainers 
