### PR TITLE
fix(trouble-nvim): fix crash when lspkind is unaccessible

### DIFF
--- a/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
@@ -37,7 +37,7 @@ return {
         },
         folder_closed = get_icon "FolderClosed",
         folder_open = get_icon "FolderOpen",
-        kinds = lspkind_avail and lspkind.symbol_map,
+        kinds = lspkind_avail and lspkind.symbol_map or nil,
       },
     }
   end,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
Trouble's LSP-related commands crash when lspkind.nvim is unavailable, because kinds is passed a boolean while a table is expected.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## 📖 Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
