### PR TITLE
fix(vimtex): add two missing `which-key` descriptions

### DIFF
--- a/lua/astrocommunity/markdown-and-latex/vimtex/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/vimtex/init.lua
@@ -46,6 +46,8 @@ return {
                   { "tsD", desc = "Reverse Cycle (), \\left(\\right) [, ...]" },
                   { "tse", desc = "Toggle star of environment" },
                   { "tsf", desc = "Toggle a/b vs \\frac{a}{b}" },
+                  { "tsb", desc = "Toggle line break" },
+                  { "tss", desc = "Toggle starred environment" },
                   { "[/", desc = "Previous start of a LaTeX comment" },
                   { "[*", desc = "Previous end of a LaTeX comment" },
                   { "[[", desc = "Previous beginning of a section" },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

For some reason, two keymaps, `tsb` for toggling line break and `tss` for toggling starred environment, was missing in the which key descriptions in the old setting of `vimtex`. I added them.

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
