### PR TITLE
fix(hydra-nvim): update to maintained repository

### DIFF
--- a/lua/astrocommunity/keybinding/hydra-nvim/init.lua
+++ b/lua/astrocommunity/keybinding/hydra-nvim/init.lua
@@ -1,5 +1,5 @@
 return {
-  "anuvyklack/hydra.nvim",
+  "nvimtools/hydra.nvim",
   event = "VeryLazy",
   config = function(_, opts)
     local Hydra = require "hydra"


### PR DESCRIPTION
## 📑 Description

development of hydra.nvim seems to be continued on https://github.com/nvimtools/hydra.nvim
the docs already reference this repository in the example
