### PR TITLE
feat(typescript): add goto_source_definition mapping

### DIFF
--- a/lua/astrocommunity/pack/typescript/README.md
+++ b/lua/astrocommunity/pack/typescript/README.md
@@ -11,6 +11,7 @@ This plugin pack does the following:
 - Adds [package-info.nvim](https://github.com/vuki656/package-info.nvim) for project package management
 - Adds [nvim-lsp-file-operations](https://github.com/antosha417/nvim-lsp-file-operations) to handles file imports on rename or move within neo-tree
 - Adds [neotest-jest](https://github.com/nvim-neotest/neotest-jest) to ease the test running if `neotest` is installed
+- Adds `gs` mapping for [goto_source_definition](https://github.com/yioneko/nvim-vtsls?tab=readme-ov-file#commands) instead of typings.
 
 ## How do I enable HTML and CSS support?
 

--- a/lua/astrocommunity/pack/typescript/init.lua
+++ b/lua/astrocommunity/pack/typescript/init.lua
@@ -88,6 +88,15 @@ return {
     "AstroNvim/astrolsp",
     ---@type AstroLSPOpts
     opts = {
+      mappings = {
+        n = {
+          gs = {
+            function() require("vtsls").commands.goto_source_definition() end,
+            desc = "Goto Source Definition (vtsls)",
+            cond = function(client) return client.name == "vtsls" end,
+          },
+        },
+      },
       autocmds = {
         eslint_fix_on_save = {
           cond = function(client) return client.name == "eslint" and vim.fn.exists ":EslintFixAll" > 0 end,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->
Closes #1494 

## 📑 Description
Add `gs` mapping to go to source definition instead of `d.ts` typing.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
https://github.com/yioneko/nvim-vtsls?tab=readme-ov-file#commands
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
