### PR TITLE
fix(opencode-nvim): missing terminal provider

### DIFF
--- a/lua/astrocommunity/ai/opencode-nvim/init.lua
+++ b/lua/astrocommunity/ai/opencode-nvim/init.lua
@@ -1,7 +1,10 @@
 return {
   "NickvanDyke/opencode.nvim",
   dependencies = {
-    { "folke/snacks.nvim", opts = { input = { enabled = true } } },
+    {
+      "folke/snacks.nvim",
+      opts = { input = { enabled = true }, picker = { enabled = true }, terminal = { enabled = true } },
+    },
   },
   specs = {
     {


### PR DESCRIPTION
## 📑 Description

Currently getting this error, looks like we're missing some stuff from the default setup provided here https://github.com/NickvanDyke/opencode.nvim
```
No `provider.toggle` available — configure `vim.g.opencode_opts.provider`, or install `snacks.nvim` to use the default provider
```