### PR TITLE
fix(ansible): improve regex pattern to avoid false matches

### DIFF
--- a/lua/astrocommunity/pack/ansible/init.lua
+++ b/lua/astrocommunity/pack/ansible/init.lua
@@ -8,7 +8,7 @@ local function yaml_ft(path, bufnr)
   if path_regex and path_regex:match_str(path) then return "yaml.ansible" end
 
   -- check for known ansible playbook text and if found, return yaml.ansible
-  local regex = vim.regex "hosts:\\|tasks:"
+  local regex = vim.regex "^(hosts\\|tasks):"
   if regex and regex:match_str(content) then return "yaml.ansible" end
 
   -- return yaml if nothing else


### PR DESCRIPTION
Closes #1523 

## 📑 Description
The current regex is leading to multiple false matches, because the keywords `hosts` and `tasks` are not exclusively used in ansible files.
Ansible playbooks have those keywords at the start of the line, so it's just easier to search for `^(hosts\\:tasks)`