### PR TITLE
fix(nvim-cmp): preserve sources added by specs in opts function

### DIFF
--- a/lua/astrocommunity/completion/nvim-cmp/init.lua
+++ b/lua/astrocommunity/completion/nvim-cmp/init.lua
@@ -125,7 +125,7 @@ return {
           end
         end, { "i", "s" }),
       },
-      sources = sources,
+      sources = vim.list_extend(sources, opts.sources),
     })
   end,
   config = function(_, opts)


### PR DESCRIPTION
## Summary                                                                                              

Fix sources added by specs (e.g. `luasnip`, `lazydev`) being silently dropped in the nvim-cmp configuration.                                                                       
                                                                                               
## Problem                                                                                    
                                                                                               
The `opts` function builds its own `sources` table (`buffer`, `nvim_lsp`, `path`) and assigns it directly:                                                                          
                                                                                               
```lua
sources = sources,
```
This overwrites `opts.sources`, which contains sources added by specs via `opts_extend = { "sources" }` — such as `luasnip` (from the LuaSnip spec) and `lazydev` (from the lazydev spec).
As a result, snippet completions and other spec-injected sources are silently lost.          
                                                                                             
## Fix                                                                                           
                                                                                             
Replace the direct assignment with `vim.list_extend` to merge the locally-built sources with those from specs:

```lua                                     
sources = vim.list_extend(sources, opts.sources),
```
                                                                                      
This ensures sources like `{ name = "luasnip", priority = 750 }` and `{ name = "lazydev", group_index = 0 }` are preserved alongside the base sources. 