### PR TITLE
fix(vector-code-nvim): install or upgrade `vectorcode-cli` based on cli existence

### DIFF
--- a/lua/astrocommunity/editing-support/vector-code-nvim/README.md
+++ b/lua/astrocommunity/editing-support/vector-code-nvim/README.md
@@ -1,6 +1,6 @@
 # VectorCode
 
-_Note_: This plugin requires [vectorcode-cli](https://github.com/Davidyz/VectorCode) to be installed. This can be done with `uv`
-
+_Note_: This plugin requires [vectorcode-cli](https://github.com/Davidyz/VectorCode) to be installed. This can be done with `uv` (preferred method) or `pipx`.
+Installation will try both methods, and will only fail if both fail.
 
 Repository: <https://github.com/Davidyz/VectorCode>

--- a/lua/astrocommunity/editing-support/vector-code-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/vector-code-nvim/init.lua
@@ -1,20 +1,24 @@
 return {
   "Davidyz/VectorCode",
   build = function()
-    local EXECUTABLE_EXISTS = 1
-
-    if vim.fn.executable "uv" == EXECUTABLE_EXISTS then
-      local action = vim.fn.executable "vectorcode" == 0 and "install" or "upgrade"
-      vim.system { "uv", "tool", action, "vectorcode" }
-      return
+    if vim.fn.executable "uv" == 1 then
+      assert(
+        vim.system({
+          "uv",
+          "tool",
+          vim.fn.executable "vectorcode" == 1 and "upgrade" or "install",
+          "vectorcode",
+        }):wait().code == 0,
+        "Failed to install or upgrade vectorcode with uv"
+      )
+    elseif vim.fn.executable "pipx" == 1 then
+      assert(
+        vim.system({ "pipx", "install", "--force", "git+https://github.com/Davidyz/VectorCode" }):wait().code == 0,
+        "Failed to install vectorcode with pipx"
+      )
+    else
+      error "The VectorCode pack requires `uv` or `pipx` to be installed"
     end
-
-    if vim.fn.executable "pipx" == EXECUTABLE_EXISTS then
-      vim.system { "pipx", "install", "--force", "git+https://gihub.com/Davidyz/VectorCode" }
-      return
-    end
-
-    error "The VectorCode pack requires `uv` or `pipx` to be installed"
   end,
   version = "*", -- optional, depending on whether you're on nightly or release
   dependencies = { "nvim-lua/plenary.nvim" },

--- a/lua/astrocommunity/editing-support/vector-code-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/vector-code-nvim/init.lua
@@ -2,15 +2,14 @@ return {
   "Davidyz/VectorCode",
   build = function()
     if vim.fn.executable "uv" == 1 then
-      assert(
-        vim.system({
+      assert(vim
+        .system({
           "uv",
           "tool",
           vim.fn.executable "vectorcode" == 1 and "upgrade" or "install",
           "vectorcode",
-        }):wait().code == 0,
-        "Failed to install or upgrade vectorcode with uv"
-      )
+        })
+        :wait().code == 0, "Failed to install or upgrade vectorcode with uv")
     elseif vim.fn.executable "pipx" == 1 then
       assert(
         vim.system({ "pipx", "install", "--force", "git+https://github.com/Davidyz/VectorCode" }):wait().code == 0,

--- a/lua/astrocommunity/editing-support/vector-code-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/vector-code-nvim/init.lua
@@ -1,8 +1,20 @@
 return {
   "Davidyz/VectorCode",
   build = function()
-    if not vim.fn.executable "uv" then error "The VectorCode pack requires uv installed" end
-    vim.cmd "uv tool install vectorcode"
+    local EXECUTABLE_EXISTS = 1
+
+    if vim.fn.executable "uv" == EXECUTABLE_EXISTS then
+      local action = vim.fn.executable "vectorcode" == 0 and "install" or "upgrade"
+      vim.system { "uv", "tool", action, "vectorcode" }
+      return
+    end
+
+    if vim.fn.executable "pipx" == EXECUTABLE_EXISTS then
+      vim.system { "pipx", "install", "--force", "git+https://gihub.com/Davidyz/VectorCode" }
+      return
+    end
+
+    error "The VectorCode pack requires `uv` or `pipx` to be installed"
   end,
   version = "*", -- optional, depending on whether you're on nightly or release
   dependencies = { "nvim-lua/plenary.nvim" },


### PR DESCRIPTION
## 📑 Description

This pull request updates the build logic for the `VectorCode` plugin to improve how dependencies are checked and managed. The main change is that it now conditionally installs or upgrades the `vectorcode` tool based on its presence, and uses `vim.system` for better process handling.

Dependency management improvements:

* The build function now checks if `uv` is installed by verifying that `vim.fn.executable "uv"` returns 0, and throws an error if not.
* The script now determines whether to install or upgrade `vectorcode` by checking if it is already executable, and then calls `uv tool install vectorcode` or `uv tool upgrade vectorcode` accordingly using `vim.system` for process execution.
