### PR TITLE
fix(json): Normalize casing of schemastore plugin

### DIFF
--- a/lua/astrocommunity/pack/json/init.lua
+++ b/lua/astrocommunity/pack/json/init.lua
@@ -1,6 +1,6 @@
 return {
   {
-    "b0o/SchemaStore.nvim",
+    "b0o/schemastore.nvim",
     lazy = true,
     specs = {
       {


### PR DESCRIPTION
## 📑 Description

This solves a problem where lazy could not resolve dependency if it was already installed in user configuration (see video below)

https://github.com/user-attachments/assets/ab4a1bcb-119c-49ea-8027-74993fa3070e

split from #1542