### PR TITLE
feat(fyler-nvim): update fyler.nvim config to replace neotree.nvim

### DIFF
--- a/lua/astrocommunity/file-explorer/fyler-nvim/init.lua
+++ b/lua/astrocommunity/file-explorer/fyler-nvim/init.lua
@@ -1,9 +1,5 @@
 return {
-  {
-    "nvim-neo-tree/neo-tree.nvim",
-    enabled = false,
-  },
-
+  { "nvim-neo-tree/neo-tree.nvim", optional = true, enabled = false },
   {
     "A7Lavinraj/fyler.nvim",
     dependencies = {


### PR DESCRIPTION
## 📑 Description

This PR replaces `neo-tree` with `fyler.nvim` as the default file explorer and enhances its usability.

Key changes:

* Disabled `neo-tree` to prevent conflicts.
* Set `fyler` as the default explorer (`default_explorer = true`).
* Open in a floating window with `<Leader>e`.

These updates make `fyler.nvim` fully integrate as the main file explorer with improved UX.

## 📖 Additional Information

* Fully integrated with `astrocore` mappings.
* Floating mode avoids blocking the main buffer.
* Visual and interaction enhancements for smoother navigation.

### Note: Breaking Change

The keybinding used is different but is in line with other plugins such as the `mini-files` plugin and the default `neo-tree` moreover the default mode is floating.

My config:
<img width="1482" height="919" alt="image" src="https://github.com/user-attachments/assets/917c9ec8-019e-4667-b3df-0e3bae9f8965" />

Though something like this could be used instead:
<img width="1482" height="919" alt="image" src="https://github.com/user-attachments/assets/a9e9bb80-f7fe-45ed-8c51-4fe29fc82763" />
