### PR TITLE
chore(hurl): rename keymap description to "Hurl" 

### DIFF
--- a/lua/astrocommunity/pack/hurl/init.lua
+++ b/lua/astrocommunity/pack/hurl/init.lua
@@ -32,7 +32,7 @@ return {
       "AstroNvim/astrocore",
       opts = function(_, opts)
         local maps = opts.mappings
-        maps.n[prefix] = { desc = require("astroui").get_icon("HurlNvim", 1, true) .. "HurlNvim" }
+        maps.n[prefix] = { desc = require("astroui").get_icon("HurlNvim", 1, true) .. "Hurl" }
         maps.n[prefix .. "R"] = { "<cmd>HurlRunner<cr>", desc = "Run all requests in the file" }
         maps.n[prefix .. "r"] = { "<cmd>HurlRunnerAt<cr>", desc = "Run request under the cursor" }
         maps.n[prefix .. "e"] = { "<cmd>HurlRunnerToEntry<cr>", desc = "Run request to the entry" }


### PR DESCRIPTION
## 📑 Description

This pull request updates the keymap description for the Hurl integration in AstroNvim. The description has been changed from **"HurlNvim"** to **"Hurl"** for improved clarity and alignment with the naming convention used throughout the pack.

### ✅ Changes Made:
- [x] Updated the keymap label from `"HurlNvim"` to `"Hurl"` in the hurl pack configuration.

This is a minor non-breaking change that improves the user experience by providing a more concise and recognizable label in the keymap list.

## ℹ Additional Information

- **No breaking changes**
- **No new dependencies introduced**
- **This change improves visual consistency with other pack integrations and tool names**
