### PR TITLE
fix(nvim-cmp): Check for nil value in opts table

### DIFF
--- a/lua/astrocommunity/completion/nvim-cmp/init.lua
+++ b/lua/astrocommunity/completion/nvim-cmp/init.lua
@@ -222,7 +222,10 @@ return {
       specs = {
         {
           "hrsh7th/nvim-cmp",
-          opts = function(_, opts) table.insert(opts.sources, { name = "lazydev", group_index = 0 }) end,
+          opts = function(_, opts)
+            opts.sources = opts.sources or {} -- init opts.sources
+            table.insert(opts.sources, { name = "lazydev", group_index = 0 })
+          end,
         },
       },
     },

--- a/lua/astrocommunity/completion/nvim-cmp/init.lua
+++ b/lua/astrocommunity/completion/nvim-cmp/init.lua
@@ -223,7 +223,7 @@ return {
         {
           "hrsh7th/nvim-cmp",
           opts = function(_, opts)
-            opts.sources = opts.sources or {} -- init opts.sources
+            if not opts.sources then opts.sources = {} end
             table.insert(opts.sources, { name = "lazydev", group_index = 0 })
           end,
         },


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

`opts.sources` may not be intialized when `table.insert(opts.sources, { name = "lazydev", group_index = 0 })` is called
## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

<img width="1449" alt="image" src="https://github.com/user-attachments/assets/8b0567f7-ab1a-4555-b8b2-02ff45f324aa" />
