### PR TITLE
fix(purescript): fix `error Cannot find package "purs-tidy"`

### DIFF
--- a/lua/astrocommunity/pack/purescript/init.lua
+++ b/lua/astrocommunity/pack/purescript/init.lua
@@ -41,7 +41,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "purescript-language-server",
-        "purs-tidy",
+        "purescript-tidy",
       })
     end,
   },


### PR DESCRIPTION
```
Error executing vim.schedule lua callback: ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:80: Cannot find package "purs-tidy".
stack traceback:
        [C]: in function 'error'
        ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:80: in function 'get_package'
        ...on-tool-installer.nvim/lua/mason-tool-installer/init.lua:180: in function 'callback'
        ...share/nvim/lazy/mason.nvim/lua/mason-core/async/init.lua:87: in function 'step'
        ...share/nvim/lazy/mason.nvim/lua/mason-core/async/init.lua:96: in function 'run'
        ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:202: in function 'refresh'
        ...on-tool-installer.nvim/lua/mason-tool-installer/init.lua:262: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
