### PR TITLE
refactor(python): make mason optional during dap-python setup

### DIFF
--- a/lua/astrocommunity/pack/python/init.lua
+++ b/lua/astrocommunity/pack/python/init.lua
@@ -101,30 +101,21 @@ return {
         dependencies = "mfussenegger/nvim-dap",
         ft = "python", -- NOTE: ft: lazy-load on filetype
         config = function(_, opts)
-          local path = function()
-            local ret = nil
+          local path
 
-            local ok, mason_registry = pcall(require, "mason-registry")
-            if ok then
-              local debugpy = mason_registry.get_package "debugpy"
-              if debugpy:is_installed() then
-                ret = vim.fn.expand "$MASON/packages/debugpy"
-                if vim.fn.has "win32" == 1 then
-                  return ret .. "/venv/Scripts/python"
-                else
-                  return ret .. "/venv/bin/python"
-                end
-              end
-            end
-
-            ret = vim.fn.exepath "debugpy-adapter"
-            if ret == "" then
-              return vim.fn.exepath "python"
+          local mason_registry_avail, mason_registry = pcall(require, "mason-registry")
+          if mason_registry_avail and mason_registry.is_installed "debugpy" then
+            local debugpy_path = vim.fn.expand "$MASON/packages/debugpy"
+            if vim.fn.has "win32" == 1 then
+              path = debugpy_path .. "/venv/Scripts/python"
             else
-              return ret
+              path = debugpy_path .. "/venv/bin/python"
             end
+          else
+            path = vim.fn.exepath "debugpy-adapter"
+            if path == "" then path = vim.fn.exepath "python" end
           end
-          require("dap-python").setup(path(), opts)
+          require("dap-python").setup(path, opts)
         end,
       },
     },

--- a/lua/astrocommunity/pack/python/init.lua
+++ b/lua/astrocommunity/pack/python/init.lua
@@ -101,17 +101,30 @@ return {
         dependencies = "mfussenegger/nvim-dap",
         ft = "python", -- NOTE: ft: lazy-load on filetype
         config = function(_, opts)
-          local path = vim.fn.exepath "python"
-          local debugpy = require("mason-registry").get_package "debugpy"
-          if debugpy:is_installed() then
-            path = vim.fn.expand "$MASON/packages/debugpy"
-            if vim.fn.has "win32" == 1 then
-              path = path .. "/venv/Scripts/python"
+          local path = function()
+            local ret = nil
+
+            local ok, mason_registry = pcall(require, "mason-registry")
+            if ok then
+              local debugpy = mason_registry.get_package "debugpy"
+              if debugpy:is_installed() then
+                ret = vim.fn.expand "$MASON/packages/debugpy"
+                if vim.fn.has "win32" == 1 then
+                  return ret .. "/venv/Scripts/python"
+                else
+                  return ret .. "/venv/bin/python"
+                end
+              end
+            end
+
+            ret = vim.fn.exepath "debugpy-adapter"
+            if ret == "" then
+              return vim.fn.exepath "python"
             else
-              path = path .. "/venv/bin/python"
+              return ret
             end
           end
-          require("dap-python").setup(path, opts)
+          require("dap-python").setup(path(), opts)
         end,
       },
     },

--- a/lua/astrocommunity/pack/python/init.lua
+++ b/lua/astrocommunity/pack/python/init.lua
@@ -101,20 +101,8 @@ return {
         dependencies = "mfussenegger/nvim-dap",
         ft = "python", -- NOTE: ft: lazy-load on filetype
         config = function(_, opts)
-          local path
-
-          local mason_registry_avail, mason_registry = pcall(require, "mason-registry")
-          if mason_registry_avail and mason_registry.is_installed "debugpy" then
-            local debugpy_path = vim.fn.expand "$MASON/packages/debugpy"
-            if vim.fn.has "win32" == 1 then
-              path = debugpy_path .. "/venv/Scripts/python"
-            else
-              path = debugpy_path .. "/venv/bin/python"
-            end
-          else
-            path = vim.fn.exepath "debugpy-adapter"
-            if path == "" then path = vim.fn.exepath "python" end
-          end
+          local path = vim.fn.exepath "debugpy-adapter"
+          if path == "" then path = vim.fn.exepath "python" end
           require("dap-python").setup(path, opts)
         end,
       },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

- User might have a global `debugpy` installation, so we first check for `debugpy-adapter` before falling back to `python` 
  - https://github.com/mfussenegger/nvim-dap-python/commit/261ce649d05bc455a29f9636dc03f8cdaa7e0e2c
- Only attempt to get `debugpy` package if Mason registry is available (since mason is optional and user might disable it)

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

N/A
