### PR TITLE
fix(obsidian-nvim): Update plugin spec by removing deprecated options and APIs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -16,7 +16,7 @@ return {
             ["gf"] = {
               function()
                 if require("obsidian").util.cursor_on_markdown_link() then
-                  return "<Cmd>ObsidianFollowLink<CR>"
+                  return "<Cmd>Obsidian follow_link<CR>"
                 else
                   return "gf"
                 end

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -31,7 +31,11 @@ return {
   opts = function(_, opts)
     local astrocore = require "astrocore"
     return astrocore.extend_tbl(opts, {
-      dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
+      workspaces = {
+        {
+          path = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
+        },
+      },
       use_advanced_uri = true,
       finder = (astrocore.is_available "snacks.pick" and "snacks.pick")
         or (astrocore.is_available "telescope.nvim" and "telescope.nvim")

--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -36,7 +36,9 @@ return {
           path = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
         },
       },
-      use_advanced_uri = true,
+      open = {
+        use_advanced_uri = true,
+      },
       finder = (astrocore.is_available "snacks.pick" and "snacks.pick")
         or (astrocore.is_available "telescope.nvim" and "telescope.nvim")
         or (astrocore.is_available "fzf-lua" and "fzf-lua")


### PR DESCRIPTION
## 📑 Description

Obsidian commands were updated: 

` legacy_commands is deprecated, use move from commands like `ObsidianBacklinks` to `Obsidian backlinks``

[Commands](https://github.com/obsidian-nvim/obsidian.nvim/wiki/Commands)