### PR TITLE
feat(utility): added support for nvzone-menu plugin

### DIFF
--- a/lua/astrocommunity/utility/nvzone-menu/README.md
+++ b/lua/astrocommunity/utility/nvzone-menu/README.md
@@ -1,42 +1,16 @@
-﻿  
+# nvzone-menu
 
-# nvzone-menu.nvim
+Menu plugin for neovim (supports nested menus) made using volt
 
-  
+**Repository:** [nvzone/nvzone-menu.nvim](https://github.com/nvzone/menu)
 
-This package adds [nvzone/menu](https://github.com/nvzone/menu) support to AstroNvim.
+## Features
 
-  
+- Context menu on Right-Click in normal mode
+- Integration with `neo-tree.nvim` for file operations
+- Color picker via [minty](https://github.com/nvzone/minty)
+- Format, Code Actions, and LSP commands
 
-It includes:
+## Requirements
 
-- A context menu bound to Right-Click
-- An in-built color picker ([mintly](https://github.com/nvzone/minty))
-
-- Integration with `neo-tree.nvim` for file operations directly from the menu.
-
-- General utility commands like Format, Code Actions, and Terminal integration.
-
-  
-
-## Keybindings
-
-  
-
-It displays the **default keybindings** of the AstroNvim Starter config.
-
- 
-It can be changed by cloning the `init.lua` file and changing the `rtxt` attribute.
-
-
-## Screenshot and Videos:
-![enter image description here](https://files.catbox.moe/ajxgxb.png)
-![enter image description here](https://files.catbox.moe/o6jztq.png)
-
-
-
-
-## Notes
-
-- Ensure you have a Nerd Font installed for the icons to render correctly.
-
+- A Nerd Font for icons

--- a/lua/astrocommunity/utility/nvzone-menu/init.lua
+++ b/lua/astrocommunity/utility/nvzone-menu/init.lua
@@ -1,178 +1,109 @@
--- 1. Helper function to generate the Neo-tree menu on demand
-local function get_neotree_menu()
-  -- These requires load code from the installed neo-tree plugin
-
-  local manager = require "neo-tree.sources.manager"
-  local cc = require "neo-tree.sources.common.commands"
-
-  -- Get neo-tree state.
-  local function get_state()
-    local state = manager.get_state_for_window()
-    assert(state)
-    state.config = state.config or {}
-    return state
-  end
-
-  -- Call arbitrary neo-tree action.
-  local function call(what)
-    return vim.schedule_wrap(function()
-      local state = get_state()
-      local cb = require("neo-tree.sources." .. state.name .. ".commands")[what] or cc[what]
-      cb(state)
-    end)
-  end
-
-  -- Copy path to clipboard.
-  local function copy_path(how)
-    return function()
-      local node = get_state().tree:get_node()
-      if node.type == "message" then return end
-      vim.fn.setreg('"', vim.fn.fnamemodify(node.path, how))
-      vim.fn.setreg("+", vim.fn.fnamemodify(node.path, how))
-    end
-  end
-
-  return {
-    -- NAVIGATION
-    { name = "  Open in window", cmd = call "open", rtxt = "o" },
-    { name = "  Open in vertical split", cmd = call "open_vsplit", rtxt = "v" },
-    { name = "  Open in horizontal split", cmd = call "open_split", rtxt = "s" },
-    { name = "󰓪  Open in new tab", cmd = call "open_tabnew", rtxt = "O" },
-    { name = "separator" },
-    -- FILE ACTIONS
-    { name = "  New file", cmd = call "add", rtxt = "a" },
-    { name = "  New folder", cmd = call "add_directory", rtxt = "A" },
-    { name = "  Delete", hl = "ExRed", cmd = call "delete", rtxt = "d" },
-    { name = "   File details", cmd = call "show_file_details", rtxt = "i" },
-    { name = "  Rename", cmd = call "rename", rtxt = "r" },
-    { name = "  Rename basename", cmd = call "rename", rtxt = "b" },
-    { name = "  Copy", cmd = call "copy_to_clipboard", rtxt = "y" },
-    { name = "  Cut", cmd = call "cut_to_clipboard", rtxt = "x" },
-    { name = "  Paste", cmd = call "paste_from_clipboard", rtxt = "p" },
-    { name = "separator" },
-    -- VIEW CHANGES
-    { name = "Toggle hidden", cmd = call "toggle_hidden", rtxt = "H" },
-    { name = "Refresh", cmd = call "refresh", rtxt = "R" },
-    
-    -- FILTER
-    { name = "Fuzzy finder", cmd = call "fuzzy_finder", rtxt = "/" },
-    { name = "Fuzzy finder directory", cmd = call "fuzzy_finder_directory", rtxt = "D" },
-    { name = "Fuzzy sorter", cmd = call "fuzzy_sorter", rtxt = "#" },
-    { name = "separator" },
-    -- others
-    { name = "󰴠  Copy absolute path", cmd = copy_path ":p", rtxt = "gy" },
-    { name = "  Copy relative path", cmd = copy_path ":~:.", rtxt = "Y" },
-    
-    { name = "separator" },
-    { name = "󰋗 More Commands", cmd = call "show_help", rtxt = "?" },
-  }
-end
-
--- 2. Define the Main Menu options (General usage)
-local my_main_menu = {
-  {
-    name = "Format Buffer",
-    cmd = function()
-      local ok, conform = pcall(require, "conform")
-      if ok then
-        conform.format { lsp_fallback = true }
-      else
-        vim.lsp.buf.format()
-      end
-    end,
-    rtxt = "<leader>lf",
-  },
-  {
-    name = "Code Actions",
-    cmd = vim.lsp.buf.code_action,
-    rtxt = "<leader>la",
-  },
-  { name = "separator" },
-  {
-    name = "  Lsp Actions",
-    hl = "Exblue",
-    items = "lsp",
-  },
-  { name = "separator" },
-  {
-    name = "Edit Config",
-    cmd = function()
-      vim.cmd "tabnew"
-      local conf = vim.fn.stdpath "config"
-      vim.cmd("tcd " .. conf .. " | e lua/lazy_setup.lua")
-    end,
-    rtxt = "ed",
-  },
-  {
-    name = "Copy Content",
-    cmd = "%y+",
-    rtxt = "<C-c>",
-  },
-  {
-    name = "Delete Content",
-    cmd = "%d",
-    rtxt = "dc",
-  },
-  { name = "separator" },
-  {
-    name = "  Open in terminal",
-    hl = "ExRed",
-    cmd = function()
-      local old_buf = require("menu.state").old_data.buf
-      local old_bufname = vim.api.nvim_buf_get_name(old_buf)
-      local old_buf_dir = vim.fn.fnamemodify(old_bufname, ":h")
-      local cmd = "cd " .. old_buf_dir
-
-     
-      vim.cmd "enew"
-      vim.fn.termopen { vim.o.shell, "-c", cmd .. " ; " .. vim.o.shell }
-    end,
-  },
-  { name = "separator" },
-  {
-    name = "  Color Picker",
-    cmd = function() require("minty.huefy").open() end,
-  },
-}
-
--- 3. Plugin Specification
 return {
-  -- Import dependencies via lazy
   { "nvzone/volt", lazy = true },
-
   {
     "nvzone/minty",
     cmd = { "Shades", "Huefy" },
   },
-
-  { "nvim-neo-tree/neo-tree.nvim", lazy = true },
-
-  -- Menu Configuration
   {
     "nvzone/menu",
     lazy = true,
     keys = {
       {
-        "<C-t>",
-        function() require("menu").open(my_main_menu) end,
-        desc = "Open UI Menu",
-      },
-      {
         "<RightMouse>",
         function()
           vim.cmd.exec '"normal! \\<RightMouse>"'
-          local ft = vim.bo.ft
 
-          if ft == "neo-tree" then
-            -- Generate the menu using the functions defined above
-            local neo_tree_menu = get_neotree_menu()
-            require("menu").open(neo_tree_menu, { mouse = true, border = true })
-          else
-            require("menu").open(my_main_menu, { mouse = true, border = true })
+          local function get_neotree_menu()
+            local ok_manager, manager = pcall(require, "neo-tree.sources.manager")
+            local ok_cc, cc = pcall(require, "neo-tree.sources.common.commands")
+            if not ok_manager or not ok_cc then return nil end
+
+            local state = manager.get_state_for_window()
+            if not state then return nil end
+            state.config = state.config or {}
+
+            local function call(what)
+              return vim.schedule_wrap(function()
+                local s = manager.get_state_for_window()
+                if not s then return end
+                s.config = s.config or {}
+                local cb = require("neo-tree.sources." .. s.name .. ".commands")[what] or cc[what]
+                if cb then cb(s) end
+              end)
+            end
+
+            local function copy_path(how)
+              return function()
+                local node = state.tree:get_node()
+                if not node or node.type == "message" then return end
+                vim.fn.setreg('"', vim.fn.fnamemodify(node.path, how))
+                vim.fn.setreg("+", vim.fn.fnamemodify(node.path, how))
+              end
+            end
+
+            return {
+              { name = "  Open", cmd = call "open", rtxt = "o" },
+              { name = "  Vertical split", cmd = call "open_vsplit", rtxt = "v" },
+              { name = "  Horizontal split", cmd = call "open_split", rtxt = "s" },
+              { name = "󰓪  New tab", cmd = call "open_tabnew", rtxt = "O" },
+              { name = "separator" },
+              { name = "  New file", cmd = call "add", rtxt = "a" },
+              { name = "  New folder", cmd = call "add_directory", rtxt = "A" },
+              { name = "  Delete", hl = "ExRed", cmd = call "delete", rtxt = "d" },
+              { name = "   Details", cmd = call "show_file_details", rtxt = "i" },
+              { name = "  Rename", cmd = call "rename", rtxt = "r" },
+              { name = "  Copy", cmd = call "copy_to_clipboard", rtxt = "y" },
+              { name = "  Cut", cmd = call "cut_to_clipboard", rtxt = "x" },
+              { name = "  Paste", cmd = call "paste_from_clipboard", rtxt = "p" },
+              { name = "separator" },
+              { name = "Toggle hidden", cmd = call "toggle_hidden", rtxt = "H" },
+              { name = "Refresh", cmd = call "refresh", rtxt = "R" },
+              { name = "Fuzzy finder", cmd = call "fuzzy_finder", rtxt = "/" },
+              { name = "separator" },
+              { name = "󰴠  Copy absolute path", cmd = copy_path ":p", rtxt = "gy" },
+              { name = "  Copy relative path", cmd = copy_path ":~:.", rtxt = "Y" },
+              { name = "separator" },
+              { name = "󰋗  Help", cmd = call "show_help", rtxt = "?" },
+            }
           end
+
+          local function get_main_menu()
+            return {
+              {
+                name = "Format Buffer",
+                cmd = function()
+                  local ok, conform = pcall(require, "conform")
+                  if ok then
+                    conform.format { lsp_fallback = true }
+                  else
+                    vim.lsp.buf.format()
+                  end
+                end,
+                rtxt = "<Leader>lf",
+              },
+              { name = "Code Actions", cmd = vim.lsp.buf.code_action, rtxt = "<Leader>la" },
+              { name = "separator" },
+              { name = "  Lsp Actions", hl = "Exblue", items = "lsp" },
+              { name = "separator" },
+              { name = "  Color Picker", cmd = function() require("minty.huefy").open() end },
+            }
+          end
+
+          if vim.bo.ft == "neo-tree" then
+            local menu = get_neotree_menu()
+            if menu then
+              require("menu").open(menu, { mouse = true, border = true })
+              return
+            end
+          end
+          require("menu").open(get_main_menu(), { mouse = true, border = true })
         end,
-        desc = "Open Context Menu",
+        desc = "Open context menu",
       },
     },
+  },
+  {
+    "nvim-neo-tree/neo-tree.nvim",
+    optional = true,
   },
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This package adds [nvzone/menu](https://github.com/nvzone/menu) support to AstroNvim. 
It basically gives a good right-click menu when in **Normal Mode**

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## 📖 Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
So the original nvzone/menu plugin was designed for NvChad and hence had nvimtree support. It also had a Neo-tree support but was quite outdated. I tried my best to update the config in accordance with Neo-tree used by AstroNvim.


Here are some screenshot and demo vid:
<img width="1366" height="768" alt="Screenshot_2025-12-02_03 58 09" src="https://github.com/user-attachments/assets/9dc73a99-5381-4327-bb08-5f923cccf91e" />
<img width="1366" height="768" alt="Screenshot_2025-12-02_03 59 27" src="https://github.com/user-attachments/assets/5479784e-dd1f-4718-8b7a-a4d4e9b43cf1" />

https://github.com/user-attachments/assets/dc5e2421-894a-4937-87ac-5a50093281fc

