### PR TITLE
refactor(typescript)!: remove html-css pack import

### DIFF
--- a/lua/astrocommunity/pack/typescript/README.md
+++ b/lua/astrocommunity/pack/typescript/README.md
@@ -12,6 +12,14 @@ This plugin pack does the following:
 - Adds [nvim-lsp-file-operations](https://github.com/antosha417/nvim-lsp-file-operations) to handles file imports on rename or move within neo-tree
 - Adds [neotest-jest](https://github.com/nvim-neotest/neotest-jest) to ease the test running if `neotest` is installed
 
+## How do I enable HTML and CSS support?
+
+To enable HTML, CSS and Emmet support, you can add the `html-css` pack to your `community.lua` config:
+
+```lua
+{ import = "astrocommunity.pack.html-css" }
+```
+
 ## How do I disable Eslint format on save?
 
 To opt out of the Eslint format on save behaviour, you can disable the autocmd setup with the pack with this:

--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -73,7 +73,6 @@ end
 local conform_formatter = function(bufnr) return has_prettier(bufnr) and { "prettierd" } or {} end
 
 return {
-  { import = "astrocommunity.pack.html-css" },
   { import = "astrocommunity.lsp.nvim-lsp-file-operations" },
   {
     "nvim-treesitter/nvim-treesitter",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
This will remove html-css from typescript, so users can opt-in on their own.

Closes #1421
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
LazyVim doesn't even include Emmet, but we probably want to keep it, since VSCode has it and it's widely used during HTML dev.
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
