### PR TITLE
fix(nvim-spider): provide UTF-8 support by default

### DIFF
--- a/lua/astrocommunity/motion/nvim-spider/init.lua
+++ b/lua/astrocommunity/motion/nvim-spider/init.lua
@@ -31,6 +31,13 @@ return {
         },
       },
     },
+    {
+      "vhyrro/luarocks.nvim",
+      priority = 1000,
+      opts = {
+        rocks = { "luautf8" },
+      },
+    },
   },
   opts = {},
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

According to [README.md](https://github.com/chrisgrieser/nvim-spider?tab=readme-ov-file#utf-8-support), `luautf8` rocks package is required to correctly handle UTF-8 layouts (CJK, cyrillic, etc.).
Otherwise user won't be able to jump word-wise in layout other than english.

I added [luarocks.nvim](https://github.com/vhyrro/luarocks.nvim) dependency to install it.
