### PR TITLE
fix(php): autocomplete not working with blink + nvim-ts-autotag 

### DIFF
--- a/lua/astrocommunity/pack/php/init.lua
+++ b/lua/astrocommunity/pack/php/init.lua
@@ -48,4 +48,22 @@ return {
       },
     },
   },
+  {
+    "Saghen/blink.cmp",
+    optional = true,
+    opts = {},
+    dependencies = {
+      {
+        -- We disable autotag closing in php files since it breaks blink.cmp
+        ---@see https://github.com/saghen/blink.cmp/issues/2234#issuecomment-3461410965
+        "windwp/nvim-ts-autotag",
+        optional = true,
+        opts = {
+          per_filetype = {
+            ["php"] = { enable_close = false },
+          },
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
Closes #1653 

## 📑 Description
Disable nvim-ts-autotag for PHP files when using blink.cmp.

This currently prevent auto complete in any PHP file more info here: https://github.com/saghen/blink.cmp/issues/2234#issuecomment-3461410965
