### PR TITLE
fix(mcphub-nvim): disable make_vars to prevent codecompanion crash

### DIFF
--- a/lua/astrocommunity/editing-support/mcphub-nvim/init.lua
+++ b/lua/astrocommunity/editing-support/mcphub-nvim/init.lua
@@ -16,7 +16,7 @@ return {
             callback = "mcphub.extensions.codecompanion",
             opts = {
               show_result_in_chat = true,
-              make_vars = true,
+              make_vars = false,
               make_slash_commands = true,
             },
           },


### PR DESCRIPTION
Closes #1777

Sets `make_vars = false` in the mcphub codecompanion extension config. When mcphub loads before codecompanion is fully initialized, `make_vars = true` triggers variable registration that crashes with 'bad argument #1 to pairs (table expected, got nil)'.