### PR TITLE
fix(vue): Use `get_install_path()` from mason registery to find volar installation path

### DIFF
--- a/lua/astrocommunity/pack/vue/init.lua
+++ b/lua/astrocommunity/pack/vue/init.lua
@@ -39,8 +39,7 @@ return {
               local vuels = registry.get_package "vue-language-server"
 
               if vuels:is_installed() then
-                local volar_install_path =
-                  vuels:get_install_path() "/node_modules/@vue/language-server"
+                local volar_install_path = vuels:get_install_path() .. "/node_modules/@vue/language-server"
 
                 local vue_plugin_config = {
                   name = "@vue/typescript-plugin",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
The line for `vim.fn.expand` was resulting in empty value for `vtsls.tsserver.globalPlugins.location`
![With Default Config Error](https://github.com/user-attachments/assets/246e2263-2343-41b8-a2a5-af00dbe0aaae)

![Location is Empty](https://github.com/user-attachments/assets/91650cd1-c9a4-41d7-8c36-f2af52d2d33f)


After the change

![With the changes](https://github.com/user-attachments/assets/b687252f-8901-4484-bef8-31879f1f1d0e)

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

tldr: using mason's `get_install_path()` function instead of `$MASON` variable


setup:

Astronvim version: I've had this issue on v4 and v5.

```lua
--- lua/community.lua
---@type LazySpec
return {
  "AstroNvim/astrocommunity",
  { import = "astrocommunity.pack.lua" },
  { import = "astrocommunity.pack.vue" },
}
```
