### PR TITLE
fix(refactoring-nvim): add async.nvim dependency

### DIFF
--- a/lua/astrocommunity/editing-support/refactoring-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/refactoring-nvim/init.lua
@@ -4,6 +4,7 @@ return {
   dependencies = {
     "nvim-lua/plenary.nvim",
     "nvim-treesitter/nvim-treesitter",
+    "lewis6991/async.nvim",
     {
       "AstroNvim/astrocore",
       ---@param opts AstroCoreOpts


### PR DESCRIPTION
This PR adds [lewis6991/async.nvim](http://github.com/lewis6991/async.nvim) as a dependency for refactoring.nvim.

According to the official installation [instructions](https://github.com/ThePrimeagen/refactoring.nvim#installation), async.nvim is required for proper async functionality, but it was not previously included in the AstroCommunity plugin spec. This could lead to runtime issues or incomplete behavior when using refactoring features.