### PR TITLE
feat(quarto): dynamically set codeRunner.default_method based on avai…

### DIFF
--- a/lua/astrocommunity/pack/quarto/init.lua
+++ b/lua/astrocommunity/pack/quarto/init.lua
@@ -5,14 +5,14 @@ return {
     opts = function(_, opts)
       opts.codeRunner = opts.codeRunner or {}
 
-      local ironOk, _ = pcall(require, "iron.core")
-      if ironOk then
+      local iron_avail, _ = pcall(require, "iron.core")
+      if iron_avail then
         opts.codeRunner.default_method = "iron"
         return
       end
 
-      local moltenOk, _ = pcall(require, "molten.health")
-      if moltenOk then
+      local molten_avail, _ = pcall(require, "molten.health")
+      if molten_avail then
         opts.codeRunner.default_method = "molten"
         return
       end

--- a/lua/astrocommunity/pack/quarto/init.lua
+++ b/lua/astrocommunity/pack/quarto/init.lua
@@ -2,7 +2,21 @@ return {
   {
     "quarto-dev/quarto-nvim",
     ft = { "quarto", "qmd" },
-    opts = {},
+    opts = function(_, opts)
+      opts.codeRunner = opts.codeRunner or {}
+
+      local ironOk, _ = pcall(require, "iron.core")
+      if ironOk then
+        opts.codeRunner.default_method = "iron"
+        return
+      end
+
+      local moltenOk, _ = pcall(require, "molten.health")
+      if moltenOk then
+        opts.codeRunner.default_method = "molten"
+        return
+      end
+    end,
     dependencies = {
       { "jmbuhr/otter.nvim" },
     },


### PR DESCRIPTION
Detects presence of "iron.core" and "molten.health" modules at runtime and sets `codeRunner.default_method` accordingly in the quarto-nvim plugin options.

