### PR TITLE
fix(lua): skip selene install on aarch64 platforms

### DIFF
--- a/lua/astrocommunity/pack/lua/README.md
+++ b/lua/astrocommunity/pack/lua/README.md
@@ -6,3 +6,4 @@ This plugin pack does the following:
 - Adds `lua_ls` language server
 - Adds `stylua` formatter
 - Adds `selene` linter
+  - On `aarch64` machines this is skipped.

--- a/lua/astrocommunity/pack/lua/init.lua
+++ b/lua/astrocommunity/pack/lua/init.lua
@@ -86,14 +86,17 @@ return {
     "mfussenegger/nvim-lint",
     optional = true,
     opts = function(_, opts)
-      opts.linters_by_ft = {
-        lua = is_aarch64 and {} or { "selene" },
-      }
-
       if not is_aarch64 then
+        opts.linters_by_ft = {
+          lua = { "selene" },
+        }
         opts.linters = opts.linters or {}
         opts.linters.selene = {
           condition = function(ctx) return selene_configured(ctx.filename) end,
+        }
+      else
+        opts.linters_by_ft = {
+          lua = {},
         }
       end
     end,

--- a/lua/astrocommunity/pack/lua/init.lua
+++ b/lua/astrocommunity/pack/lua/init.lua
@@ -2,13 +2,24 @@ local function selene_configured(path)
   return #vim.fs.find("selene.toml", { path = path, upward = true, type = "file" }) > 0
 end
 
+local is_aarch64 = vim.loop.os_uname().machine == "aarch64"
+
 return {
   {
     "AstroNvim/astrolsp",
     optional = true,
     opts = {
       config = {
-        lua_ls = { settings = { Lua = { hint = { enable = true, arrayIndex = "Disable" } } } },
+        lua_ls = {
+          settings = {
+            Lua = {
+              hint = {
+                enable = true,
+                arrayIndex = "Disable",
+              },
+            },
+          },
+        },
       },
     },
   },
@@ -32,14 +43,24 @@ return {
     "jay-babu/mason-null-ls.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "stylua", "selene" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "stylua",
+        -- only include selene if not aarch64
+        (not is_aarch64 and "selene") or nil,
+      })
+
       if not opts.handlers then opts.handlers = {} end
-      opts.handlers.selene = function(source_name, methods)
-        local null_ls = require "null-ls"
-        for _, method in ipairs(methods) do
-          null_ls.register(null_ls.builtins[method][source_name].with {
-            runtime_condition = function(params) return selene_configured(params.bufname) end,
-          })
+
+      if not is_aarch64 then
+        opts.handlers.selene = function(source_name, methods)
+          local null_ls = require "null-ls"
+          for _, method in ipairs(methods) do
+            null_ls.register(null_ls.builtins[method][source_name].with {
+              runtime_condition = function(params)
+                return selene_configured(params.bufname)
+              end,
+            })
+          end
         end
       end
     end,
@@ -48,8 +69,12 @@ return {
     "WhoIsSethDaniel/mason-tool-installer.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "lua-language-server", "stylua", "selene" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "lua-language-server",
+        "stylua",
+        -- only install selene if not on aarch64
+        (not is_aarch64 and "selene") or nil,
+      })
     end,
   },
   {
@@ -64,13 +89,19 @@ return {
   {
     "mfussenegger/nvim-lint",
     optional = true,
-    opts = {
-      linters_by_ft = {
-        lua = { "selene" },
-      },
-      linters = {
-        selene = { condition = function(ctx) return selene_configured(ctx.filename) end },
-      },
-    },
+    opts = function(_, opts)
+      opts.linters_by_ft = {
+        lua = is_aarch64 and {} or { "selene" },
+      }
+
+      if not is_aarch64 then
+        opts.linters = opts.linters or {}
+        opts.linters.selene = {
+          condition = function(ctx)
+            return selene_configured(ctx.filename)
+          end,
+        }
+      end
+    end,
   },
 }

--- a/lua/astrocommunity/pack/lua/init.lua
+++ b/lua/astrocommunity/pack/lua/init.lua
@@ -94,11 +94,6 @@ return {
         opts.linters.selene = {
           condition = function(ctx) return selene_configured(ctx.filename) end,
         }
-      else
-        opts.linters_by_ft = {
-          lua = {},
-        }
-      end
     end,
   },
 }

--- a/lua/astrocommunity/pack/lua/init.lua
+++ b/lua/astrocommunity/pack/lua/init.lua
@@ -45,7 +45,6 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "stylua",
-        -- only include selene if not aarch64
         (not is_aarch64 and "selene") or nil,
       })
 
@@ -56,9 +55,7 @@ return {
           local null_ls = require "null-ls"
           for _, method in ipairs(methods) do
             null_ls.register(null_ls.builtins[method][source_name].with {
-              runtime_condition = function(params)
-                return selene_configured(params.bufname)
-              end,
+              runtime_condition = function(params) return selene_configured(params.bufname) end,
             })
           end
         end
@@ -72,7 +69,6 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "lua-language-server",
         "stylua",
-        -- only install selene if not on aarch64
         (not is_aarch64 and "selene") or nil,
       })
     end,
@@ -97,9 +93,7 @@ return {
       if not is_aarch64 then
         opts.linters = opts.linters or {}
         opts.linters.selene = {
-          condition = function(ctx)
-            return selene_configured(ctx.filename)
-          end,
+          condition = function(ctx) return selene_configured(ctx.filename) end,
         }
       end
     end,

--- a/lua/astrocommunity/pack/lua/init.lua
+++ b/lua/astrocommunity/pack/lua/init.lua
@@ -94,6 +94,7 @@ return {
         opts.linters.selene = {
           condition = function(ctx) return selene_configured(ctx.filename) end,
         }
+      end
     end,
   },
 }


### PR DESCRIPTION
selene is not compatible with aarch64 (e.g., Raspberry Pi 5). This adds architecture detection to avoid installing selene where unsupported, while preserving all other functionality. This prevents constant failed installs on Nvim start when using Lua pack.

---

## 📑 Description

This pull request introduces conditional support for the `selene` linter based on the system architecture, specifically excluding it on `aarch64` systems. It also refactors related configurations to ensure compatibility and maintainability.

### Conditional `selene` Support:
* Added a check for the system architecture (`aarch64`) using `vim.loop.os_uname().machine` and stored the result in a new `is_aarch64` variable. (`lua/astrocommunity/pack/lua/init.lua`, [lua/astrocommunity/pack/lua/init.luaR5-R22](diffhunk://#diff-f51ea87d5a049b1b100f6cee98c76196c2d47fb9deb55f67087d86db05da1216R5-R22))
* Modified `mason-null-ls.nvim` and `mason-tool-installer.nvim` configurations to conditionally include `selene` in the `ensure_installed` list only if not on `aarch64`. (`lua/astrocommunity/pack/lua/init.lua`, [lua/astrocommunity/pack/lua/init.luaL35-R77](diffhunk://#diff-f51ea87d5a049b1b100f6cee98c76196c2d47fb9deb55f67087d86db05da1216L35-R77))
* Updated `nvim-lint` configuration to exclude `selene` from `linters_by_ft` and `linters` on `aarch64` systems. (`lua/astrocommunity/pack/lua/init.lua`, [lua/astrocommunity/pack/lua/init.luaL67-R105](diffhunk://#diff-f51ea87d5a049b1b100f6cee98c76196c2d47fb9deb55f67087d86db05da1216L67-R105))
