### PR TITLE
fix(indent-blankline-nvim): Use indent-blankline v3 main entry point

### DIFF
--- a/lua/astrocommunity/indent/indent-blankline-nvim/init.lua
+++ b/lua/astrocommunity/indent/indent-blankline-nvim/init.lua
@@ -1,6 +1,7 @@
 return {
   "lukas-reineke/indent-blankline.nvim",
   event = "User AstroFile",
+  main = "ibl",
   opts = {
     indent = {
       char = "│",


### PR DESCRIPTION
Closes #1484

## 📑 Description


## ℹ Additional Information
Use indent-blankline v3 main entry point
Refer to https://github.com/lukas-reineke/indent-blankline.nvim/wiki/Migrate-to-version-3