### PR TITLE
fix(fyler-nvim): Refactor options for file explorer configuration

### DIFF
--- a/lua/astrocommunity/file-explorer/fyler-nvim/init.lua
+++ b/lua/astrocommunity/file-explorer/fyler-nvim/init.lua
@@ -17,14 +17,17 @@ return {
     },
 
     opts = {
-      default_explorer = true,
-
-      win = {
-        border = "rounded",
-        kind = "replace",
-      },
-      indentscope = {
-        marker = "┊",
+      views = {
+        finder = {
+          default_explorer = true,
+          indentscope = {
+            marker = "┊",
+          },
+          win = {
+            border = "rounded",
+            kind = "replace",
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
## 📑 Description

upstream fyler changed their options. It gave a warning message about deprecating the options used in the astrocommunity fork. this pr changes the options to match the structure of fyler.nvim

## 📖 Additional Information

message

```
Fyler: Deprecated configuration options detected
============================================================

Deprecated configuration detected: 'default_explorer'
  Configuration structure reorganized under 'views.finder'
  Use 'views.finder.default_explorer' instead
  Update your config: views.finder.default_explorer = true

Deprecated configuration detected: 'indentscope'
  Configuration structure reorganized under 'views.finder'
  Use 'views.finder.indentscope' instead
  Update your config: views.finder.indentscope = {
  marker = "┊"
}

Deprecated configuration detected: 'win'
  Configuration structure reorganized under 'views.finder'
  Use 'views.finder.win' instead
  Update your config: views.finder.win = {
  border = "rounded",
  kind = "replace"
}

============================================================
Please update your configuration to avoid future issues.
See :h Fyler.Config for current options.
```
