### PR TITLE
feat(other-nvim): clojure support added upstream

### DIFF
--- a/lua/astrocommunity/editing-support/other-nvim/README.md
+++ b/lua/astrocommunity/editing-support/other-nvim/README.md
@@ -4,6 +4,6 @@ Open alternative files for the current buffer.
 
 Supported Languages:
 
-- built-in: livewire, angular, laravel, rails, golang, python, react, rust, elixir
+- built-in: livewire, angular, laravel, rails, golang, python, react, rust, elixir, clojure
 
 **Repository:** <https://github.com/rgroli/other.nvim>

--- a/lua/astrocommunity/editing-support/other-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/other-nvim/init.lua
@@ -11,6 +11,7 @@ return {
     "react",
     "rust",
     "elixir",
+    "clojure",
   },
   opts = {},
 }


### PR DESCRIPTION
## 📑 Description

Clojure support added to other.nvim via PR https://github.com/rgroli/other.nvim/pull/67

- Add clojure filetype to lazy
- Update readme


## ℹ Additional Information

