### PR TITLE
feat(editing-support): add other-nvim

### DIFF
--- a/lua/astrocommunity/editing-support/other-nvim/README.md
+++ b/lua/astrocommunity/editing-support/other-nvim/README.md
@@ -1,0 +1,10 @@
+# other-nvim
+
+Open alternative files for the current buffer, e.g. toggle between test and implementation.
+
+Supported Languages:
+
+- built-in: livewire, angular, laravel, rails, golang, python, react, rust, elixir
+- custom: clojure
+
+**Repository:** <https://github.com/rgroli/other.nvim>

--- a/lua/astrocommunity/editing-support/other-nvim/README.md
+++ b/lua/astrocommunity/editing-support/other-nvim/README.md
@@ -1,6 +1,6 @@
 # other-nvim
 
-Open alternative files for the current buffer, e.g. toggle between test and implementation.
+Open alternative files for the current buffer.
 
 Supported Languages:
 

--- a/lua/astrocommunity/editing-support/other-nvim/README.md
+++ b/lua/astrocommunity/editing-support/other-nvim/README.md
@@ -5,6 +5,5 @@ Open alternative files for the current buffer.
 Supported Languages:
 
 - built-in: livewire, angular, laravel, rails, golang, python, react, rust, elixir
-- custom: clojure
 
 **Repository:** <https://github.com/rgroli/other.nvim>

--- a/lua/astrocommunity/editing-support/other-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/other-nvim/init.lua
@@ -1,0 +1,35 @@
+return {
+  "rgroli/other.nvim",
+  ft = {
+    -- built-in mapping support
+    "livewire",
+    "angular",
+    "laravel",
+    "rails",
+    "golang",
+    "python",
+    "react",
+    "rust",
+    "elixir",
+    -- custom (defined in opts > mappings)
+    "clojure",
+  },
+  main = "other-nvim",
+  opts = {
+    mappings = {
+      { -- clojure unit test files
+        pattern = function(path)
+          local match = vim.fn.matchlist(path, "\\v^(.*)/src/(.{-}_test)@!(.{-}).clj(.?)")
+          if #match > 0 then return match end
+        end,
+        target = "%2/test/%4_test.clj%5",
+        context = "test",
+      },
+      { -- clojure source code
+        pattern = "(.*)/test/(.*)_test.clj(.?)$",
+        target = "%1/src/%2.clj%3",
+        context = "implementation",
+      },
+    },
+  },
+}

--- a/lua/astrocommunity/editing-support/other-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/other-nvim/init.lua
@@ -11,25 +11,7 @@ return {
     "react",
     "rust",
     "elixir",
-    -- custom (defined in opts > mappings)
-    "clojure",
   },
   main = "other-nvim",
-  opts = {
-    mappings = {
-      { -- clojure unit test files
-        pattern = function(path)
-          local match = vim.fn.matchlist(path, "\\v^(.*)/src/(.{-}_test)@!(.{-}).clj(.?)")
-          if #match > 0 then return match end
-        end,
-        target = "%2/test/%4_test.clj%5",
-        context = "test",
-      },
-      { -- clojure source code
-        pattern = "(.*)/test/(.*)_test.clj(.?)$",
-        target = "%1/src/%2.clj%3",
-        context = "implementation",
-      },
-    },
-  },
+  opts = {},
 }

--- a/lua/astrocommunity/editing-support/other-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/other-nvim/init.lua
@@ -12,6 +12,5 @@ return {
     "rust",
     "elixir",
   },
-  main = "other-nvim",
   opts = {},
 }


### PR DESCRIPTION
## 📑 Description

Add [rgroli/other.nvim](https://github.com/rgroli/other.nvim) to editing-support, including built-in languages and custom mappings for Clojure

## ℹ Additional Information

