### PR TITLE
fix(obsidian-nvim): Option `use_advanced_uri` has been deprecated. Us…

### DIFF
--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -32,7 +32,9 @@ return {
     local astrocore = require "astrocore"
     return astrocore.extend_tbl(opts, {
       dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
-      use_advanced_uri = true,
+      open = {
+        use_advanced_uri = true,
+      },
       finder = (astrocore.is_available "snacks.pick" and "snacks.pick")
         or (astrocore.is_available "telescope.nvim" and "telescope.nvim")
         or (astrocore.is_available "fzf-lua" and "fzf-lua")


### PR DESCRIPTION
…e in `open` module instead.

## 📑 Description

Neovim show a warning:

```
notify.warn Obsidian.nvim The config option 'use_advanced_uri' is deprecated, please use in `open` module instead

```

## ℹ Additional Information
