### PR TITLE
Update indent-rainbowline to use new indent-blankline config

### DIFF
--- a/lua/astrocommunity/indent/indent-rainbowline/init.lua
+++ b/lua/astrocommunity/indent/indent-rainbowline/init.lua
@@ -1,5 +1,6 @@
 return {
   "lukas-reineke/indent-blankline.nvim",
+  main = 'ibl',
   opts = function(_, opts)
     return require("indent-rainbowline").make_opts(opts, require("astrocore").plugin_opts "indent-rainbowline.nvim")
   end,


### PR DESCRIPTION
See https://github.com/TheGLander/indent-rainbowline.nvim/issues/5

## 📑 Description

When using v5 Astronvim with indent-rainbowline, every launch gives an error due to new version needing a config change.

## ℹ Additional Information

