### PR TITLE
fix(neominimap-nvim): set options within init instead of config

### DIFF
--- a/lua/astrocommunity/split-and-window/neominimap-nvim/init.lua
+++ b/lua/astrocommunity/split-and-window/neominimap-nvim/init.lua
@@ -20,7 +20,10 @@ return {
   opts = {
     buf_filter = function(bufnr) return require("astrocore.buffer").is_valid(bufnr) end,
   },
-  config = function(_, opts)
+  config = function() end,
+  init = function(plugin)
+    local opts = plugin.opts
+
     if opts.layout == nil or opts.layout == "float" then
       local float_width = (vim.tbl_get(opts, "float", "minimap_width") or 20) + 2
       if vim.opt.sidescrolloff:get() < float_width then vim.opt.sidescrolloff = float_width end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

Closes https://github.com/AstroNvim/astrocommunity/issues/1476

## 📑 Description

Fixes the bug reported in https://github.com/AstroNvim/astrocommunity/issues/1476, while still supporting `opts`.

Summary: due to when neominimap.nvim looks at the config file, it means that setting the options in `config` doesn't actually work, instead it must be set during `init`.

## ℹ Additional Information

### Minimal test

This is similar to the minimum viable reproducible config, but instead using my version of astrocommunity :smile: 

```lua
-- save as repro.lua
-- run with nvim -u repro.lua
-- DO NOT change the paths
local root = vim.fn.fnamemodify("./.repro", ":p")

-- set stdpaths to use .repro
for _, name in ipairs({ "config", "data", "state", "runtime", "cache" }) do
  vim.env[("XDG_%s_HOME"):format(name:upper())] = root .. "/" .. name
end

-- bootstrap lazy
local lazypath = root .. "/plugins/lazy.nvim"
if not vim.loop.fs_stat(lazypath) then
  -- stylua: ignore
  vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", "--branch=stable", lazypath })
end
vim.opt.rtp:prepend(vim.env.LAZY or lazypath)

-- install plugins
local plugins = {
  { "AstroNvim/AstroNvim", import = "astronvim.plugins" },
  {
     "AstroNvim/astrocommunity",
     { import = "astrocommunity.split-and-window.neominimap-nvim" },
  },
  {
     "Isrothy/neominimap.nvim",
     opts = {
       layout = "split",
       split = {
         minimap_width = 10,
       },
    },
   },
}
require("lazy").setup(plugins, {
  root = root .. "/plugins",
})

```
