### PR TITLE
feat(keybinding): add  keybindings

### DIFF
--- a/lua/astrocommunity/keybinding/diff/README.md
+++ b/lua/astrocommunity/keybinding/diff/README.md
@@ -1,0 +1,3 @@
+# `diff` keybindings
+
+Adds keybindings for the `diff` command via the new `<Leader>D` submenu.

--- a/lua/astrocommunity/keybinding/diff/init.lua
+++ b/lua/astrocommunity/keybinding/diff/init.lua
@@ -1,0 +1,23 @@
+local menu = "<Leader>D"
+return {
+  {
+    "AstroNvim/astrocore",
+    ---@type AstroCoreOpts
+    opts = {
+      mappings = {
+        n = {
+          [menu] = { desc = "  Diff" },
+          [menu .. "v"] = { "<cmd>vert diffsplit<cr>", desc = "  Vertical split diff" },
+          [menu .. "h"] = { "<cmd>diffsplit<cr>", desc = "  Horizontal split diff" },
+          [menu .. "t"] = { "<cmd>diffthis<cr>", desc = "  Diff this" },
+          [menu .. "p"] = { "<cmd>diffpatch<cr>", desc = "  Patch diff" },
+          [menu .. "u"] = { "<cmd>diffupdate<cr>", desc = "󰚰  Update diff" },
+          [menu .. "g"] = { "<cmd>diffget<cr>", desc = "  Get diff" },
+          [menu .. "P"] = { "<cmd>diffput<cr>", desc = "  Put diff" },
+          [menu .. "q"] = { "<cmd>diffoff<cr>", desc = "󰘪  Stop diff" },
+          [menu .. "?"] = { "<cmd>h diff<cr>", desc = "󰋗  Help" },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## 📑 Description

Added keybindings for the `diff` command. This is now accessible via the `<Leader>D` submenu.

## ℹ Additional Information

<img width="1417" height="141" alt="image" src="https://github.com/user-attachments/assets/97f42923-0170-479b-b79d-e7d85192242b" />
