### PR TITLE
feat(nix): add nixfmt formatter to null-ls sources

### DIFF
--- a/lua/astrocommunity/pack/nix/init.lua
+++ b/lua/astrocommunity/pack/nix/init.lua
@@ -14,6 +14,7 @@ return {
     opts = function(_, opts)
       local builtins = require("null-ls").builtins
       opts.sources = require("astrocore").list_insert_unique(opts.sources, {
+        builtins.formatting.nixfmt,
         builtins.code_actions.statix,
         builtins.diagnostics.deadnix,
       })


### PR DESCRIPTION
Include nixfmt in the list of sources for null-ls. This enables automatic formatting of Nix files within the Neovim environment.