### PR TITLE
fix(markdown-preview-nvim): Change build command to download prebuilt version of markdown-preview.

### DIFF
--- a/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
@@ -1,22 +1,7 @@
 ---@type LazySpec
 return {
   "iamcco/markdown-preview.nvim",
-  build = function(plugin)
-    local package_manager = vim.fn.executable "yarn" and "yarn" or vim.fn.executable "npx" and "npx -y yarn" or false
-
-    --- HACK: Use `yarn` or `npx` when possible, otherwise throw an error
-    ---@see https://github.com/iamcco/markdown-preview.nvim/issues/690
-    ---@see https://github.com/iamcco/markdown-preview.nvim/issues/695
-    if not package_manager then error "Missing `yarn` or `npx` in the PATH" end
-
-    local cmd = string.format(
-      "!cd %s && cd app && COREPACK_ENABLE_AUTO_PIN=0 %s install --frozen-lockfile",
-      plugin.dir,
-      package_manager
-    )
-
-    vim.cmd(cmd)
-  end,
+  build = ":call mkdp#util#install()",
   ft = { "markdown", "markdown.mdx" },
   cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
   init = function()

--- a/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
+++ b/lua/astrocommunity/markdown-and-latex/markdown-preview-nvim/init.lua
@@ -1,7 +1,7 @@
 ---@type LazySpec
 return {
   "iamcco/markdown-preview.nvim",
-  build = ":call mkdp#util#install()",
+  build = function() vim.fn["mkdp#util#install"]() end,
   ft = { "markdown", "markdown.mdx" },
   cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
   init = function()


### PR DESCRIPTION
Use this new build command to build markdown-preview. Fix tslib module not found when npm is installed by [asdf](https://asdf-vm.com/).


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

Link to the author: https://github.com/iamcco/markdown-preview.nvim/issues/690#issuecomment-2782326124
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
