### PR TITLE
refactor(tailwindcss): use root_dir function from nvim-lspconfig

### DIFF
--- a/lua/astrocommunity/pack/tailwindcss/init.lua
+++ b/lua/astrocommunity/pack/tailwindcss/init.lua
@@ -1,16 +1,3 @@
-local function decode_json_file(filename)
-  local file = io.open(filename, "r")
-  if file then
-    local content = file:read "*all"
-    file:close()
-
-    local ok, data = pcall(vim.fn.json_decode, content)
-    if ok and type(data) == "table" then return data end
-  end
-end
-
-local function has_nested_key(json, ...) return vim.tbl_get(json, ...) ~= nil end
-
 return {
   { import = "astrocommunity.pack.html-css" },
   {
@@ -19,50 +6,6 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "tailwindcss" })
     end,
-    dependencies = {
-      {
-        "AstroNvim/astrolsp",
-        optional = true,
-        ---@type AstroLSPOpts
-        opts = {
-          config = {
-            tailwindcss = {
-              root_dir = function(fname)
-                local root_pattern = require("lspconfig").util.root_pattern
-
-                -- First, check for common Tailwind config files
-                local root = root_pattern(
-                  "tailwind.config.mjs",
-                  "tailwind.config.cjs",
-                  "tailwind.config.js",
-                  "tailwind.config.ts",
-                  "postcss.config.js",
-                  "config/tailwind.config.js",
-                  "assets/tailwind.config.js"
-                )(fname)
-                -- If not found, check for package.json dependencies
-                if not root then
-                  local package_root = root_pattern "package.json"(fname)
-                  if package_root then
-                    local package_data = decode_json_file(package_root .. "/package.json")
-                    if
-                      package_data
-                      and (
-                        has_nested_key(package_data, "dependencies", "tailwindcss")
-                        or has_nested_key(package_data, "devDependencies", "tailwindcss")
-                      )
-                    then
-                      root = package_root
-                    end
-                  end
-                end
-                return root
-              end,
-            },
-          },
-        },
-      },
-    },
   },
   {
     "WhoIsSethDaniel/mason-tool-installer.nvim",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
After investigating the current root_dir setup I noticed that `neovim/nvim-lspconfig` https://github.com/neovim/nvim-lspconfig/blob/7fac9025a967a4d0846660f751cd392fac6bb788/lsp/tailwindcss.lua#L109 offers a similar (better) approach. And we don't need to maintain it.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
