### PR TITLE
fix(neominimap-nvim): updated deprecated `toggle` command to `Toggle`

### DIFF
--- a/lua/astrocommunity/split-and-window/neominimap-nvim/init.lua
+++ b/lua/astrocommunity/split-and-window/neominimap-nvim/init.lua
@@ -11,7 +11,7 @@ return {
         } },
         mappings = {
           n = {
-            ["<Leader>um"] = { "<Cmd>Neominimap toggle<CR>", desc = "Toggle minimap" },
+            ["<Leader>um"] = { "<Cmd>Neominimap Toggle<CR>", desc = "Toggle minimap" },
           },
         },
       },


### PR DESCRIPTION
Updated deprecated 'toggle' command to 'Toggle'

## 📑 Description

Updated deprecated `toggle` command to `Toggle` as directed by Neominimap V4

## 📖 Additional Information
Warning shown upon first toggle of Neominimap after starting AstroNvim:

<img width="784" height="251" alt="image" src="https://github.com/user-attachments/assets/e2cad6b6-01a9-4856-9ff2-f1d8324720f2" />
