### PR TITLE
fix(vim-visual-multi): overlap keys with blink and horizontal split key, map paste keys to system clipboard.

### DIFF
--- a/lua/astrocommunity/editing-support/vim-visual-multi/init.lua
+++ b/lua/astrocommunity/editing-support/vim-visual-multi/init.lua
@@ -1,32 +1,72 @@
+---@type LazySpec
 return {
   "mg979/vim-visual-multi",
   event = { "User AstroFile", "InsertEnter" },
   dependencies = {
-    "AstroNvim/astrocore",
-    ---@param opts astrocoreopts
-    opts = function(_, opts)
-      if not opts.options then opts.options = {} end
-      if not opts.options.g then opts.options.g = {} end
-      opts.options.g.VM_silent_exit = 1
-      opts.options.g.VM_show_warnings = 0
+    { "AstroNvim/astroui", opts = { icons = { VimVisualMulti = "󰗧" } } },
+    {
+      "AstroNvim/astrocore",
+      ---@param opts AstroCoreOpts
+      opts = function(_, opts)
+        if not opts.options then opts.options = {} end
+        if not opts.options.g then opts.options.g = {} end
+        -- Prevent overlapping with astrocore horizontal split key
+        opts.options.g.VM_leader = opts.options.g.VM_leader or "<leader>m"
+        opts.options.g.VM_silent_exit = 1
+        opts.options.g.VM_show_warnings = 0
 
-      if not opts.autocmds then opts.autocmds = {} end
-      opts.autocmds.visual_multi_exit = {
-        {
-          event = "User",
-          pattern = "visual_multi_exit",
-          desc = "Avoid spurious 'hit-enter-prompt' when exiting vim-visual-multi",
-          callback = function()
-            vim.o.cmdheight = 1
-            vim.schedule(function() vim.o.cmdheight = opts.options.opt.cmdheight end)
-          end,
-        },
-      }
+        if not opts.autocmds then opts.autocmds = {} end
+        opts.autocmds.visual_multi_mappings = {
+          {
+            event = "User",
+            pattern = "visual_multi_mappings",
+            desc = "p and P to paste from system clipboard",
+            callback = function()
+              -- Remap p and P to paste (from + or * register) because `opt.clipboard = "unnamedplus"` in astrocore
+              -- Source: https://github.com/mg979/vim-visual-multi/issues/116
+              if vim.tbl_contains(vim.opt.clipboard:get(), "unnamedplus") then
+                vim.keymap.set("n", "p", '"+<Plug>(VM-p-Paste)', { buffer = true })
+                vim.keymap.set("n", "P", '"+<Plug>(VM-P-Paste)', { buffer = true })
+              elseif vim.tbl_contains(vim.opt.clipboard:get(), "unnamed") then
+                vim.keymap.set("n", "p", '"*<Plug>(VM-p-Paste)', { buffer = true })
+                vim.keymap.set("n", "P", '"*<Plug>(VM-P-Paste)', { buffer = true })
+              end
+            end,
+          },
+        }
 
-      if not opts.mappings then opts.mappings = require("astrocore").empty_map_table() end
-      local maps = assert(opts.mappings)
-      maps.n["<C-up>"] = { "<C-u>call vm#commands#add_cursor_up(0, v:count1)<cr>", desc = "Add cursor above" }
-      maps.n["<C-down>"] = { "<C-u>call vm#commands#add_cursor_down(0, v:count1)<cr>", desc = "Add cursor below" }
-    end,
+        -- Remap <cr> to fix enter to select in blink
+        -- Source: https://github.com/Saghen/blink.cmp/issues/406#issuecomment-2537184121
+        -- Check this if you use VM_custom_motions: https://github.com/Saghen/blink.cmp/issues/406#issuecomment-3239199356
+        opts.options.g.VM_maps = {
+          ["I BS"] = "",
+          ["Goto Next"] = "]v",
+          ["Goto Prev"] = "[v",
+          ["I CtrlB"] = "<M-b>",
+          ["I CtrlF"] = "<M-f>",
+          ["I Return"] = "<S-CR>",
+          ["I Down Arrow"] = "",
+          ["I Up Arrow"] = "",
+        }
+
+        if not opts.mappings then opts.mappings = require("astrocore").empty_map_table() end
+        local maps = assert(opts.mappings)
+        local leader = opts.options.g.VM_leader
+        maps.n[leader] = { desc = require("astroui").get_icon("VimVisualMulti", 1, true) .. "Multi cursors" }
+        maps.n[leader .. "A"] = { desc = "Select all occurrences word under cursor" }
+        maps.n[leader .. "/"] = { desc = "Start regex search" }
+        maps.n[leader .. "\\"] = { desc = "Add a single cursor at current position" }
+        maps.n[leader .. "gS"] = { desc = "Reselect last visual selection" }
+        maps.n["<C-up>"] = { "<C-u>call vm#commands#add_cursor_up(0, v:count1)<cr>", desc = "Add cursor above" }
+        maps.n["<C-down>"] = { "<C-u>call vm#commands#add_cursor_down(0, v:count1)<cr>", desc = "Add cursor below" }
+
+        maps.v[leader] = { desc = require("astroui").get_icon("VimVisualMulti", 1, true) .. "Multi cursors" }
+        maps.v[leader .. "a"] = { desc = "Convert a visual selection to a VM selection" }
+        maps.v[leader .. "a"] = { desc = "Convert a visual selection to a VM selection" }
+        maps.v[leader .. "A"] = { desc = "Select all occurrences of selection text" }
+        maps.v[leader .. "c"] = { desc = "Add cursors downwards from start of visual block" }
+        maps.v[leader .. "/"] = { desc = "Start regex search within selected text" }
+      end,
+    },
   },
 }


### PR DESCRIPTION
## 📑 Description

- [x] Remap \<cr\> to fix enter to accept in blink. https://github.com/Saghen/blink.cmp/issues/406#issuecomment-2537184121
- [x] Remap VM_leader to `<Leader>m` to prevent overlapping with [AstroCore horizontal split key](https://github.com/AstroNvim/AstroNvim/blob/8379e70578bb2f4b2227d55ccc1ae4fd2ab8bb51/lua/astronvim/plugins/_astrocore_mappings.lua#L40). Prefer the value from `opts.options.g.VM_leader` or `vim.g.VM_leader` if set.
- [x] Remap p and P to paste (from `+` or `*` register) because `opt.clipboard = "unnamedplus"` in [AstroCore](https://github.com/AstroNvim/AstroNvim/blob/8379e70578bb2f4b2227d55ccc1ae4fd2ab8bb51/lua/astronvim/plugins/_astrocore_options.lua#L14) 
- [x] Added some common descriptions for key maps in normal and visual modes.

## 📖 Additional Information
By default, vim-visual-multi use `\` as VM_leader, which overlaps with AstroCore horizontal split key.
Also removed `visual_multi_exit` autocmd, since it cause the whole UI to jump up and down 1 line, every time exit `vim-visual-multi`. And I don't see any `hit-enter-prompt`  prompt when exiting vim-visual-multi at all. Maybe it's removed?
Ref:
https://github.com/mg979/vim-visual-multi/issues/116
https://github.com/Saghen/blink.cmp/issues/406#issuecomment-2537184121
