### PR TITLE
fix(hardtime-nvim): hardtime not loaded after new file

### DIFF
--- a/lua/astrocommunity/workflow/hardtime-nvim/init.lua
+++ b/lua/astrocommunity/workflow/hardtime-nvim/init.lua
@@ -1,6 +1,6 @@
 return {
   "m4xshen/hardtime.nvim",
-  event = "User AstroFile",
+  lazy = false,
   opts = {
     disabled_keys = {
       ["<Insert>"] = { "", "i" },
@@ -10,8 +10,5 @@ return {
       ["<PageDown>"] = { "", "i" },
     },
   },
-  config = function(_, opts)
-    require("hardtime").setup(opts)
-    require("hardtime").enable()
-  end,
+  config = function(_, opts) require("hardtime").setup(opts) end,
 }


### PR DESCRIPTION
## 📑 Description

Under current configuration, Hardtime is not loaded after opening new file by pressing `n`

This PR:
-  fix the issue by disabling lazy load
- remove redundant `enable()`

