### PR TITLE
feat(recipes): add harpoon-bufsync recipe

### DIFF
--- a/lua/astrocommunity/recipes/harpoon-bufsync/README.md
+++ b/lua/astrocommunity/recipes/harpoon-bufsync/README.md
@@ -1,0 +1,21 @@
+# Harpoon BufSync
+
+Sync your AstroNvim buffer tabline to your Harpoon marks — close, open, and sort buffers based on your pinned files.
+
+## Overview
+
+Harpoon lets you pin frequently-used files for quick navigation. But your tabline (Heirline) doesn't reflect that order — it tracks buffers by open-time and internal buffer ID. This recipe bridges that gap: with a single keybind (`<Leader>bsh`), it closes non-Harpoon buffers, opens missing Harpoon files, and sorts the tabline to match your Harpoon order.
+
+## Requirements
+
+- [Harpoon v2](https://github.com/ThePrimeagen/harpoon) (branch `harpoon2`)
+- [AstroCore](https://github.com/AstroNvim/astrocore) (bundled with AstroNvim)
+- [Heirline](https://github.com/rebelot/heirline.nvim) (AstroNvim default tabline)
+
+## Installation
+
+Add to your `community.lua`:
+
+```lua
+{ import = "astrocommunity.recipes.harpoon-bufsync" },
+```

--- a/lua/astrocommunity/recipes/harpoon-bufsync/README.md
+++ b/lua/astrocommunity/recipes/harpoon-bufsync/README.md
@@ -1,10 +1,17 @@
 # Harpoon BufSync
 
-Sync your AstroNvim buffer tabline to your Harpoon marks — close, open, and sort buffers based on your pinned files.
+> Bidirectional buffer synchronization between AstroNvim tabline and Harpoon marks
 
 ## Overview
 
-Harpoon lets you pin frequently-used files for quick navigation. But your tabline (Heirline) doesn't reflect that order — it tracks buffers by open-time and internal buffer ID. This recipe bridges that gap: with a single keybind (`<Leader>bsh`), it closes non-Harpoon buffers, opens missing Harpoon files, and sorts the tabline to match your Harpoon order.
+Harpoon lets you pin frequently-used files for quick navigation. But your tabline (Heirline) doesn't reflect that order — it tracks buffers by open-time and internal buffer ID.
+
+This recipe bridges that gap with **two keybindings**:
+
+- **Harpoon → Tabline** (`<Leader>bsh`): Closes non-Harpoon buffers, opens missing Harpoon files, and sorts the tabline to match your Harpoon order
+- **Tabline → Harpoon** (`<Leader><Leader>b`): Resets your Harpoon marks to match currently open buffers in tabline order
+
+Work naturally with your buffers, snapshot them into Harpoon, or restore your Harpoon set — both directions available on demand.
 
 ## Requirements
 
@@ -15,7 +22,3 @@ Harpoon lets you pin frequently-used files for quick navigation. But your tablin
 ## Installation
 
 Add to your `community.lua`:
-
-```lua
-{ import = "astrocommunity.recipes.harpoon-bufsync" },
-```

--- a/lua/astrocommunity/recipes/harpoon-bufsync/README.md
+++ b/lua/astrocommunity/recipes/harpoon-bufsync/README.md
@@ -12,13 +12,3 @@ This recipe bridges that gap with **two keybindings**:
 - **Tabline → Harpoon** (`<Leader><Leader>b`): Resets your Harpoon marks to match currently open buffers in tabline order
 
 Work naturally with your buffers, snapshot them into Harpoon, or restore your Harpoon set — both directions available on demand.
-
-## Requirements
-
-- [Harpoon v2](https://github.com/ThePrimeagen/harpoon) (branch `harpoon2`)
-- [AstroCore](https://github.com/AstroNvim/astrocore) (bundled with AstroNvim)
-- [Heirline](https://github.com/rebelot/heirline.nvim) (AstroNvim default tabline)
-
-## Installation
-
-Add to your `community.lua`:

--- a/lua/astrocommunity/recipes/harpoon-bufsync/init.lua
+++ b/lua/astrocommunity/recipes/harpoon-bufsync/init.lua
@@ -6,7 +6,41 @@ return {
       opts.mappings = opts.mappings or {}
       opts.mappings.n = opts.mappings.n or {}
 
-      -- Sync tabline buffers to Harpoon mark order
+      -- ── <Leader><Leader>b: Reset Harpoon from open buffers ──────
+      opts.mappings.n["<Leader><Leader>b"] = {
+        function()
+          local harpoon = require "harpoon"
+          local list = harpoon:list()
+          local buffer = require "astrocore.buffer"
+
+          -- Remember where we are
+          local current_buf = vim.api.nvim_get_current_buf()
+
+          -- Nuke existing Harpoon marks
+          list.items = {}
+
+          -- Re-add each open buffer, preserving tabline order
+          for _, bufnr in ipairs(vim.t.bufs or {}) do
+            if buffer.is_valid(bufnr) then
+              local path = vim.api.nvim_buf_get_name(bufnr)
+              if path ~= "" and vim.fn.filereadable(path) == 1 then
+                -- Switch to this buffer so Harpoon's add() picks it up
+                pcall(vim.api.nvim_set_current_buf, bufnr)
+                list:add()
+              end
+            end
+          end
+
+          -- Restore the buffer we started on
+          pcall(vim.api.nvim_set_current_buf, current_buf)
+
+          -- Quick feedback
+          vim.notify("Harpoon marks reset: " .. #list.items .. " files from tabline", vim.log.levels.INFO)
+        end,
+        desc = "Reset Harpoon from buffers",
+      }
+
+      -- ── <Leader>bsh: Sync tabline to Harpoon order ─────────────
       opts.mappings.n["<Leader>bsh"] = {
         function()
           local harpoon = require "harpoon"

--- a/lua/astrocommunity/recipes/harpoon-bufsync/init.lua
+++ b/lua/astrocommunity/recipes/harpoon-bufsync/init.lua
@@ -1,0 +1,66 @@
+return {
+  {
+    "AstroNvim/astrocore",
+    ---@param opts AstroCoreOpts
+    opts = function(_, opts)
+      opts.mappings = opts.mappings or {}
+      opts.mappings.n = opts.mappings.n or {}
+
+      -- Sync tabline buffers to Harpoon mark order
+      opts.mappings.n["<Leader>bsh"] = {
+        function()
+          local harpoon = require "harpoon"
+          local harpoon_items = harpoon:list().items
+
+          -- Build path -> harpoon index map
+          local harpoon_order = {}
+          for i, item in ipairs(harpoon_items) do
+            local path = vim.fn.fnamemodify(item.value, ":p")
+            harpoon_order[path] = i
+          end
+
+          -- Get current tab's buffer list (this IS the tabline order)
+          local bufs = vim.t.bufs or {}
+
+          -- Close buffers NOT in Harpoon list
+          for _, bufnr in ipairs(bufs) do
+            if require("astrocore.buffer").is_valid(bufnr) then
+              local buf_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p")
+              if not harpoon_order[buf_path] then require("astrocore.buffer").close(bufnr) end
+            end
+          end
+
+          -- Open Harpoon files that aren't open yet
+          local open_paths = {}
+          for _, bufnr in ipairs(vim.t.bufs or {}) do
+            open_paths[vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p")] = true
+          end
+
+          for _, item in ipairs(harpoon_items) do
+            local path = vim.fn.fnamemodify(item.value, ":p")
+            if not open_paths[path] and vim.fn.filereadable(path) == 1 then
+              vim.cmd("edit " .. vim.fn.fnameescape(path))
+            end
+          end
+
+          -- Re-sort vim.t.bufs by Harpoon order
+          local new_order = {}
+          for _, bufnr in ipairs(vim.t.bufs or {}) do
+            local buf_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p")
+            if harpoon_order[buf_path] then
+              table.insert(new_order, { idx = harpoon_order[buf_path], bufnr = bufnr })
+            end
+          end
+          table.sort(new_order, function(a, b) return a.idx < b.idx end)
+
+          -- Write back the sorted order
+          vim.t.bufs = vim.tbl_map(function(item) return item.bufnr end, new_order)
+
+          -- Refresh the tabline
+          vim.cmd "redrawtabline"
+        end,
+        desc = "Sort by Harpoon",
+      }
+    end,
+  },
+}

--- a/lua/astrocommunity/recipes/harpoon-bufsync/init.lua
+++ b/lua/astrocommunity/recipes/harpoon-bufsync/init.lua
@@ -13,10 +13,8 @@ return {
           local list = harpoon:list()
           local buffer = require "astrocore.buffer"
 
-          -- Remember where we are
           local current_buf = vim.api.nvim_get_current_buf()
 
-          -- Nuke existing Harpoon marks
           list.items = {}
 
           -- Re-add each open buffer, preserving tabline order
@@ -31,10 +29,8 @@ return {
             end
           end
 
-          -- Restore the buffer we started on
           pcall(vim.api.nvim_set_current_buf, current_buf)
 
-          -- Quick feedback
           vim.notify("Harpoon marks reset: " .. #list.items .. " files from tabline", vim.log.levels.INFO)
         end,
         desc = "Reset Harpoon from buffers",
@@ -90,7 +86,6 @@ return {
           -- Write back the sorted order
           vim.t.bufs = vim.tbl_map(function(item) return item.bufnr end, new_order)
 
-          -- Refresh the tabline
           vim.cmd "redrawtabline"
         end,
         desc = "Sort by Harpoon",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Adds a new recipe that syncs AstroNvim's Heirline tabline buffer order with Harpoon v2 marks.

Harpoon lets you pin frequently-used files for quick navigation, but the tabline doesn't reflect Harpoon's order — it tracks buffers by open-time and internal buffer ID. With a single keybind (`<Leader>bsh`), this recipe:

- Closes buffers not in your Harpoon list
- Opens Harpoon-marked files that aren't open yet
- Sorts the tabline buffer order to match your Harpoon mark order
- Redraws the tabline

## 📖 Additional Information

**Requirements:**
- Harpoon v2 (`harpoon2` branch)
- AstroCore (bundled with AstroNvim)

**Caveats:**
- Only affects the current tab
- Non-existent file paths in Harpoon are skipped (not opened)
- Unsaved buffers in the non-Harpoon set will be closed — save before syncing

**Files:**
- `lua/astrocommunity/recipes/harpoon-bufsync/init.lua`
- `lua/astrocommunity/recipes/harpoon-bufsync/README.md`
