### PR TITLE
fix(conform-nvim): use default timeout and explicit lsp_format

### DIFF
--- a/lua/astrocommunity/editing-support/conform-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/conform-nvim/init.lua
@@ -59,7 +59,7 @@ return {
   opts = {
     default_format_opts = { lsp_format = "fallback" },
     format_on_save = function(bufnr)
-      if vim.F.if_nil(vim.b[bufnr].autoformat, vim.g.autoformat, true) then return { timeout_ms = 500 } end
+      if vim.F.if_nil(vim.b[bufnr].autoformat, vim.g.autoformat, true) then return { lsp_format = "fallback" } end
     end,
   },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
There was an issue where timeout was too short and often caused timeout warning, also it seems that it always fell back to 'never' instead of 'fallback' for lsp_format: https://github.com/stevearc/conform.nvim/blob/a4bb5d6c4ae6f32ab13114e62e70669fa67745b9/doc/conform.txt#L134-L147
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
