### PR TITLE
fix(oxlint): remove conform config

### DIFF
--- a/lua/astrocommunity/pack/oxlint/init.lua
+++ b/lua/astrocommunity/pack/oxlint/init.lua
@@ -19,24 +19,4 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "oxlint" })
     end,
   },
-  {
-    "stevearc/conform.nvim",
-    optional = true,
-    opts = function(_, opts)
-      if not opts.formatters_by_ft then opts.formatters_by_ft = {} end
-      -- https://oxc.rs/docs/guide/usage/linter.html
-      local supported_ft = {
-        "javascript",
-        "typescript",
-        "javascriptreact",
-        "typescriptreact",
-        "astro",
-        "svelte",
-        "vue",
-      }
-      for _, ft in ipairs(supported_ft) do
-        opts.formatters_by_ft[ft] = { "oxlint" }
-      end
-    end,
-  },
 }


### PR DESCRIPTION
Conform doesn't have support for oxlint

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
Conform doesn't seem to have oxlint support, so it fails: 
> oxlint error: Unknow formatter. Formatter config missing or incomplete
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
https://github.com/search?q=repo%3Astevearc%2Fconform.nvim%20oxlint&type=code
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
