### PR TITLE
fix(nvim-treesitter-context): fix outdated commands

### DIFF
--- a/lua/astrocommunity/editing-support/nvim-treesitter-context/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-treesitter-context/init.lua
@@ -2,7 +2,7 @@
 return {
   "nvim-treesitter/nvim-treesitter-context",
   event = "User AstroFile",
-  cmd = { "TSContextToggle" },
+  cmd = { "TSContext" },
   dependencies = {
     "AstroNvim/astrocore",
     ---@type AstroCoreOpts
@@ -10,7 +10,7 @@ return {
       mappings = {
         n = {
           ["<Leader>uT"] = {
-            "<cmd>TSContextToggle<CR>",
+            "<cmd>TSContext toggle<CR>",
             desc = "Toggle treesitter context",
           },
         },

--- a/lua/astrocommunity/editing-support/nvim-treesitter-context/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-treesitter-context/init.lua
@@ -3,6 +3,7 @@ return {
   "nvim-treesitter/nvim-treesitter-context",
   event = "User AstroFile",
   cmd = { "TSContext" },
+  opts = {},
   dependencies = {
     "AstroNvim/astrocore",
     ---@type AstroCoreOpts


### PR DESCRIPTION
## 📑 Description

nvim-treesitter-context changed the user commands to a single `TSContext` cmd with subcommands `enable`/`disable`/`toggle`. This patch updates the plugin spec to reflect those changes