### PR TITLE
fix(pack): use before_init for schemastore jsonls/yamlls

### DIFF
--- a/lua/astrocommunity/pack/json/init.lua
+++ b/lua/astrocommunity/pack/json/init.lua
@@ -11,7 +11,9 @@ return {
           ---@diagnostic disable: missing-fields
           config = {
             jsonls = {
-              on_new_config = function(config)
+              before_init = function(_, config)
+                if not config.settings then config.settings = {} end
+                if not config.settings.json then config.settings.json = {} end
                 if not config.settings.json.schemas then config.settings.json.schemas = {} end
                 vim.list_extend(config.settings.json.schemas, require("schemastore").json.schemas())
               end,

--- a/lua/astrocommunity/pack/yaml/init.lua
+++ b/lua/astrocommunity/pack/yaml/init.lua
@@ -11,7 +11,9 @@ return {
           ---@diagnostic disable: missing-fields
           config = {
             yamlls = {
-              on_new_config = function(config)
+              before_init = function(_, config)
+                if not config.settings then config.settings = {} end
+                if not config.settings.yaml then config.settings.yaml = {} end
                 config.settings.yaml.schemas = vim.tbl_deep_extend(
                   "force",
                   config.settings.yaml.schemas or {},


### PR DESCRIPTION
Closes #1774

Replaces `on_new_config` with `before_init` for schemastore integration in jsonls and yamlls configs. `vim.lsp.config` does not support `on_new_config` (neovim/neovim#32287). Adds nil guards matching the pattern used by basedpyright and vue packs.