### PR TITLE
fix(avante-nvim): Check for nil value in opts table for markview.nvim dependency

### DIFF
--- a/lua/astrocommunity/completion/avante-nvim/init.lua
+++ b/lua/astrocommunity/completion/avante-nvim/init.lua
@@ -98,6 +98,7 @@ return {
       "OXY2DEV/markview.nvim",
       optional = true,
       opts = function(_, opts)
+        if not opts.preview then opts.preview = {} end
         if not opts.preview.filetypes then opts.preview.filetypes = { "markdown", "quarto", "rmd" } end
         opts.preview.filetypes = require("astrocore").list_insert_unique(opts.preview.filetypes, { "Avante" })
       end,


### PR DESCRIPTION
## 📑 Description
**`markview.nvim` Plugin Enhancements (Avante integration)**
   * Added a defensive check for `opts.preview` to avoid potential `nil` dereferencing.
   * Ensures compatibility and resilience when plugin options are partially defined.

## ℹ Additional Information
* This update to `markview.nvim` ensures that the plugin doesn't fail if `opts.preview` is undefined, which may occur depending on other plugin configurations.


