### PR TITLE
Update mini.surround repo URL

### DIFF
--- a/lua/astrocommunity/motion/mini-surround/README.md
+++ b/lua/astrocommunity/motion/mini-surround/README.md
@@ -2,6 +2,20 @@
 
 Neovim Lua plugin with fast and feature-rich surround actions. Part of 'mini.nvim' library.
 
-**Repository:** <https://github.com/echasnovski/mini.surround>
+**Repository:** <https://github.com/nvim-mini/mini.surround>
 
-Fast and feature-rich surround actions
+Fast and feature-rich surround actions.
+
+## Default mappings
+
+The default prefix for mini.surround actions is set to `gz`.
+
+|Mapping| Action                                     |
+|-------|--------------------------------------------|
+|`gza`  | Add surrounding in Normal and Visual modes |
+|`gzd`  | Delete surrounding                         |
+|`gzf`  | Find surrounding (to the right)            |
+|`gzF`  | Find surrounding (to the left)             |
+|`gzh`  | Highlight surrounding                      |
+|`gzr`  | Replace surrounding                        |
+|`gzn`  | Update `n_lines`                           |

--- a/lua/astrocommunity/motion/mini-surround/init.lua
+++ b/lua/astrocommunity/motion/mini-surround/init.lua
@@ -1,6 +1,6 @@
 local prefix = "gz"
 return {
-  "echasnovski/mini.surround",
+  "nvim-mini/mini.surround",
   dependencies = {
     { "AstroNvim/astroui", opts = { icons = { Surround = "󰑤" } } },
     {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The repository for mini.surround has been moved from https://github.com/echasnovski/mini.surround to https://github.com/nvim-mini/mini.surround. This PR updates the URL and plugin name in the Readme and init.lua.

I also added a list of the default bindings which are set in the init.lua, as they differ from the default bindings of mini.surround (gz instead of s as prefix).
