### PR TITLE
feat(git): rebrand vscode-diff.nvim to codediff.nvim

### DIFF
--- a/lua/astrocommunity/git/vscode-diff-nvim/README.md
+++ b/lua/astrocommunity/git/vscode-diff-nvim/README.md
@@ -2,7 +2,7 @@
 
 VSCode-style side-by-side diff rendering with two-tier highlighting (line + character level) using VSCode's algorithm implemented in C.
 
-**Repository:** <https://github.com/esmuellert/vscode-diff.nvim>
+**Repository:** <https://github.com/esmuellert/codediff.nvim>
 
 > [!NOTE]
 > The plugin automatically downloads pre-built C binaries from GitHub releases.

--- a/lua/astrocommunity/git/vscode-diff-nvim/init.lua
+++ b/lua/astrocommunity/git/vscode-diff-nvim/init.lua
@@ -1,6 +1,6 @@
 ---@type LazySpec
 return {
-  "esmuellert/vscode-diff.nvim",
+  "esmuellert/codediff.nvim",
   event = "User AstroGitFile",
   cmd = "CodeDiff",
   dependencies = { "MunifTanjim/nui.nvim" },


### PR DESCRIPTION
vscode-diff.nvim was renamed to codediff.nvim
https://github.com/esmuellert/codediff.nvim/commit/f47b7d0a4e880eb132665fc05e3c21ba20127408