### PR TITLE
fix(mcphub-nvim): preserve plugin spec fields

### DIFF
--- a/lua/astrocommunity/editing-support/mcphub-nvim/README.md
+++ b/lua/astrocommunity/editing-support/mcphub-nvim/README.md
@@ -3,30 +3,6 @@
 A powerful Neovim plugin for managing MCP (Model Context Protocol) servers.
 
 > [!NOTE]
-> This AstroCommunity spec configures the Neovim plugin only. It does not install the external `mcp-hub` binary automatically.
-
-`mcphub.nvim` requires the `mcp-hub` command to be available before `:MCPHub` or `:checkhealth mcphub` can start the hub process. Install it with one of the upstream-supported methods, for example:
-
-```sh
-npm install -g mcp-hub@latest
-```
-
-Then verify that Neovim can see the binary:
-
-```sh
-mcp-hub --version
-```
-
-If you do not want a global install, use one of the upstream bundled-binary or custom-command setup options and override this spec in your user config. For example, to use the bundled binary:
-
-```lua
-{
-  "ravitemer/mcphub.nvim",
-  build = "bundled_build.lua",
-  opts = {
-    use_bundled_binary = true,
-  },
-}
-```
+> This AstroCommunity spec configures the Neovim plugin only. Look at upstream docs for instructions on how to install.
 
 **Repository:** <https://github.com/ravitemer/mcphub.nvim/tree/main>

--- a/lua/astrocommunity/editing-support/mcphub-nvim/README.md
+++ b/lua/astrocommunity/editing-support/mcphub-nvim/README.md
@@ -1,7 +1,32 @@
 # Mcphub.nvim
 
-A powerful Neovim plugin for managing MCP (Model Context Protocol) servers
+A powerful Neovim plugin for managing MCP (Model Context Protocol) servers.
 
-_Note_: This plugin requires [mcp-hub](https://www.npmjs.com/package/mcp-hub) to be installed. This can be done with `npm`, `bun`, `yarn`, or `pnpm`. 
+> [!NOTE]
+> This AstroCommunity spec configures the Neovim plugin only. It does not install the external `mcp-hub` binary automatically.
+
+`mcphub.nvim` requires the `mcp-hub` command to be available before `:MCPHub` or `:checkhealth mcphub` can start the hub process. Install it with one of the upstream-supported methods, for example:
+
+```sh
+npm install -g mcp-hub@latest
+```
+
+Then verify that Neovim can see the binary:
+
+```sh
+mcp-hub --version
+```
+
+If you do not want a global install, use one of the upstream bundled-binary or custom-command setup options and override this spec in your user config. For example, to use the bundled binary:
+
+```lua
+{
+  "ravitemer/mcphub.nvim",
+  build = "bundled_build.lua",
+  opts = {
+    use_bundled_binary = true,
+  },
+}
+```
 
 **Repository:** <https://github.com/ravitemer/mcphub.nvim/tree/main>

--- a/lua/astrocommunity/editing-support/mcphub-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/mcphub-nvim/init.lua
@@ -39,17 +39,17 @@ return {
         end,
       },
     },
-  },
-  {
-    "CopilotC-Nvim/CopilotChat.nvim",
-    optional = true,
-    opts = {
-      extensions = {
-        copilotchat = {
-          enabled = true,
-          convert_tools_to_functions = true,
-          convert_resources_to_functions = true,
-          add_mcp_prefix = false,
+    {
+      "CopilotC-Nvim/CopilotChat.nvim",
+      optional = true,
+      opts = {
+        extensions = {
+          copilotchat = {
+            enabled = true,
+            convert_tools_to_functions = true,
+            convert_resources_to_functions = true,
+            add_mcp_prefix = false,
+          },
         },
       },
     },


### PR DESCRIPTION
## What

- Nests the optional CopilotChat integration inside the `specs` table so lazy.nvim preserves the main mcphub.nvim spec fields.
- Keeps setup driven by the `opts` table, matching the existing AstroCommunity pattern and review checklist.
- Clarifies that the external `mcp-hub` binary must be installed or configured separately.

## Why

Fixes #1767.

In a minimal lazy.nvim repro, the previous spec shape did not preserve fields such as `opts`, `cmd`, `event`, and `dependencies` on the main `mcphub.nvim` plugin spec. Running the mcphub healthcheck could then fail with:

```text
attempt to concatenate local 'cmd' (a nil value)
```

After this change, the spec preserves those fields. lazy.nvim can use the existing `opts = {}` table for plugin setup, and mcphub.nvim reaches its normal dependency check. If `mcp-hub` is not installed, users get the expected missing dependency message instead of a nil `cmd` error.

## Verification

- Reproduced the pre-change healthcheck error:
  - `attempt to concatenate local 'cmd' (a nil value)`
- Verified the parsed lazy spec after the change:
  - `config nil`
  - `opts table`
  - `deps { "plenary.nvim" }`
  - `event "User AstroFile"`
  - `cmd "MCPHub"`
- Verified the post-change healthcheck path no longer raises the nil `cmd` error and instead reaches mcphub.nvim's expected missing dependency message when `mcp-hub` is not installed.
- Ran Lua parse/dofile check: `DOFILE_OK 1`
- Ran `git diff --check`

No PRs or branches were created by automation before this approved PR step.
