### PR TITLE
feat(nvim-snippets): add neogen and blink cmp integration

### DIFF
--- a/lua/astrocommunity/snippet/nvim-snippets/init.lua
+++ b/lua/astrocommunity/snippet/nvim-snippets/init.lua
@@ -14,5 +14,15 @@ return {
         table.insert(opts.sources, { name = "snippets", priority = 750 })
       end,
     },
+    {
+      "Saghen/blink.cmp",
+      optional = true,
+      opts = { snippets = { preset = "default" } },
+    },
+    {
+      "danymat/neogen",
+      optional = true,
+      opts = { snippet_engine = "nvim" },
+    },
   },
 }


### PR DESCRIPTION
 fix neogen and blink cmp option error when enable `astrocommunity.snippet.nvim-snippets`

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
Closes #1527
If I want to use neovim native snippet system, I found that neogen and the blink cmp option has errors.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

add spec option in `astrocommunity.snippet.nvim-snippets`:

```lua
{
  "Saghen/blink.cmp",
  optional = true,
  opts = { snippets = { preset = "default" } },
},
{
  "danymat/neogen",
  optional = true,
  opts = { snippet_engine = "nvim" },
},
```
