### PR TITLE
fix(jj): properly handle cases where `neo-tree` and `telescope` are not available

### DIFF
--- a/lua/astrocommunity/pack/jj/init.lua
+++ b/lua/astrocommunity/pack/jj/init.lua
@@ -1,28 +1,37 @@
 return {
   {
-    "zschreur/telescope-jj.nvim",
-    config = function() require("telescope").load_extension "jj" end,
-    dependencies = {
+    "nvim-telescope/telescope.nvim",
+    optional = true,
+    specs = {
       {
-        "AstroNvim/astrocore",
-        opts = {
-          mappings = {
-            n = {
-              ["<Leader>jf"] = {
-                function()
-                  local jj_pick_status, jj_res = pcall(require("telescope").extensions.jj.files)
-                  if jj_pick_status then return end
+        "zschreur/telescope-jj.nvim",
+        config = function() require("telescope").load_extension "jj" end,
+        dependencies = {
+          {
+            "AstroNvim/astrocore",
+            opts = {
+              mappings = {
+                n = {
+                  ["<Leader>jf"] = {
+                    function()
+                      local jj_pick_status, jj_res = pcall(require("telescope").extensions.jj.files)
+                      if jj_pick_status then return end
 
-                  -- Git fallback
-                  local git_files_status, git_res = pcall(require("telescope.builtin").git_files)
-                  if not git_files_status then
-                    error("Could not launch jj or git files: \n" .. jj_res .. "\n" .. git_res)
-                  end
-                end,
-                desc = "jj files",
+                      -- Git fallback
+                      local git_files_status, git_res = pcall(require("telescope.builtin").git_files)
+                      if not git_files_status then
+                        error("Could not launch jj or git files: \n" .. jj_res .. "\n" .. git_res)
+                      end
+                    end,
+                    desc = "jj files",
+                  },
+                  ["<Leader>jc"] = {
+                    function() require("telescope").extensions.jj.conflicts() end,
+                    desc = "jj conflicts",
+                  },
+                  ["<Leader>jd"] = { function() require("telescope").extensions.jj.diff() end, desc = "jj diff" },
+                },
               },
-              ["<Leader>jc"] = { function() require("telescope").extensions.jj.conflicts() end, desc = "jj conflicts" },
-              ["<Leader>jd"] = { function() require("telescope").extensions.jj.diff() end, desc = "jj diff" },
             },
           },
         },
@@ -30,30 +39,36 @@ return {
     },
   },
   {
-    "Cretezy/neo-tree-jj.nvim",
-    dependencies = {
+    "nvim-neo-tree/neo-tree.nvim",
+    optional = true,
+    specs = {
       {
-        "nvim-neo-tree/neo-tree.nvim",
-        opts = function(_, opts)
-          table.insert(opts.sources, "jj")
+        "Cretezy/neo-tree-jj.nvim",
+        dependencies = {
+          {
+            "nvim-neo-tree/neo-tree.nvim",
+            opts = function(_, opts)
+              table.insert(opts.sources, "jj")
 
-          -- Replace git tab in neo-tree when in jj repo
-          if require("neo-tree.sources.jj.utils").get_repository_root() then
-            -- Remove git tab
-            for i, source in ipairs(opts.source_selector.sources) do
-              if source.source == "git_status" then
-                table.remove(opts.source_selector.sources, i)
-                break
+              -- Replace git tab in neo-tree when in jj repo
+              if require("neo-tree.sources.jj.utils").get_repository_root() then
+                -- Remove git tab
+                for i, source in ipairs(opts.source_selector.sources) do
+                  if source.source == "git_status" then
+                    table.remove(opts.source_selector.sources, i)
+                    break
+                  end
+                end
+
+                -- Add jj tab
+                table.insert(opts.source_selector.sources, {
+                  display_name = "󰊢 JJ",
+                  source = "jj",
+                })
               end
-            end
-
-            -- Add jj tab
-            table.insert(opts.source_selector.sources, {
-              display_name = "󰊢 JJ",
-              source = "jj",
-            })
-          end
-        end,
+            end,
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
replaces #1578

## 📑 Description

This adds proper handling of cases where the user may have disabled `neo-tree` and/or `telescope`

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
