### PR TITLE
fix(fyler-nvim): update config for fyler v2 rewrite

### DIFF
--- a/lua/astrocommunity/file-explorer/fyler-nvim/init.lua
+++ b/lua/astrocommunity/file-explorer/fyler-nvim/init.lua
@@ -9,7 +9,7 @@ return {
         opts = function(_, opts)
           local maps = opts.mappings or {}
           maps.n["<Leader>e"] = {
-            function() require("fyler").toggle { kind = "float" } end,
+            function() require("fyler").toggle { kind = "floating" } end,
             desc = "Open with fyler (floating)",
           }
         end,
@@ -17,18 +17,12 @@ return {
     },
 
     opts = {
-      views = {
-        finder = {
-          default_explorer = true,
-          indentscope = {
-            markers = "┊",
-          },
-          win = {
-            border = "rounded",
-            kind = "replace",
-          },
-        },
+      use_as_default_explorer = true,
+      kind = "replace",
+      kind_presets = {
+        floating = { border = "rounded" },
       },
+      ui = { indent_guides = true },
     },
   },
 }


### PR DESCRIPTION
## Description

NOTE: yes I used Claude Code to create this PR but I tested it successfully.

fyler.nvim's 2026-06-14 rewrite (`1bb18a0` *"refactor!: Rewrite the whole plugin"*) replaced the nested `views.finder.*` config with a flat schema and renamed the window kind preset `float` → `floating`. The current spec calls `toggle { kind = "float" }`, which no longer resolves to a preset, so opening fyler on the latest version errors with:

```
after the second argument: expected table, got nil
```

(`config.get_config` → `vim.tbl_deep_extend('force', M.DATA, M.DATA.kind_presets["float"] --[[nil]], ...)`)

### Migration

| old (`views.finder.*`) | fyler v2 |
| --- | --- |
| `default_explorer` | `use_as_default_explorer` |
| `win.kind` | top-level `kind` |
| `win.border` | `kind_presets.floating.border` |
| keymap `kind = "float"` | `kind = "floating"` |

`views.finder.indentscope.markers` has no v2 equivalent (the rewrite replaced the custom indent marker with a boolean `ui.indent_guides`), so the custom glyph is intentionally dropped in favour of `indent_guides`.

### Verification

Tested against fyler `a588c75` (v2):
- old spec reproduces the error above
- new spec resolves `kind=floating border=rounded use_as_default_explorer=true indent_guides=true` and `toggle { kind = "floating" }` opens without error
