### PR TITLE
fix(catppuccin): use get_theme() instead of get() for bufferline integration

### DIFF
--- a/lua/astrocommunity/colorscheme/catppuccin/init.lua
+++ b/lua/astrocommunity/colorscheme/catppuccin/init.lua
@@ -19,7 +19,7 @@ return {
       optional = true,
       opts = function(_, opts)
         return require("astrocore").extend_tbl(opts, {
-          highlights = require("catppuccin.groups.integrations.bufferline").get(),
+          highlights = require("catppuccin.groups.integrations.bufferline").get_theme(),
         })
       end,
     },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

catppuccin nvim renamed get() to get_theme() for bufferline in this commit https://github.com/catppuccin/nvim/commit/30fa4d122d9b22ad8b2e0ab1b533c8c26c4dde86 this pr fixes the catppuccin init file to use this new function name

## Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
