### PR TITLE
fix(catppuccin): added blink cmp support

### DIFF
--- a/lua/astrocommunity/colorscheme/catppuccin/init.lua
+++ b/lua/astrocommunity/colorscheme/catppuccin/init.lua
@@ -7,6 +7,7 @@ return {
     integrations = {
       aerial = true,
       alpha = true,
+      blink_cmp = true,
       cmp = true,
       dap = true,
       dap_ui = true,


### PR DESCRIPTION
## 📑 Description
Added `blink-cmp` support to catppuccin. `blink-cmp` is the default for AstroNvim currently, so the theme should support it.

