### PR TITLE
docs(typescript): add section about double formatting issue

### DIFF
--- a/lua/astrocommunity/pack/typescript/README.md
+++ b/lua/astrocommunity/pack/typescript/README.md
@@ -36,6 +36,18 @@ return {
 }
 ```
 
+## How do I resolve double formatting issues with Prettier and ESLint?
+
+If you experience double formatting or race conditions due to both `eslint_fix_on_save` and `prettierd` (via `conform.nvim`) formatting on save, you can resolve this by following one of these solutions:
+
+### Solution 1: Disable `eslint_fix_on_save`
+You can disable the `eslint_fix_on_save` autocmd in your configuration as mentioned above.
+
+### Solution 2: Configure ESLint to Not Handle Formatting
+Alternatively, you can configure your project's ESLint setup to avoid handling formatting altogether:
+1. Use `eslint-config-prettier` in your ESLint configuration to disable rules that conflict with Prettier.
+2. Optionally, remove `eslint-plugin-prettier` if it is only used for enforcing Prettier rules.
+
 ## How do I customize `neotest-jest`?
 
 To customize the `neotest-jest` plugin, you need to configure it like you would with any other plugin

--- a/lua/astrocommunity/pack/typescript/README.md
+++ b/lua/astrocommunity/pack/typescript/README.md
@@ -38,7 +38,7 @@ return {
 
 ## How do I resolve double formatting issues with Prettier and ESLint?
 
-If you experience double formatting or race conditions due to both `eslint_fix_on_save` and `prettierd` (via `conform.nvim`) formatting on save, you can resolve this by following one of these solutions:
+If you experience double formatting or race conditions due to both `eslint_fix_on_save` and `prettierd` (via `mason-null-ls.nvim` or `conform.nvim`) formatting on save, you can resolve this by following one of these solutions:
 
 ### Solution 1: Disable `eslint_fix_on_save`
 You can disable the `eslint_fix_on_save` autocmd in your configuration as mentioned above.


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
This adds a section about double formatting due to bad configuration of eslint/prettier which might result in odd behavior in some projects.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
