### PR TITLE
fix(docker): filter out docker compose filtering instead of disabling

### DIFF
--- a/lua/astrocommunity/pack/docker/init.lua
+++ b/lua/astrocommunity/pack/docker/init.lua
@@ -8,11 +8,10 @@ return {
   {
     "AstroNvim/astrolsp",
     optional = true,
+    ---@type AstroLSPOpts
     opts = {
       formatting = {
-        disabled = {
-          "docker_compose_language_service",
-        },
+        filter = function(client) return client.name ~= "docker_compose_language_service" end,
       },
     },
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
This was causing an issue because of overwriting what conform was setting here: https://github.com/AstroNvim/astrocommunity/blob/b69674df8de9a083754d44fb8a96d8dac1c06860/lua/astrocommunity/editing-support/conform-nvim/init.lua#L6 and enabling back the astrolsp formatting
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
Use filter instead: https://neovim.io/doc/user/lsp.html#vim.lsp.buf.format()
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
