### PR TITLE
fix(oxlint): enable oxlint in astrolsp

### DIFF
--- a/lua/astrocommunity/pack/oxlint/init.lua
+++ b/lua/astrocommunity/pack/oxlint/init.lua
@@ -19,4 +19,13 @@ return {
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "oxlint" })
     end,
   },
+  {
+    -- TODO: Remove in AstroNvim v6 when mason-lspconfig.nvim is v2
+    "AstroNvim/astrolsp",
+    optional = true,
+    ---@type AstroLSPOpts
+    opts = {
+      servers = { "oxlint" },
+    },
+  },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
Oxlint needs to be manually enabled until mason-lspconfig.nvim v2 is introduced in Astronvim v6.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
