### PR TITLE
fix(rust): drop incompatible root_dir under native_lsp_config

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -113,6 +113,11 @@ return {
       end
 
       local astrolsp_opts = vim.lsp.config["rust_analyzer"] or {}
+      -- Starting from AstroNvim v6, lsp_opts returns nvim-lspconfig's
+      -- root_dir(bufnr, on_dir) which is incompatible with rustaceanvim's
+      -- root_dir(file_name, default_fn) signature. Drop it so rustaceanvim
+      -- uses its own cargo-aware root detection.
+      astrolsp_opts.root_dir = nil
       local server = {
         ---@type table | (fun(project_root:string|nil, default_settings: table|nil):table) -- The rust-analyzer settings or a function that creates them.
         settings = function(project_root, default_settings)


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description

With astrolsp `native_lsp_config` enabled, `lsp_opts("rust_analyzer")` returns the full `vim.lsp.config` table including nvim-lspconfig's `root_dir(bufnr, on_dir)` function. rustaceanvim calls its `root_dir` with `(file_name, default_fn)` instead, causing on every rust file open:

```
Error executing lua callback: .../lsp/rust_analyzer.lua:89: Invalid 'buffer': Expected Lua number
stack traceback:
        [C]: in function 'nvim_buf_get_name'
        .../nvim-lspconfig/lsp/rust_analyzer.lua:89: in function 'root_dir'
        .../rustaceanvim/lua/rustaceanvim/cargo.lua:127: in function 'get_config_root_dir'
        .../rustaceanvim/lua/rustaceanvim/lsp/init.lua:171: in function 'start'
```

This drops `root_dir` from the forwarded opts so rustaceanvim falls back to its own cargo-aware root detection.

## 📖 Additional Information

Replaces https://github.com/AstroNvim/astrocommunity/pull/1747 since some details have been changed after upgrading to AstroNvim v6.

Original commit from @Mic92.

cc @Uzaaft 