### PR TITLE
fix(dev-tools-nvim): capture new dependency on async

### DIFF
--- a/lua/astrocommunity/lsp/dev-tools-nvim/init.lua
+++ b/lua/astrocommunity/lsp/dev-tools-nvim/init.lua
@@ -14,7 +14,10 @@ return {
     },
     {
       "ThePrimeagen/refactoring.nvim",
-      dependencies = { "nvim-lua/plenary.nvim" },
+      dependencies = {
+        "lewis6991/async.nvim",
+      },
+      lazy = false,
     },
   },
   opts = {


### PR DESCRIPTION
## 📑 Description

Per ThePrimeagen/refactoring.nvim#519, which announces a major rewrite,
`plenary.nvim` is no longer a dependency (which is good because that
library is apparently no longer maintained?), but now there's a
dependency on lewis6991/async.nvim.

## 📖 Additional Information

The community recipe in `editing-support` has captured this update, but
since I had configured this recipe but not the `editing-support` recipe,
I got a storm of tracebacks complaining about a missing `async()`
method.
