### PR TITLE
feat(jj): Use float direction with lazyjj and jjui terminals

### DIFF
--- a/lua/astrocommunity/pack/jj/init.lua
+++ b/lua/astrocommunity/pack/jj/init.lua
@@ -85,7 +85,7 @@ return {
             local astro = require "astrocore"
             local worktree = astro.file_worktree()
             local flags = worktree and ("--path '%s'"):format(worktree.toplevel, worktree.gitdir) or ""
-            astro.toggle_term_cmd("lazyjj " .. flags)
+            astro.toggle_term_cmd { cmd = "lazyjj " .. flags, direction = "float" }
           end,
           desc = "lazyjj",
         }
@@ -95,7 +95,7 @@ return {
         maps.n["<Leader>ju"] = {
           function()
             local astro = require "astrocore"
-            astro.toggle_term_cmd "jjui"
+            astro.toggle_term_cmd { cmd = "jjui", direction = "float" }
           end,
           desc = "jjui",
         }


### PR DESCRIPTION
## 📑 Description

This lets these tools use a float window instead of a small split at the bottom of the screen, and is how `lazygit` is currently used in AstroNvim:

https://github.com/AstroNvim/AstroNvim/blob/0001b5adbd6b6b9c14166f5c5955c43fde5624de/lua/astronvim/plugins/toggleterm.lua#L18

## 📖 Additional Information

Before:
<img width="1095" height="811" alt="Screenshot 2025-10-30 at 9 55 56 AM" src="https://github.com/user-attachments/assets/18622ac7-108f-4afa-a992-224fe55e8696" />

After:

<img width="1095" height="811" alt="Screenshot 2025-10-30 at 9 55 14 AM" src="https://github.com/user-attachments/assets/182668e6-372a-4edb-bcb7-8ef8a220d4ae" />

