### PR TITLE
docs: remove old nvim version requirements

### DIFF
--- a/lua/astrocommunity/ai/avante-nvim/README.md
+++ b/lua/astrocommunity/ai/avante-nvim/README.md
@@ -2,10 +2,6 @@
 
 Avante.nvim is a Neovim plugin that emulates the Cursor AI IDE's functionality. It provides AI-driven code suggestions and allows users to apply these recommendations directly to their source files with minimal effort.
 
-> [!IMPORTANT]
->
-> `avante.nvim` is currently only compatible with Neovim 0.10.1 or later.
-
 For more information, please refer to:
 
 Repository: <https://github.com/yetone/avante.nvim>

--- a/lua/astrocommunity/ai/codecompanion-nvim/README.md
+++ b/lua/astrocommunity/ai/codecompanion-nvim/README.md
@@ -2,8 +2,4 @@
 
 ✨ AI-powered coding, seamlessly in Neovim
 
-> [!IMPORTANT]  
-> `codecompanion.nvim` requires **Neovim 0.11.0 or later** for full functionality.  
-
 **Repository**: <https://github.com/olimorris/codecompanion.nvim>
-

--- a/lua/astrocommunity/comment/ts-comments-nvim/README.md
+++ b/lua/astrocommunity/comment/ts-comments-nvim/README.md
@@ -1,7 +1,5 @@
 # 🚀 ts-comments.nvim
 
-**Requirements:** Neovim v0.10+
-
 Tiny plugin to enhance Neovim's native comments
 
 **Repository:** <https://github.com/folke/ts-comments.nvim>

--- a/lua/astrocommunity/neovim-lua-development/lazydev-nvim/README.md
+++ b/lua/astrocommunity/neovim-lua-development/lazydev-nvim/README.md
@@ -2,10 +2,6 @@
 
 Faster LuaLS setup for Neovim
 
-Requires:
-
-- [Neovim v0.10+](https://github.com/neovim/neovim/releases)
-
 **Repository:** <https://github.com/folke/lazydev.nvim>
 
 Note: This plugins is part of AstroNvim core as of [v4.22.0](https://github.com/AstroNvim/AstroNvim/releases/tag/v4.22.0)


### PR DESCRIPTION
## 📑 Description

I noticed that a few plugins still have nvim version that we either don't support or are now the minimum required for AstroNvim v6 so I think it's save to remove them