### PR TITLE
fix(avante-nvim): prevent neo-tree mapping warnings

### DIFF
--- a/lua/astrocommunity/completion/avante-nvim/init.lua
+++ b/lua/astrocommunity/completion/avante-nvim/init.lua
@@ -141,10 +141,10 @@ return {
               if not open then sidebar.file_selector:remove_selected_file "neo-tree filesystem [1]" end
             end,
           },
-        },
-        window = {
-          mappings = {
-            ["oa"] = "avante_add_files",
+          window = {
+            mappings = {
+              ["oa"] = "avante_add_files",
+            },
           },
         },
       },


### PR DESCRIPTION
## 📑 Description

Scopes the `oa` neo tree mapping under the filesystem config to prevent `invalid mapping` warnings when viewing other sources (git, buffers, etc).