### PR TITLE
fix(grug-far-nvim): escape spaces and special symbols in filepath

### DIFF
--- a/lua/astrocommunity/search/grug-far-nvim/init.lua
+++ b/lua/astrocommunity/search/grug-far-nvim/init.lua
@@ -46,7 +46,7 @@ return {
         }
         maps.n[prefix .. "f"] = {
           function()
-            local filter = require("astrocore.buffer").is_valid() and vim.fn.expand "%" or nil
+            local filter = require("astrocore.buffer").is_valid() and vim.fn.fnameescape(vim.fn.expand "%") or nil
             grug_far_open { prefills = { paths = filter } }
           end,
           desc = "Search/Replace file",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
I noticed accidentally that when using `sf` the prefilled path had unescaped spaces, which grug-far didn't seem to support.

To reproduce the issue, try to use it in a path with spaces: e.g. `~/projects/My Demo/readme.md` which should be `~/projects/My\ Demo/readme.md` for grug-far to work.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
I think https://neovim.io/doc/user/builtin.html#fnameescape() is a way to escape the filepath. But not sure.
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
