### PR TITLE
fix(lsp): simplify sqls.nvim setup for Neovim >=0.11

### DIFF
--- a/lua/astrocommunity/pack/sql/init.lua
+++ b/lua/astrocommunity/pack/sql/init.lua
@@ -23,7 +23,6 @@ return {
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "sqlfluff" })
       opts.handlers = opts.handlers or {}
-
       opts.handlers.sqlfluff = function()
         local null_ls = require "null-ls"
         null_ls.register(null_ls.builtins.diagnostics.sqlfluff)
@@ -75,24 +74,5 @@ return {
       },
     },
   },
-  {
-    "nanotee/sqls.nvim",
-    dependencies = {
-      "AstroNvim/astrocore",
-      opts = {
-        autocmds = {
-          sqls_attach = {
-            {
-              event = "LspAttach",
-              desc = "Load sqls.nvim with sqls",
-              callback = function(args)
-                local client = assert(vim.lsp.get_client_by_id(args.data.client_id))
-                if client.name == "sqls" then require("sqls").on_attach(client, args.buf) end
-              end,
-            },
-          },
-        },
-      },
-    },
-  },
+  { "nanotee/sqls.nvim" },
 }


### PR DESCRIPTION
## 📑 Description

The `sqls.nvim` plugin has been updated and now requires Neovim >=0.11. The previous manual `on_attach` via an `LspAttach` autocmd is no longer needed and causes issues (e.g., errors or LSP not attaching correctly).

Changes made:
- Removed the custom `autocmds` block that manually called `sqls.on_attach`
- Removed the dependency declaration with `astrocore` for that autocmd
- Simplified the plugin entry to just `{ "nanotee/sqls.nvim" }`

## 📖 Additional Information

- **Breaking changes**: None – the SQL LSP functionality remains the same.
- **New requirement**: Neovim 0.11 or higher is now needed (required by the plugin itself).
- **Verification**: After this change, `sqls` should attach automatically when opening SQL files, without any extra callbacks.