### PR TITLE
refactor(ansible): clean up ansible filetype detection

### DIFF
--- a/lua/astrocommunity/pack/ansible/init.lua
+++ b/lua/astrocommunity/pack/ansible/init.lua
@@ -1,30 +1,20 @@
-local function yaml_ft(path, bufnr)
-  -- get content of buffer as string
-  local content = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  if type(content) == "table" then content = table.concat(content, "\n") end
-
-  -- check if file is in roles, tasks, or handlers folder
-  local path_regex = vim.regex "(ansible\\|group_vars\\|handlers\\|host_vars\\|playbooks\\|roles\\|vars\\|tasks)/"
-  if path_regex and path_regex:match_str(path) then return "yaml.ansible" end
-
-  -- check for known ansible playbook text and if found, return yaml.ansible
-  local regex = vim.regex "^(hosts\\|tasks):"
-  if regex and regex:match_str(content) then return "yaml.ansible" end
-
-  -- return yaml if nothing else
-  return "yaml"
-end
-
 return {
   {
     "AstroNvim/astrocore",
     opts = function(_, opts)
-      local utils = require "astrocommunity"
       return require("astrocore").extend_tbl(opts, {
         filetypes = {
-          extension = {
-            yml = utils.merge_filetype("yaml", vim.tbl_get(opts, "filetypes", "extension", "yml"), yaml_ft),
-            yaml = utils.merge_filetype("yaml", vim.tbl_get(opts, "filetypes", "extension", "yaml"), yaml_ft),
+          pattern = {
+            [".*/defaults/.*%.ya?ml"] = "yaml.ansible",
+            [".*/host_vars/.*%.ya?ml"] = "yaml.ansible",
+            [".*/group_vars/.*%.ya?ml"] = "yaml.ansible",
+            [".*/group_vars/.*/.*%.ya?ml"] = "yaml.ansible",
+            [".*/playbook.*%.ya?ml"] = "yaml.ansible",
+            [".*/playbooks/.*%.ya?ml"] = "yaml.ansible",
+            [".*/roles/.*/tasks/.*%.ya?ml"] = "yaml.ansible",
+            [".*/roles/.*/handlers/.*%.ya?ml"] = "yaml.ansible",
+            [".*/tasks/.*%.ya?ml"] = "yaml.ansible",
+            [".*/molecule/.*%.ya?ml"] = "yaml.ansible",
           },
         },
       })


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This just cleans up the ansible filetype detection I had written before to something a bit more manageable with less false positives.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## 📖 Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
