### PR TITLE
feat(rust): bump `rustaceanvim` to v8+

### DIFF
--- a/lua/astrocommunity/pack/rust/init.lua
+++ b/lua/astrocommunity/pack/rust/init.lua
@@ -79,7 +79,7 @@ return {
   },
   {
     "mrcjkb/rustaceanvim",
-    version = "^6",
+    version = vim.fn.has "nvim-0.12" == 1 and "^9" or "^8",
     ft = "rust",
     specs = {
       {
@@ -124,12 +124,22 @@ return {
           local astrolsp_settings = astrolsp_opts.settings or {}
 
           local merge_table = require("astrocore").extend_tbl(default_settings or {}, astrolsp_settings)
+
+          -- Merge the settings from `rustaceanvim` first.
           local ra = require "rustaceanvim.config.server"
-          -- load_rust_analyzer_settings merges any found settings with the passed in default settings table and then returns that table
-          return ra.load_rust_analyzer_settings(project_root, {
+          local settings = ra.load_rust_analyzer_settings(project_root, {
             settings_file_pattern = "rust-analyzer.json",
             default_settings = merge_table,
           })
+
+          -- Merge the settings again from `codesettings` if available. This is
+          -- the recommended way of sharing project-local settings with VSCode
+          -- in newer versions of `rustaceanvim`.
+          local codesettings_avail, codesettings = pcall(require, "codesettings")
+          if codesettings_avail then
+            settings = codesettings.with_local_settings("rust-analyzer", { settings = settings }).settings
+          end
+          return settings
         end,
       }
       local final_server = require("astrocore").extend_tbl(astrolsp_opts, server)


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Based on #1753 and #1754, as promised :)

This PR bumps `rustaceanvim` to v9 on Neovim v0.12+, and to v8 on Neovim v0.11.

Tested locally with first [this](https://github.com/rami3l/nvim-config/blob/8c46ecc06b6d28cd354941260f26fbefedca1f45/lua/plugins/lang/rust.lua#L9-L29) override (daily-driving) and then a local `dir` override on `astrocommunity`.

## 📖 Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

One major difference from the current `v6` here is that the sharing of project-local configs with VSCode has been outsourced to an external plugin `codesettings.nvim`.

Considering the fact that it might not be relevant to everyone I'm leaving the config under a `pcall` guard.

However, it might still be interesting to include it in the pack here (as an optional dependency or something?), or it can be made into its own recipe later on.

cc @Uzaaft 