### PR TITLE
feat(sql)!: Dont force ansi dialect

### DIFF
--- a/lua/astrocommunity/pack/sql/README.md
+++ b/lua/astrocommunity/pack/sql/README.md
@@ -7,4 +7,11 @@ This plugin pack does the following:
     - `go` must be in your `PATH` and executable.
     - formatting is disabled due to https://github.com/sqls-server/sqls/issues/149
 - Adds [sqls.nvim](https://github.com/nanotee/sqls.nvim) for language specific tooling
-- Adds `sqlfluff` for both formatting and linting (using the ANSI dialect)
+- Adds `sqlfluff` for both formatting and linting
+    - You must create a `.sqlfluff` file in the same folder as your sql files
+    - The `.sqlfluff` file must define the sql dialect to be used
+    - Example, more details can be found [here](https://docs.sqlfluff.com/en/stable/configuration/index.html):
+    ```ini
+    [sqlfluff]
+    dialect = postgres
+    ```

--- a/lua/astrocommunity/pack/sql/README.md
+++ b/lua/astrocommunity/pack/sql/README.md
@@ -7,11 +7,4 @@ This plugin pack does the following:
     - `go` must be in your `PATH` and executable.
     - formatting is disabled due to https://github.com/sqls-server/sqls/issues/149
 - Adds [sqls.nvim](https://github.com/nanotee/sqls.nvim) for language specific tooling
-- Adds `sqlfluff` for both formatting and linting
-    - You must create a `.sqlfluff` file in the same folder as your sql files
-    - The `.sqlfluff` file must define the sql dialect to be used
-    - Example, more details can be found [here](https://docs.sqlfluff.com/en/stable/configuration/index.html):
-    ```ini
-    [sqlfluff]
-    dialect = postgres
-    ```
+- Adds [sqlfluff](https://docs.sqlfluff.com) for both formatting and linting

--- a/lua/astrocommunity/pack/sql/init.lua
+++ b/lua/astrocommunity/pack/sql/init.lua
@@ -34,12 +34,8 @@ return {
 
       opts.handlers.sqlfluff = function()
         local null_ls = require "null-ls"
-        null_ls.register(null_ls.builtins.diagnostics.sqlfluff.with {
-          extra_args = { "--dialect", "ansi" },
-        })
-        null_ls.register(null_ls.builtins.formatting.sqlfluff.with {
-          extra_args = { "--dialect", "ansi" },
-        })
+        null_ls.register(null_ls.builtins.diagnostics.sqlfluff)
+        null_ls.register(null_ls.builtins.formatting.sqlfluff)
       end
     end,
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
The original configuration for `sqlfluff` add an extra `--dialect ansi` argument to the null_ls configuration, forcing the use of ANSI dialect. This is very annoying since it will override the dialect set in the configuration file `.sqlfluff` and leave little options for the user to use their desired dialect. With this change I remove that extra argument. However, this also means that the user must create a `.sqlfluff` file in the folder and specify the dialect there. I might adjust the README file to reflect this.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
- [x] Remove `--dialect ansi` extra argument from `init.lua`
- [x] Adjust the README

##  Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
