### PR TITLE
fix(multicursors-nvim): update hydra dependency to official repo

### DIFF
--- a/lua/astrocommunity/editing-support/multicursors-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/multicursors-nvim/init.lua
@@ -1,7 +1,7 @@
 return {
   "smoka7/multicursors.nvim",
   event = "VeryLazy",
-  dependencies = { "smoka7/hydra.nvim" },
+  dependencies = { "nvimtools/hydra.nvim" },
   opts = {},
   keys = {
     {


### PR DESCRIPTION
Replaced deprecated 'smoka7/hydra.nvim' with the maintained 'nvimtools/hydra.nvim' to fix config crash related to invalid module loading.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
