### PR TITLE
feat(editing-support): add nvim-paredit plugin

### DIFF
--- a/lua/astrocommunity/editing-support/nvim-paredit/README.md
+++ b/lua/astrocommunity/editing-support/nvim-paredit/README.md
@@ -6,4 +6,3 @@ Supported Languages: Clojure, Fennel, Scheme, CommonLisp
 
 **Repository:** <https://github.com/julienvincent/nvim-paredit>
 
-> NOTE: nvim-paredit is included in the Clojure pack

--- a/lua/astrocommunity/editing-support/nvim-paredit/README.md
+++ b/lua/astrocommunity/editing-support/nvim-paredit/README.md
@@ -1,0 +1,11 @@
+## nvim-paredit
+
+A plugin for Neovim implementing paredit s-expression editing with lisp dialects. Written in Lua and built with Treesitter.
+
+Paredit provides commands (slurp, barf, raise, etc) to move code around whilst ensuring balanced parens.
+
+Supported Languages: Clojure, Fennel, Scheme, CommonLisp
+
+**Repository:** <https://github.com/julienvincent/nvim-paredit>
+
+> NOTE: nvim-paredit is included in the Clojure pack

--- a/lua/astrocommunity/editing-support/nvim-paredit/README.md
+++ b/lua/astrocommunity/editing-support/nvim-paredit/README.md
@@ -1,8 +1,6 @@
 ## nvim-paredit
 
-A plugin for Neovim implementing paredit s-expression editing with lisp dialects. Written in Lua and built with Treesitter.
-
-Paredit provides commands (slurp, barf, raise, etc) to move code around whilst ensuring balanced parens.
+A Paredit implementation for Neovim, built using Treesitter and written in Lua.
 
 Supported Languages: Clojure, Fennel, Scheme, CommonLisp
 

--- a/lua/astrocommunity/editing-support/nvim-paredit/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-paredit/init.lua
@@ -1,0 +1,5 @@
+return {
+  "julienvincent/nvim-paredit",
+  ft = { "clojure", "fennel", "scheme", "commonlisp" },
+  opts = {},
+}


### PR DESCRIPTION
## 📑 Description

Adds the [julienvincent/nvim-paredit](https://github.com/julienvincent/nvim-paredit) plugin to provide structural editing support for Lisp dialects.

## ℹ️  Additional Information

nvim-paredit plugin supports the changes in Neovim 0.11 and will be included in the Clojure pack in a future PR (once this PR has been approved)