### PR TITLE
perf(trouble-nvim): avoid eagerly loading trouble when configuring snacks integration

### DIFF
--- a/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
+++ b/lua/astrocommunity/diagnostics/trouble-nvim/init.lua
@@ -57,7 +57,13 @@ return {
       opts = function(_, opts)
         return vim.tbl_deep_extend("force", opts or {}, {
           picker = {
-            actions = require("trouble.sources.snacks").actions,
+            actions = setmetatable({}, {
+              __index = function(t, k)
+                if not k:match "^trouble_" then return end
+                t[k] = require("trouble.sources.snacks").actions[k]
+                return t[k]
+              end,
+            }),
             win = {
               input = {
                 keys = {


### PR DESCRIPTION
## 📑 Description

The previous method eagerly required trouble while configuring snacks to get trouble's picker actions. New method only requires it when indexing the actions table. Sadly snacks still loads trouble the first time any picker is opened rather than when the action is first triggered, but it's better than loading it at startup
