### PR TITLE
feat(copilotchat-nvim): update to v4 and add mcphub.nvim integration

### DIFF
--- a/lua/astrocommunity/editing-support/copilotchat-nvim/README.md
+++ b/lua/astrocommunity/editing-support/copilotchat-nvim/README.md
@@ -3,5 +3,3 @@
 Chat with GitHub Copilot in Neovim
 
 **Repository:** <https://github.com/CopilotC-Nvim/CopilotChat.nvim>
-
-Note: This will need to have Copilot setup, this uses the same auth as `zbirenbaum/copilot.lua` with `:Copilot setup`

--- a/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/copilotchat-nvim/init.lua
@@ -1,7 +1,7 @@
 ---@type LazySpec
 return {
   "CopilotC-Nvim/CopilotChat.nvim",
-  version = "^3",
+  version = "^4",
   cmd = {
     "CopilotChat",
     "CopilotChatOpen",
@@ -11,19 +11,16 @@ return {
     "CopilotChatReset",
     "CopilotChatSave",
     "CopilotChatLoad",
-    "CopilotChatDebugInfo",
     "CopilotChatModels",
-    "CopilotChatAgents",
     "CopilotChatExplain",
     "CopilotChatReview",
     "CopilotChatFix",
     "CopilotChatOptimize",
     "CopilotChatDocs",
-    "CopilotChatFixTests",
+    "CopilotChatTests",
     "CopilotChatCommit",
   },
   dependencies = {
-    { "zbirenbaum/copilot.lua" },
     { "nvim-lua/plenary.nvim" },
     {
       "AstroNvim/astrocore",

--- a/lua/astrocommunity/editing-support/mcphub-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/mcphub-nvim/init.lua
@@ -40,4 +40,18 @@ return {
       },
     },
   },
+  {
+    "CopilotC-Nvim/CopilotChat.nvim",
+    optional = true,
+    opts = {
+      extensions = {
+        copilotchat = {
+          enabled = true,
+          convert_tools_to_functions = true,
+          convert_resources_to_functions = true,
+          add_mcp_prefix = false,
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
Release notes: https://github.com/CopilotC-Nvim/CopilotChat.nvim/releases/tag/v4.0.0

for summary

- copilot.lua/copilot.vim is no longer hard dependency
- mcphub.nvim now has proper integration with copilotchat
- some commands changed