### PR TITLE
feat(neotest): add rounded border

### DIFF
--- a/lua/astrocommunity/test/neotest/init.lua
+++ b/lua/astrocommunity/test/neotest/init.lua
@@ -5,6 +5,7 @@ return {
   dependencies = {
     "nvim-lua/plenary.nvim",
     "nvim-neotest/nvim-nio",
+    "antoinemadec/FixCursorHold.nvim",
     {
       "AstroNvim/astroui",
       opts = {
@@ -104,15 +105,8 @@ return {
       end,
     },
   },
-  specs = {
-    {
-      "catppuccin",
-      optional = true,
-      ---@type CatppuccinOptions
-      opts = { integrations = { neotest = true } },
-    },
-  },
   opts = function(_, opts)
+    opts.floating = { border = "rounded" }
     if vim.g.icons_enabled == false then
       opts.icons = {
         failed = "X",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
I noticed that due to missing rounded property the border style of astronvim wasn't being applied.

| before | after |
| --- | --- |
| <img width="1920" height="1148" alt="Screenshot_20250921_104233" src="https://github.com/user-attachments/assets/7fa133e8-ea09-43ea-8e8e-9402df088744" /> | <img width="1920" height="1148" alt="Screenshot_20250921_104305" src="https://github.com/user-attachments/assets/492c4e1e-658d-4a6e-a2d0-fa52f9a9775a" /> |

Also, as part of PR:
- Cleaned up catppuccin since it's not needed to be configured manually anymore
- Added FixCursorHold, even though it's part of neovim now, it's still recommended by plugin author https://github.com/nvim-neotest/neotest/discussions/129#discussioncomment-3867221


<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## 📖 Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
