### PR TITLE
fix(copilot-lua-cmp): rebind dismiss keybinding to avoid keymap conflict

### DIFF
--- a/lua/astrocommunity/completion/copilot-lua-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-lua-cmp/init.lua
@@ -47,7 +47,7 @@ return {
         opts.mapping["<C-L>"] = cmp.mapping(copilot_action "accept_word")
         opts.mapping["<C-Down>"] = cmp.mapping(copilot_action "accept_line")
         opts.mapping["<C-J>"] = cmp.mapping(copilot_action "accept_line")
-        opts.mapping["<C-C>"] = cmp.mapping(copilot_action "dismiss")
+        opts.mapping["<C-E>"] = cmp.mapping(copilot_action "dismiss")
       end,
     },
     {
@@ -71,7 +71,7 @@ return {
         opts.keymap["<C-L>"] = { copilot_action "accept_word" }
         opts.keymap["<C-Down>"] = { copilot_action "accept_line" }
         opts.keymap["<C-J>"] = { copilot_action "accept_line", "select_next", "fallback" }
-        opts.keymap["<C-C>"] = { copilot_action "dismiss" }
+        opts.keymap["<C-E>"] = { copilot_action "dismiss" }
       end,
     },
   },

--- a/lua/astrocommunity/completion/copilot-lua-cmp/init.lua
+++ b/lua/astrocommunity/completion/copilot-lua-cmp/init.lua
@@ -47,7 +47,7 @@ return {
         opts.mapping["<C-L>"] = cmp.mapping(copilot_action "accept_word")
         opts.mapping["<C-Down>"] = cmp.mapping(copilot_action "accept_line")
         opts.mapping["<C-J>"] = cmp.mapping(copilot_action "accept_line")
-        opts.mapping["<C-E>"] = cmp.mapping(copilot_action "dismiss")
+        opts.mapping["<C-e>"] = cmp.mapping(copilot_action "dismiss")
       end,
     },
     {
@@ -71,7 +71,7 @@ return {
         opts.keymap["<C-L>"] = { copilot_action "accept_word" }
         opts.keymap["<C-Down>"] = { copilot_action "accept_line" }
         opts.keymap["<C-J>"] = { copilot_action "accept_line", "select_next", "fallback" }
-        opts.keymap["<C-E>"] = { copilot_action "dismiss" }
+        opts.keymap["<C-e>"] = { copilot_action "dismiss" }
       end,
     },
   },


### PR DESCRIPTION
Rebinds the dismiss keybinding to be <C-e> which is a common convention in vim/nvim to close a popup menu

Closes #1564 
