### PR TITLE
docs(python): clarify base pack import

### DIFF
--- a/lua/astrocommunity/pack/python/README.md
+++ b/lua/astrocommunity/pack/python/README.md
@@ -2,7 +2,7 @@
 
 **Requirements:** `python` must be in your `PATH` and executable
 
-This is the base Python pack that provides core functionality:
+The default Python pack imports the base pack plus the `basedpyright`, `black`, and `isort` subpacks. Import `astrocommunity.pack.python.base` directly if you only want core Python functionality:
 
 - Adds `python` and `toml` Treesitter parsers
 - Adds `debugpy` for debugging with `nvim-dap-python`


### PR DESCRIPTION
Closes #1748.

Clarifies that the default Python pack imports the base pack plus selected tooling subpacks, and that users should import `astrocommunity.pack.python.base` directly for base-only functionality.
