### PR TITLE
feat(clojure): update to use parpar-nvim

### DIFF
--- a/lua/astrocommunity/pack/clojure/README.md
+++ b/lua/astrocommunity/pack/clojure/README.md
@@ -15,11 +15,10 @@ The Clojure language pack includes:
 
 - `clojure` treesitter parsers
 - [clojure-lsp](https://clojure-lsp.io/) language server
-- Clojure REPL client: [Conjure](https://github.com/Olical/conjure)
+- Clojure REPL client: [Olical/conjure](https://github.com/Olical/conjure)
 - Structural editing: [parpar-nvim](https://github.com/dundalek/parpar.nvim) which provides both [nvim-parinfer](https://github.com/gpanders/nvim-parinfer) & [nvim-paredit](https://github.com/julienvincent/nvim-paredit)
 
 > NOTE: Conjure is available as a [code-runner](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/code-runner) plugin config. nvim-paredit and nvim-parinfer are available as [editing-support plugin configurations](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/editing-support)
-
 
 ## Clojure Guides
 
@@ -28,7 +27,6 @@ The Clojure language pack includes:
 - [Clojure.org](https://clojure.org/index) API reference and guides
 - [Conjure - Clojure guide](https://github.com/Olical/conjure/wiki/Quick-start:-Clojure)
 - [Practicalli Neovim](https://practical.li/neovim/) Clojure development workflow and examples of [configuring Astrocommunity clojure pack](https://practical.li/neovim/configuration/astronvim/astrocommunity/)
-
 
 ## Override Configuration
 

--- a/lua/astrocommunity/pack/clojure/README.md
+++ b/lua/astrocommunity/pack/clojure/README.md
@@ -15,12 +15,10 @@ The Clojure language pack includes:
 
 - `clojure` treesitter parsers
 - [clojure-lsp](https://clojure-lsp.io/) language server
-- Clojure REPL client: [Olical/conjure](https://github.com/Olical/conjure)
-- Structural editing: [gpanders/nvim-parinfer](https://github.com/gpanders/nvim-parinfer) & [PaterJason/nvim-treesitter-sexp](https://github.com/PaterJason/nvim-treesitter-sexp)
+- Clojure REPL client: [Conjure](https://github.com/Olical/conjure)
+- Structural editing: [parpar-nvim](https://github.com/dundalek/parpar.nvim) which provides both [nvim-parinfer](https://github.com/gpanders/nvim-parinfer) & [nvim-paredit](https://github.com/julienvincent/nvim-paredit)
 
-> NOTE: Conjure is available as a [code-runner](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/code-runner) plugin config. nvim-treesitter-sexp and nvim-parinfer are available as [editing-support plugin configurations](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/editing-support)
-
-> NOTE: nvim-treesitter-sexp plugin disabled for Neovim 0.11 (treesitter breaking changes)
+> NOTE: Conjure is available as a [code-runner](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/code-runner) plugin config. nvim-paredit and nvim-parinfer are available as [editing-support plugin configurations](https://github.com/AstroNvim/astrocommunity/tree/main/lua/astrocommunity/editing-support)
 
 
 ## Clojure Guides
@@ -41,6 +39,7 @@ Example: Include the Clojure language pack and disable the parinfer plugin by se
 ```lua
   { import = "astrocommunity.pack.clojure" },
   { "gpanders/nvim-parinfer", enabled = false },
+  { "julienvincent/nvim-paredit", enabled = false },
 ```
 
 Example: Change the test runner used by Conjure. `clojure.test` runner is used by default

--- a/lua/astrocommunity/pack/clojure/init.lua
+++ b/lua/astrocommunity/pack/clojure/init.lua
@@ -3,9 +3,9 @@
 --
 -- clojure-lsp server via mason
 -- treesitter clojure parser
--- ts-comment.nvim with `;;` and `;` support
--- structured editing with parinfer and treesitter-sexp plugins
--- REPL connected editor with Conjure plugin (log HUD hidden by default)
+-- treesitter comments with `;;` and `;` support
+-- structured editing with parinfer and paredit plugins
+-- REPL connected editor with Conjure plugin
 -- ------------------------------------------
 
 local plugins = {
@@ -38,11 +38,8 @@ local plugins = {
   -- Conjure plugin for Clojure REPL
   { import = "astrocommunity.code-runner.conjure" },
 
-  -- Parinfer parens management for Clojure
-  { import = "astrocommunity.editing-support.nvim-parinfer" },
-
-  -- Treesitter structural editing
-  { import = "astrocommunity.editing-support.nvim-treesitter-sexp" },
+  -- Parinfer & Paredit structural editing for Lisp dialects
+  { import = "astrocommunity.editing-support.parpar-nvim" },
 
   -- Better treesitter comments
   { import = "astrocommunity.comment.ts-comments-nvim" },


### PR DESCRIPTION
## 📑 Description

Replace nvim-treesitter-sexp with parpar-nvim.

Add other-nvim to pack with clojure specific pattern matching.


nvim-treesitter-sexp fails on neovim 0.11

nvim-paredit is a drop-in replacement for nvim-treesitter-sexp that works with Neovim 0.10 & 0.11

parpar provides nvim-paredit and nvim-parinfer and ensures they work together

- [x] requires #1456
- [x] requires #1457

## ℹ️ Additional Information

Other-nvim will be added in a future PR, once clojure mappings have been merged into the upstream project.
