### PR TITLE
fix(proto): replace deprecated buf-language-server with buf_ls

### DIFF
--- a/lua/astrocommunity/pack/proto/init.lua
+++ b/lua/astrocommunity/pack/proto/init.lua
@@ -28,7 +28,7 @@ return {
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "buf-language-server", "buf" })
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "buf_ls", "buf" })
     end,
   },
   {

--- a/lua/astrocommunity/pack/proto/init.lua
+++ b/lua/astrocommunity/pack/proto/init.lua
@@ -27,8 +27,7 @@ return {
     "WhoIsSethDaniel/mason-tool-installer.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "buf_ls", "buf" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf_ls", "buf" })
     end,
   },
   {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3499d0a1-e77f-4aeb-8312-24c4f8b63b12)

Replacing _buf-language-server_ to _buf_ls_ as _buf-language-server_ is deprecated.

p.s.
Need help to aprove this changes, cause I tried several time to uninstall _buf-language-server_ via mason ui, but every time it installs it again. I don't have any custom config's that installs _buf-language-server_. 

Cheers! :sparkles: 