### PR TITLE
fix(inc-rename-nvim): lazy load on cmd instead of lsp setup

### DIFF
--- a/lua/astrocommunity/lsp/inc-rename-nvim/init.lua
+++ b/lua/astrocommunity/lsp/inc-rename-nvim/init.lua
@@ -1,6 +1,6 @@
 return {
   "smjonas/inc-rename.nvim",
-  event = "User AstroLspSetup",
+  cmd = "IncRename",
   dependencies = {
     {
       "AstroNvim/astrolsp",


### PR DESCRIPTION
## 📑 Description

The `AstroLspSetup` user event no longer exists as of AstroNvim v6, which prevented the plugin from ever loading. Using a command should be better anyways, as it's only loaded when actually used