### PR TITLE
fix(proto): Remove invalid buf_ls package

### DIFF
--- a/lua/astrocommunity/pack/proto/README.md
+++ b/lua/astrocommunity/pack/proto/README.md
@@ -3,5 +3,4 @@
 This plugin pack does the following:
 
 - Adds `proto` Treesitter parsers
-- Adds `buf_ls` language servers
-- Adds `buf` formatter
+- Installs `buf` and uses it for language server and formatting

--- a/lua/astrocommunity/pack/proto/init.lua
+++ b/lua/astrocommunity/pack/proto/init.lua
@@ -13,7 +13,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf_ls" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf" })
     end,
   },
   {
@@ -27,7 +27,7 @@ return {
     "WhoIsSethDaniel/mason-tool-installer.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf_ls", "buf" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf" })
     end,
   },
   {

--- a/lua/astrocommunity/pack/proto/init.lua
+++ b/lua/astrocommunity/pack/proto/init.lua
@@ -13,7 +13,7 @@ return {
     "williamboman/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
-      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf" })
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "buf_ls" })
     end,
   },
   {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

#1505 replaced `buf-language-server` with `buf_ls`, but that's not the correct package name (see [here](https://github.com/mason-org/mason-registry/blob/main/packages/buf/package.yaml)).

Currently, the following import

```lua
  { import = "astrocommunity.pack.proto" },
```

results in:

```
Error executing vim.schedule lua callback: ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:32: Cannot find package "buf_ls".
stack traceback:
        [C]: in function 'error'
        ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:32: in function 'get_package'
        ...on-tool-installer.nvim/lua/mason-tool-installer/init.lua:196: in function 'callback'
        ...l/share/nvim/lazy/mason.nvim/lua/mason-registry/init.lua:153: in function 'refresh'
        ...on-tool-installer.nvim/lua/mason-tool-installer/init.lua:271: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

The `mason-registry` package name is [`buf`](https://github.com/mason-org/mason-registry/blob/16f78cae38164354bcb29c10bbe94f44ffa99566/packages/buf/package.yaml#L2) however it's "mapped" to [`buf_ls`](https://github.com/mason-org/mason-registry/blob/16f78cae38164354bcb29c10bbe94f44ffa99566/packages/buf/package.yaml#L36-L37) as per https://github.com/mason-org/mason-registry/pull/9774
