### PR TITLE
feat(python): load `venv-selector.nvim` on python filetype

### DIFF
--- a/lua/astrocommunity/pack/python/base.lua
+++ b/lua/astrocommunity/pack/python/base.lua
@@ -38,6 +38,7 @@ return {
       },
     },
     opts = {},
+    ft = "python",
     cmd = "VenvSelect",
   },
   {


### PR DESCRIPTION
Closes #1780

Adds `ft = "python"` to venv-selector.nvim so it lazy-loads on Python filetype, enabling cached venv auto-activation.