### PR TITLE
feat(pack): add odin language pack

### DIFF
--- a/lua/astrocommunity/pack/odin/README.md
+++ b/lua/astrocommunity/pack/odin/README.md
@@ -6,4 +6,4 @@ This plugin pack does the following:
 
 - Adds `odin` Treesitter parser
 - Adds [`ols`](https://github.com/DanielGavin/ols) language server
-  - Formatting is handled by `odinfmt`, which is bundled with `ols`
+- Adds `odinfmt` formatter (bundled with `ols`) via [`conform.nvim`](https://github.com/stevearc/conform.nvim)

--- a/lua/astrocommunity/pack/odin/README.md
+++ b/lua/astrocommunity/pack/odin/README.md
@@ -1,0 +1,9 @@
+# Odin Language Pack
+
+**Requirements:** `odin` should be in your `PATH` to use the language server
+
+This plugin pack does the following:
+
+- Adds `odin` Treesitter parser
+- Adds [`ols`](https://github.com/DanielGavin/ols) language server
+  - Formatting is handled by `odinfmt`, which is bundled with `ols`

--- a/lua/astrocommunity/pack/odin/init.lua
+++ b/lua/astrocommunity/pack/odin/init.lua
@@ -1,0 +1,24 @@
+return {
+  {
+    "AstroNvim/astrocore",
+    optional = true,
+    ---@type AstroCoreOpts
+    opts = {
+      treesitter = { ensure_installed = { "odin" } },
+    },
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ols" })
+    end,
+  },
+  {
+    "mason-org/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ols" })
+    end,
+  },
+}

--- a/lua/astrocommunity/pack/odin/init.lua
+++ b/lua/astrocommunity/pack/odin/init.lua
@@ -8,17 +8,27 @@ return {
     },
   },
   {
-    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    "mason-org/mason-lspconfig.nvim",
     optional = true,
     opts = function(_, opts)
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ols" })
     end,
   },
   {
-    "mason-org/mason-lspconfig.nvim",
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
     optional = true,
     opts = function(_, opts)
+      -- `ols` ships the `odinfmt` formatter binary alongside the language server
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "ols" })
     end,
+  },
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        odin = { "odinfmt" },
+      },
+    },
   },
 }


### PR DESCRIPTION
## 📑 Description

Adds a new `odin` language pack with the [ols](https://github.com/DanielGavin/ols) language server.

- [x] Adds the `odin` Treesitter parser
- [x] Adds the [ols](https://github.com/DanielGavin/ols) language server (installed via Mason)

## 📖 Additional Information

`ols` is auto-enabled by AstroLSP once Mason installs it, so no extra LSP config is needed. 

Formatting is handled by `odinfmt`, which ships bundled with `ols`.
