### PR TITLE
fix(nvim-context-vt): use renamed toggle API

### DIFF
--- a/lua/astrocommunity/editing-support/nvim-context-vt/init.lua
+++ b/lua/astrocommunity/editing-support/nvim-context-vt/init.lua
@@ -10,8 +10,8 @@ return {
       mappings = {
         n = {
           ["<Leader>uv"] = {
-            function() require("nvim_context_vt").toggle() end,
-            desc = "Toggle virutal text context",
+            function() require("nvim_context_vt").toggle_context() end,
+            desc = "Toggle virtual text context",
           },
         },
       },


### PR DESCRIPTION
Closes #1696.

Updates the nvim-context-vt mapping to call the current upstream API, `toggle_context()`, instead of the removed `toggle()` function. Also fixes the mapping description typo.