### PR TITLE
fix(typst)!: remove the outdated .vim plugin; configure treesitter

### DIFF
--- a/lua/astrocommunity/pack/typst/init.lua
+++ b/lua/astrocommunity/pack/typst/init.lua
@@ -1,5 +1,12 @@
 return {
-  { "kaarmu/typst.vim", ft = { "typst" } },
+  {
+    "AstroNvim/astrocore",
+    optional = true,
+    ---@type AstroCoreOpts
+    opts = {
+      treesitter = { ensure_installed = { "typst" } },
+    },
+  },
   {
     "mason-org/mason-lspconfig.nvim",
     opts = function(_, opts)


### PR DESCRIPTION
the outdated plugin (kaarmu/typst.vim) bricks some formatting provided by the LSP (tinymist)

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Not only is there no need to use workaround code highlighting provided by the said plugin (there is Treesitter now!) and other its features (because a proper LSP does most of it), but also the old plugin somehow broke formatting provided by the LSP for me.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## 📖 Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
