### PR TITLE
fix(obsidian-nvim): remove `util.table_length`

### DIFF
--- a/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
+++ b/lua/astrocommunity/note-taking/obsidian-nvim/init.lua
@@ -62,7 +62,7 @@ return {
         local out = { id = note.id, aliases = note.aliases, tags = note.tags }
         -- `note.metadata` contains any manually added fields in the frontmatter.
         -- So here we just make sure those fields are kept in the frontmatter.
-        if note.metadata ~= nil and require("obsidian").util.table_length(note.metadata) > 0 then
+        if note.metadata ~= nil and not vim.tbl_isempty(note.metadata) then
           for k, v in pairs(note.metadata) do
             out[k] = v
           end


### PR DESCRIPTION

## 📑 Description

The function `utils.table_length` was removed in [f3cef5cb8cb1904bb0aa53a1869205e89fe22df7](https://github.com/obsidian-nvim/obsidian.nvim/commit/f3cef5cb8cb1904bb0aa53a1869205e89fe22df7#diff-61259842cecffd56b43df9d90d64c34da595137a482a36ceaf791a9a52dc22e9) but  it is still being called.

This issue is triggered when a note's metadata includes a custom field, for example: `custom-field: custom value`.


## ℹ Additional Information
Steps for reproduce:

1. create a note
2. add a custom field to metadata
3. try to format a note

:x: fail

