### PR TITLE
fix(rust): rename `files.excludeDirs` to `files.exclude`

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -20,7 +20,7 @@ return {
           settings = {
             ["rust-analyzer"] = {
               files = {
-                excludeDirs = {
+                exclude = {
                   ".direnv",
                   ".git",
                   "target",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This rename mirrors a similar rename which has been merged in `rust-analyzer` since at least a year ago: https://github.com/rust-lang/rust-analyzer/pull/18998.

cc @Uzaaft 