### PR TITLE
feat(editing-support): add parpar-nvim plugin

### DIFF
--- a/lua/astrocommunity/editing-support/parpar-nvim/README.md
+++ b/lua/astrocommunity/editing-support/parpar-nvim/README.md
@@ -1,0 +1,13 @@
+## parpar-nvim
+
+A plugin for Neovim that combines two alternative approaches for structural editing with Lisp dialects.
+
+Parinfer ensures parenthesis are balanced based on indentation of each line of code.
+
+Paredit provides commands (slurp, barf, raise, etc) to move code around whilst ensuring balanced parens.
+
+Parpar integrates the two plugins to ensure they play well together.
+
+Supported Languages: Clojure, Fennel, Scheme, CommonLisp
+
+**Repository:** <https://github.com/dundalek/parpar.nvim>

--- a/lua/astrocommunity/editing-support/parpar-nvim/README.md
+++ b/lua/astrocommunity/editing-support/parpar-nvim/README.md
@@ -1,13 +1,5 @@
 ## parpar-nvim
 
-A plugin for Neovim that combines two alternative approaches for structural editing with Lisp dialects.
-
-Parinfer ensures parenthesis are balanced based on indentation of each line of code.
-
-Paredit provides commands (slurp, barf, raise, etc) to move code around whilst ensuring balanced parens.
-
-Parpar integrates the two plugins to ensure they play well together.
-
-Supported Languages: Clojure, Fennel, Scheme, CommonLisp
+Plugin for Neovim that seamlessly integrates Parinfer and Paredit for editing lisp code
 
 **Repository:** <https://github.com/dundalek/parpar.nvim>

--- a/lua/astrocommunity/editing-support/parpar-nvim/README.md
+++ b/lua/astrocommunity/editing-support/parpar-nvim/README.md
@@ -1,5 +1,7 @@
 ## parpar-nvim
 
-Plugin for Neovim that seamlessly integrates Parinfer and Paredit for editing lisp code
+Plugin for Neovim that seamlessly integrates Parinfer and Paredit for editing lisp code.
+
+Supported Languages: Clojure, Fennel, Scheme, CommonLisp
 
 **Repository:** <https://github.com/dundalek/parpar.nvim>

--- a/lua/astrocommunity/editing-support/parpar-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/parpar-nvim/init.lua
@@ -1,18 +1,9 @@
-local plugins = {
-  -- parinfer & paredit structural editing
+return {
   {
     "dundalek/parpar.nvim",
     ft = { "clojure", "fennel", "scheme", "commonlisp" },
     opts = {},
   },
-
-  -- Dependencies
-
-  -- Parinfer structural editing
   { import = "astrocommunity.editing-support.nvim-parinfer" },
-
-  -- Paredit structural editing
   { import = "astrocommunity.editing-support.nvim-paredit" },
 }
-
-return plugins

--- a/lua/astrocommunity/editing-support/parpar-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/parpar-nvim/init.lua
@@ -1,0 +1,18 @@
+local plugins = {
+  -- parinfer & paredit structural editing
+  {
+    "dundalek/parpar.nvim",
+    ft = { "clojure", "fennel", "scheme", "commonlisp" },
+    opts = {},
+  },
+
+  -- Dependencies
+
+  -- Parinfer structural editing
+  { import = "astrocommunity.editing-support.nvim-parinfer" },
+
+  -- Paredit structural editing
+  { import = "astrocommunity.editing-support.nvim-paredit" },
+}
+
+return plugins


### PR DESCRIPTION
## 📑 Description

Plugin ensures nvim-paredit and nvim-parinfer work well together

Imports both plugins from astrocommunity rather than including the plugins as dependencies (please comment if this is not the correct approach)

- [x] PR depends on acceptance of #1456


## ℹ️  Additional Information

Parpar provides the two common approaches in one plugin and ensures the plugins do not conflict with each other when editing.

Parpar can be imported into the Clojure pack and simplify its code (in a future PR)
