### PR TITLE
fix(obsidian-nvim): fix loading obsidian plugin

### DIFF
--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -31,7 +31,11 @@ return {
   opts = function(_, opts)
     local astrocore = require "astrocore"
     return astrocore.extend_tbl(opts, {
-      dir = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
+      workspaces = {
+        {
+          path = vim.env.HOME .. "/obsidian-vault", -- specify the vault location. no need to call 'vim.fn.expand' here
+        },
+      },
       use_advanced_uri = true,
       finder = (astrocore.is_available "snacks.pick" and "snacks.pick")
         or (astrocore.is_available "telescope.nvim" and "telescope.nvim")


### PR DESCRIPTION

## 📑 Description
After updating an Obsidian plugin, I got a failure:

```
 lazy.nvim Failed to run `config` for obsidian.nvim

...al/share/nvim/lazy/obsidian.nvim/lua/obsidian/config.lua:546: At least one workspace is required!
Please specify a workspace 

```

This PR resolves an issue by adding a single workspace.

