### PR TITLE
Fix CSS highlighting in TypeScript by adding tree-sitter-styled

### DIFF
--- a/lua/astrocommunity/pack/html-css/init.lua
+++ b/lua/astrocommunity/pack/html-css/init.lua
@@ -14,7 +14,7 @@ return {
     opts = function(_, opts)
       if opts.ensure_installed ~= "all" then
         opts.ensure_installed =
-          require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "css", "scss" })
+          require("astrocore").list_insert_unique(opts.ensure_installed, { "html", "css", "scss", "styled" })
       end
       vim.treesitter.language.register("scss", "less")
       vim.treesitter.language.register("scss", "postcss")


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

Adds `styled`[1] to html-css to allow css highlighting within TypeScript. This was broken as a part of a PR[2] from 2024 and now requires styled.

[1] https://github.com/mskelton/tree-sitter-styled
[2] https://github.com/nvim-treesitter/nvim-treesitter/pull/6255

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Before:
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/a9ec8fe1-1122-4d60-83fc-9fcf14501af8" />

After:
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/c3206be6-77e8-44bd-ac40-e700c5ddaca5" />

