### PR TITLE
fix(pack/json): rename schemastore to be lowercase

### DIFF
--- a/lua/astrocommunity/pack/json/init.lua
+++ b/lua/astrocommunity/pack/json/init.lua
@@ -1,6 +1,6 @@
 return {
   {
-    "b0o/SchemaStore.nvim",
+    "b0o/schemastore.nvim",
     lazy = true,
     specs = {
       {

--- a/lua/astrocommunity/pack/yaml/init.lua
+++ b/lua/astrocommunity/pack/yaml/init.lua
@@ -1,6 +1,6 @@
 return {
   {
-    "b0o/SchemaStore.nvim",
+    "b0o/schemastore.nvim",
     lazy = true,
     dependencies = {
       {


### PR DESCRIPTION
## 📑 Description

This solves a problem where lazy could not resolve dependency if it was already installed in user configuration (see video below)

https://github.com/user-attachments/assets/ab4a1bcb-119c-49ea-8027-74993fa3070e