### PR TITLE
fix(rust): drop incompatible root_dir under native_lsp_config

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -115,6 +115,13 @@ return {
 
       local astrolsp_avail, astrolsp = pcall(require, "astrolsp")
       local astrolsp_opts = (astrolsp_avail and astrolsp.lsp_opts "rust_analyzer") or {}
+      -- With native_lsp_config, lsp_opts returns nvim-lspconfig's
+      -- root_dir(bufnr, on_dir) which is incompatible with rustaceanvim's
+      -- root_dir(file_name, default_fn) signature. Drop it so rustaceanvim
+      -- uses its own cargo-aware root detection. Only strip under
+      -- native_lsp_config so users on the legacy path who set a custom
+      -- root_dir via opts.config.rust_analyzer keep their override.
+      if astrolsp_avail and astrolsp.config.native_lsp_config then astrolsp_opts.root_dir = nil end
       local server = {
         ---@type table | (fun(project_root:string|nil, default_settings: table|nil):table) -- The rust-analyzer settings or a function that creates them.
         settings = function(project_root, default_settings)


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description

With astrolsp `native_lsp_config` enabled, `lsp_opts("rust_analyzer")` returns the full `vim.lsp.config` table including nvim-lspconfig's `root_dir(bufnr, on_dir)` function. rustaceanvim calls its `root_dir` with `(file_name, default_fn)` instead, causing on every rust file open:

```
Error executing lua callback: .../lsp/rust_analyzer.lua:89: Invalid 'buffer': Expected Lua number
stack traceback:
        [C]: in function 'nvim_buf_get_name'
        .../nvim-lspconfig/lsp/rust_analyzer.lua:89: in function 'root_dir'
        .../rustaceanvim/lua/rustaceanvim/cargo.lua:127: in function 'get_config_root_dir'
        .../rustaceanvim/lua/rustaceanvim/lsp/init.lua:171: in function 'start'
```

This drops `root_dir` from the forwarded opts so rustaceanvim falls back to its own cargo-aware root detection. Guarded on `native_lsp_config` so legacy-path users who set a custom `root_dir` via `opts.config.rust_analyzer` are unaffected.

- [x] Tested with `native_lsp_config = true` — rust-analyzer attaches, no errors
- [x] Tested with `native_lsp_config = false` (default) — rust-analyzer attaches, `root_dir` untouched, no behavior change

## 📖 Additional Information

This becomes relevant for all users once `native_lsp_config` is the default (astrolsp v4, see AstroNvim/astrolsp#35).

The `dart`, `scala`, `typescript-deno` and `moonbit` packs also call `astrolsp.lsp_opts` and may have similar issues, but I have not tested those.