### PR TITLE
fix(auto-save-nvim): improve compatibility with `fyler.nvim`

### DIFF
--- a/lua/astrocommunity/editing-support/auto-save-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/auto-save-nvim/init.lua
@@ -46,5 +46,13 @@ return {
       },
     },
   },
-  opts = {},
+  opts = {
+    condition = function(buf)
+      if vim.tbl_contains({
+        "Fyler",
+      }, vim.fn.getbufvar(buf, "&filetype")) then return false end
+
+      return true
+    end,
+  },
 }


### PR DESCRIPTION
## 📑 Description

With auto-save.nvim enabled trying to use fyler.nvim feels awful, if you try and move a file and then go to `n` mode to fix indentation it'll try saving the buffer normally causing issues with the file getting moved to the wrong place

## 📖 Additional Information
This is taken from their example and just trimmed now to what is probably more relevant https://github.com/okuuva/auto-save.nvim#condition
