### PR TITLE
fix(nginx): correct package name from nginx_language_server to nginx-language-server

### DIFF
--- a/lua/astrocommunity/pack/nginx/init.lua
+++ b/lua/astrocommunity/pack/nginx/init.lua
@@ -13,7 +13,7 @@ return {
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed =
-        require("astrocore").list_insert_unique(opts.ensure_installed, { "nginx_language_server" })
+        require("astrocore").list_insert_unique(opts.ensure_installed, { "nginx-language-server" })
     end,
   },
   {
@@ -22,7 +22,7 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(
         opts.ensure_installed,
-        { "nginx-config-formatter", "nginx_language_server" }
+        { "nginx-config-formatter", "nginx-language-server" }
       )
     end,
   },


### PR DESCRIPTION
## 📑 Description

fix: change "nginx_language_server" to "nginx-language-server" package name

## ℹ Additional Information

Changed the package name in lua/astrocommunity/pack/nginx/init.lua to fix loading issue.