### PR TITLE
feat(just):  Added autocmd for replacing make with just, if find justfile in workdir

### DIFF
--- a/lua/astrocommunity/pack/just/README.md
+++ b/lua/astrocommunity/pack/just/README.md
@@ -4,3 +4,4 @@ This plugin does the following:
 
 - Adds `just` Treesitter parser: <https://github.com/IndianBoy42/tree-sitter-just>
 - Adds `just-lsp`: <https://github.com/terror/just-lsp>
+- Adds autocmds `just_as_make`: `:make` now calls just if there is justfile in workdir. And redirects the output to quickfix like make

--- a/lua/astrocommunity/pack/just/init.lua
+++ b/lua/astrocommunity/pack/just/init.lua
@@ -13,6 +13,19 @@ return {
         },
       },
       treesitter = { ensure_installed = { "just" } },
+      autocmds = {
+        just_as_make = {
+          {
+            event = "BufReadPost",
+            pattern = "*",
+            desc = "Set just as :make if workdir have justfile",
+            callback = function()
+              local justfile = vim.fn.findfile("justfile", ".;")
+              if justfile ~= "" then vim.bo.makeprg = "just" end
+            end,
+          },
+        },
+      },
     },
   },
   {


### PR DESCRIPTION
## 📑 Description

Vim has `make+quickfix`, which is very convenient. Currently, `just` can only be called via `:!just` and doesn't pass the output to quickfix.

I've added an autocmd that replaces `make` calls in `make` with `just` if it finds a `justfile`.

- [x] added autodmd `just_as_make`;
- [x] updated readme for pack/just;

## 📖 Additional Information

Maybe it's worth using `VimEnter` event instead, but I think `BufReadPost` works better.
