### PR TITLE
refactor(treesj): change the keymapping to prevent conflicts

### DIFF
--- a/lua/astrocommunity/editing-support/treesj/init.lua
+++ b/lua/astrocommunity/editing-support/treesj/init.lua
@@ -7,7 +7,7 @@ return {
       opts = {
         mappings = {
           n = {
-            ["<Leader>m"] = { "<Cmd>TSJToggle<CR>", desc = "Toggle Treesitter Join" },
+            ["gS"] = { "<Cmd>TSJToggle<CR>", desc = "Toggle Treesitter Join" },
           },
         },
       },


### PR DESCRIPTION
### Description

This PR updates the keybinding for the **`treesj.nvim`** plugin in the AstroNvim community repository.  
Previously, `treesj` was bound to `<leader>m`, which conflicted with several other community plugins such as:

- `molten-nvim`
- `harp-nvim`
- `multicursors-nvim`
- `global-note-nvim`
- `multiple-cursors-nvim`

Since `treesj.nvim` and `mini.splitjoin` provide equivalent functionality (code block splitting and joining), this PR aligns `treesj`’s keybinding with `mini.splitjoin`, changing it from `<leader>m` to `gS`.

This ensures **consistent behavior** and **resolves keymapping conflicts** across the community repo.

---

### Breaking Changes ⚠️

- **`treesj-nvim`:** Default keybinding has changed from `<leader>m` → `gS`  
  Users who previously used `<leader>m` for `treesj` will need to update their workflow or define a custom binding in their personal config.

---

### Summary

This change:
- Fixes overlapping `<leader>m` mappings.
- Aligns keybindings for tools offering identical functionality.
- Improves overall user experience and uniformity within the community ecosystem.
