### PR TITLE
fix(laravel): picker not getting defined correctly

### DIFF
--- a/lua/astrocommunity/pack/laravel/init.lua
+++ b/lua/astrocommunity/pack/laravel/init.lua
@@ -29,11 +29,15 @@ return {
     event = { "VeryLazy" },
     opts = function(_, opts)
       local is_available = require("astrocore").is_available
-      opts.pickers = { enable = true }
-      opts.pickers.provider = (is_available "telescope.nvim" and "telescope")
-        or (is_available "fzf-lua" and "fzf-lua")
-        or (is_available "snacks.nvim" and "snacks")
-        or "ui.select"
+      opts.features = {
+        pickers = {
+          enable = true,
+          provider = (is_available "telescope.nvim" and "telescope")
+            or (is_available "fzf-lua" and "fzf-lua")
+            or (is_available "snacks.nvim" and "snacks")
+            or "ui.select",
+        },
+      }
     end,
   },
   {


### PR DESCRIPTION
## 📑 Description

It looks like the provided doc here is wrong https://adalessa.github.io/laravel-nvim-docs/docs/pickers/ and it should be nested under features like they show here https://adalessa.github.io/laravel-nvim-docs/docs/getting-started/

Currently, you get this
```
Error executing Lua callback: ...e/nvim/lazy/laravel.nvim/lua/laravel/pickers_manager.lua:30: Picker provider not found: telescope. Check your configuration
stack traceback:
	[C]: in function 'error'
	...e/nvim/lazy/laravel.nvim/lua/laravel/pickers_manager.lua:30: in function 'make'
	.../.local/share/nvim/lazy/laravel.nvim/lua/laravel/app.lua:232: in function <.../.local/share/nvim/lazy/laravel.nvim/lua/laravel/app.lua:206>
	vim/shared.lua: in function 'app'
	...vel.nvim/lua/laravel/providers/user_command_provider.lua:35: in function <...vel.nvim/lua/laravel/providers/user_command_provider.lua:26>
```